### PR TITLE
Removed storeRecommendations function call

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -621,7 +621,6 @@ const Home: FC = () => {
           getRecommendationLessons(currentStudent, currentClass).then(() => {
             console.log("Final RECOMMENDATION List ", reqLes);
             setDataCourse(reqLes);
-            storeRecommendationsInLocalStorage(reqLes);
           });
         }
         break;


### PR DESCRIPTION
removed this StoreRecommendations function call in home header click, whenever we switch header home to suggestions, the blank screen is coming, so we don't need that function call there