### PR TITLE
triggering the deeplink again after respect login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -264,6 +264,7 @@ const App: React.FC = () => {
       const authHandler = ServiceConfig.getI()?.authHandler;
       const isUserLoggedIn = await authHandler?.isUserLoggedIn();
       if (!isUserLoggedIn) {
+        Util.isDeepLinkPending = true;
         await Toast.show({
           text: "Couldn't launch the lesson, please sign in with RESPECT.",
           duration: "long",

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -829,6 +829,27 @@ const Login: React.FC = () => {
                                 JSON.stringify(result)
                               );
                               history.replace(PAGES.DISPLAY_STUDENT);
+  
+                            if (Util.isDeepLinkPending) {
+                            // Reset the flag BEFORE dispatching to avoid double-trigger/race conditions
+                              Util.isDeepLinkPending = false;
+
+                              // Wait for navigation to DISPLAY_STUDENT to complete before dispatching the event
+                              setTimeout(() => {
+                                  try {
+                                    if (history.location.pathname === PAGES.DISPLAY_STUDENT) {
+                                      document.dispatchEvent(new CustomEvent("sendLaunch"));
+                                      console.log("DeepLink sendLaunch event dispatched after RESPECT login.");
+                                    } else {
+                                      console.warn(
+                                        "Deeplink launch skipped: not on the expected student dashboard page after RESPECT login"
+                                      );
+                                    }
+                                  } catch (e) {
+                                    console.error("Failed to dispatch sendLaunch event:", e);
+                                  }
+                                }, 500); // 500ms is usually enough for navigation/render to complete
+                              }
                             } else {
                               setIsLoading(false);
                               setIsInitialLoading(false);

--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -100,6 +100,7 @@ export class Util {
   static TIME_LIMIT = 25 * 60;
   static LAST_MODAL_SHOWN_KEY = "lastModalShown";
   static isDeepLink: boolean = false;
+  static isDeepLinkPending: boolean = false;
 
   public api = ServiceConfig.getI().apiHandler;
 


### PR DESCRIPTION
triggering the deeplink again after respect login, only after the user tried to launch the deeplink without login and it showed a message "Couldn't launch the lesson, please sign in with RESPECT.",