### PR TITLE
Fixed: "Lost Reward" text is missing on the Reward page #2027

### DIFF
--- a/src/components/leaderboard/LeaderboardBadges.css
+++ b/src/components/leaderboard/LeaderboardBadges.css
@@ -93,3 +93,7 @@ filter: grayscale(2);
   width: 100%;
   color: black;
 }
+
+.lost-reward p {
+  color: rgb(24, 44, 79) !important; /* Change to a visible color */ /* Ensure it's not hidden */
+}

--- a/src/components/leaderboard/LeaderboardBadges.tsx
+++ b/src/components/leaderboard/LeaderboardBadges.tsx
@@ -299,22 +299,22 @@ const LeaderboardBadges: FC = () => {
       {/* Section for Lost Badges */}
       <div className="leaderboard-badge-section">
         <div className="leaderboard-badge-container">
-          {lostBadges &&
-            lostBadges.map((value, index) => (
-              <div
-                key={index}
-                className="leaderboard-badge-item lost-reward"
-              >
-                <div className="lost-reward-overlay">
-                  <div className="red-circle">
-                    <RxCross2 color="white" />
-                  </div>
-                </div>
-                <CachedImage src={value.badge?.image ?? undefined} />
+        {lostBadges && lostBadges.filter(value => !value.isUnlocked && !value.isNextUnlock && !value.isUpcomingBadge).map((value, index) => (
+          <div key={index} className="leaderboard-badge-item lost-reward">
+            <div className="lost-reward-overlay">
+              <div className="red-circle">
+                <RxCross2 color="white" />
+              </div>
+              <CachedImage src={value.badge?.image ?? undefined} />
+            </div>
+            <div>
+              <div className="leaderboard-badge-item lost-reward">
                 <p>{value.badge?.name}</p>
                 <p>{t("Lost Reward")}</p>
               </div>
-            ))}
+            </div>
+          </div>
+        ))}
         </div>
       </div>
 

--- a/src/components/leaderboard/LeaderboardRewards.css
+++ b/src/components/leaderboard/LeaderboardRewards.css
@@ -1,5 +1,5 @@
 .leaderboard-rewards-container {
   display: flex;
   flex-direction: column;
-  height: 80vh;
+  height: 75vh;
 }

--- a/src/components/leaderboard/LeaderboardSticker.css
+++ b/src/components/leaderboard/LeaderboardSticker.css
@@ -37,3 +37,7 @@
     color: black;
   }
   
+  .lost-reward p {
+    color: rgb(24, 44, 79) !important; /* Change to a visible color */ /* Ensure it's not hidden */
+  }
+  

--- a/src/components/leaderboard/LeaderboardSticker.tsx
+++ b/src/components/leaderboard/LeaderboardSticker.tsx
@@ -262,22 +262,22 @@ const LeaderboardStickers: FC = () => {
       {/* Section for Lost Badges */}
       <div className="leaderboard-sticker-section">
         <div className="leaderboard-sticker-container">
-          {lostStickers &&
-            lostStickers.map((value, index) => (
-              <div
-                key={index}
-                className="leaderboard-badge-item lost-reward"
-              >
-                <div className="lost-reward-overlay">
-                  <div className="red-circle">
-                    <RxCross2 color="white" />
-                  </div>
-                </div>
-                <CachedImage src={value.sticker?.image ?? undefined} />
+        {lostStickers && lostStickers.filter(value => !value.isUnlocked && !value.isNextUnlock && !value.isUpcomingSticker).map((value, index) => (
+          <div key={index} className="leaderboard-badge-item lost-reward">
+            <div className="lost-reward-overlay">
+              <div className="red-circle">
+                <RxCross2 color="white" />
+              </div>
+              <CachedImage src={value.sticker?.image ?? undefined} />
+            </div>
+            <div>
+              <div className="leaderboard-badge-item lost-reward">
                 <p>{value.sticker?.name}</p>
                 <p>{t("Lost Reward")}</p>
               </div>
-            ))}
+            </div>
+          </div>
+        ))}
         </div>
       </div>
 


### PR DESCRIPTION
Issue:
![406339582-21575dd7-8b34-42ec-b4a5-f49b51d84857](https://github.com/user-attachments/assets/6d585dad-c8a2-44d1-a260-8ebf3aa3a8d5)

Able to view the "Lost Reward" text
![image](https://github.com/user-attachments/assets/5b42f20b-afd5-47a4-89f5-47d3b7c7ed51)
