### PR TITLE
Working on UI issue in teachers mode reports page

### DIFF
--- a/src/teachers-module/components/reports/ReportsTable.tsx
+++ b/src/teachers-module/components/reports/ReportsTable.tsx
@@ -454,7 +454,7 @@ const ReportTable: React.FC<ReportTableProps> = ({
                         style={{
                           borderRight: expandedRow === key ? "0" : "",
                           borderBottom:
-                            expandedRow === key ? "0" : "2px solid #EFF2F4",
+                            expandedRow === key ? "0" : "2px solid #rgb(255, 255, 255)",
                         }}
                         onClick={() => {
                           if (


### PR DESCRIPTION
Working on --> https://github.com/chimple/cuba/issues/3134

When user slide's page in teacher reports page, line is overlapping on the students name - Done 


https://github.com/user-attachments/assets/03d66166-0a1f-4016-b50a-3e7fc6c8818d

