### PR TITLE
FIXED - Alignment issue in the new transparent background and Subject Dropdown

### DIFF
--- a/src/components/Home/DropdownMenu.css
+++ b/src/components/Home/DropdownMenu.css
@@ -80,7 +80,7 @@
 
 .dropdown-arrow.expanded-arrow {
   align-items: flex-start;
-  padding-bottom: 38vh;
+  padding-bottom: 35vh;
   padding-right: 0.1vw;
   width: 4vw;
 }

--- a/src/components/common/TextField.css
+++ b/src/components/common/TextField.css
@@ -12,6 +12,9 @@
 }
 #scroll {
   height: 57vh;
-  background-color: #e2dede;
+  background-color: transparent;
   overflow: scroll;
+}
+.input-focus {
+  height: 1px;
 }

--- a/src/components/common/TextField.css
+++ b/src/components/common/TextField.css
@@ -15,6 +15,6 @@
   background-color: transparent;
   overflow: scroll;
 }
-.input-focus {
+.keyboard-spacer {
   height: 1px;
 }

--- a/src/components/common/TextField.tsx
+++ b/src/components/common/TextField.tsx
@@ -43,7 +43,7 @@ const TextField: React.FC<{
           }
         }}
       ></input>
-      {isInputFocus ? <div ref={scollToRef} id="scroll"></div> : null}
+      {isInputFocus ? <div ref={scollToRef} className="input-focus" id="scroll"></div> : null}
     </div>
   );
 };

--- a/src/components/common/TextField.tsx
+++ b/src/components/common/TextField.tsx
@@ -43,7 +43,7 @@ const TextField: React.FC<{
           }
         }}
       ></input>
-      {isInputFocus ? <div ref={scollToRef} className="input-focus" id="scroll"></div> : null}
+      {isInputFocus ? <div ref={scollToRef} className="keyboard-spacer" id="scroll"></div> : null}
     </div>
   );
 };


### PR DESCRIPTION
1. On Tablet - New Profile - What is your child's name creates the Gray background which is fixed.
2. On Phone/Table - Toggle subjects from Dropdown create a line below the UI and move the screen up is fixed.
3. On Tablet - Expanded Dropdown shows a extra space at last, is fixed

<img width="678" alt="image" src="https://github.com/user-attachments/assets/3f6d1af9-4766-4c06-9ec2-03e034e2b392" />

<img width="677" alt="image" src="https://github.com/user-attachments/assets/ddb0b13f-e86b-4933-aea8-17654cc6a32d" />
