### PR TITLE
Fixed Rewards issue #1853

### DIFF
--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -1508,7 +1508,7 @@ export class Util {
     const currentWeek = Util.getCurrentWeekNumber();
     const stickerIds: string[] = [];
     const weeklyData = rewardsDoc.weeklySticker;
-    weeklyData?.[currentWeek.toString()].forEach((value) => {
+    weeklyData?.[currentWeek.toString()]?.forEach((value) => {
       if (value.type === LeaderboardRewardsType.STICKER) {
         stickerIds.push(value.id);
       }


### PR DESCRIPTION
Bug: Stickers and Rewards weren't being loaded completely and it was throwing a runtime exception.
Fix: Handled it by adding optional chaining operator.