### PR TITLE
resolved api issues to fetch principals and coordinators

### DIFF
--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -4807,7 +4807,7 @@ export class SupabaseApi implements ServiceApi {
 
     const { data, error } = await this.supabase
       .from("school_user")
-      .select("user(*)")
+      .select("user:user!school_user_user_id_fkey(*)") 
       .eq("school_id", schoolId)
       .eq("role", RoleType.PRINCIPAL)
       .eq("is_deleted", false)
@@ -4831,7 +4831,7 @@ export class SupabaseApi implements ServiceApi {
 
     const { data, error } = await this.supabase
       .from("school_user")
-      .select("user(*)")
+      .select("user:user!school_user_user_id_fkey(*)") 
       .eq("school_id", schoolId)
       .eq("role", RoleType.COORDINATOR)
       .eq("is_deleted", false)


### PR DESCRIPTION
We were getting a PGRST201 error from Supabase, and the message was Could not embed because more than one relationship was found for 'school_user' and 'user'.  One is user_id, which is the actual user the record belongs to.
The other is ops_created_by, which is the admin who created the record.
