### PR TITLE
ANR crash issue

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -12,6 +12,13 @@
 #   public *;
 #}
 
+# --- Chromium/WebView ProGuard rules ---
+# Keep all Chromium WebView classes (prevents obfuscation issues)
+-keep class org.chromium.** { *; }
+-keep class com.android.webview.chromium.** { *; }
+-keep class android.webkit.** { *; }
+# --- End Chromium/WebView ProGuard rules ---
+
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
 #-keepattributes SourceFile,LineNumberTable

--- a/android/app/src/main/java/org/chimple/bahama/MainActivity.java
+++ b/android/app/src/main/java/org/chimple/bahama/MainActivity.java
@@ -39,8 +39,9 @@ public  class MainActivity extends BridgeActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
         Thread.setDefaultUncaughtExceptionHandler((thread, throwable) ->{
-                SharedPreferences sharedPreferences = getSharedPreferences("AppPreferences", MODE_PRIVATE);
+            SharedPreferences sharedPreferences = getSharedPreferences("AppPreferences", MODE_PRIVATE);
             String userId = sharedPreferences.getString("userId", null);
             if(userId !=null){
                 FirebaseCrashlytics.getInstance().setUserId(userId);
@@ -48,16 +49,13 @@ public  class MainActivity extends BridgeActivity {
             FirebaseCrashlytics.getInstance().recordException(throwable);
         });
         initializeActivityLauncher();
-
         registerPlugin(PortPlugin.class);
-        super.onCreate(savedInstanceState);
         this.bridge.setWebViewClient(new MyCustomWebViewClient(this.bridge, this));
         appContext = this;
         View decorView = getWindow().getDecorView();
         int uiOptions = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
                 | View.SYSTEM_UI_FLAG_FULLSCREEN;
         decorView.setSystemUiVisibility(uiOptions);
-
         FirebaseApp.initializeApp(/*context=*/ this);
     }
     public void initializeActivityLauncher(){


### PR DESCRIPTION
- Move super.onCreate(savedInstanceState); to the very top of (before any other code). This ensures the system splash screen and view setup are completed before your app logic runs.
- Move super.onCreate(savedInstanceState); to the top of , which is the recommended order for **Android 12+ compatibility.**
