### PR TITLE
Resolved google login popup closing issue

### DIFF
--- a/src/services/auth/SupabaseAuth.ts
+++ b/src/services/auth/SupabaseAuth.ts
@@ -184,13 +184,23 @@ export class SupabaseAuth implements ServiceAuth {
       if (!this._auth) return { success: false, isSpl: false };
 
       const api = ServiceConfig.getI().apiHandler;
-      const response = await SocialLogin.login({
-        provider: "google",
-        options: {
-          scopes: ["profile", "email"],
-          forceRefreshToken: Capacitor.isNativePlatform() ? true : false,
-        },
-      });
+      let response;
+      if (Capacitor.isNativePlatform()) {
+        response = await SocialLogin.login({
+          provider: "google",
+          options: {
+            scopes: ["profile", "email"],
+            forceRefreshToken: true,
+          },
+        });
+      } else {
+        response = await SocialLogin.login({
+          provider: "google",
+          options: {
+            scopes: ["profile", "email"],
+          },
+        });
+      }
       if (response.result?.responseType !== "online") {
         return { success: false, isSpl: false };
       }


### PR DESCRIPTION
The forceRefreshToken flag was causing OAuth popup failures on hosted environments. Since the app only uses authentication so,
the refresh token is not required.