### PR TITLE
fix(pathway): use selected course code for chapter/lesson translation gating

### DIFF
--- a/src/components/LearningPathway.tsx
+++ b/src/components/LearningPathway.tsx
@@ -30,6 +30,7 @@ const LearningPathway: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(false);
   const [mode, setMode] = useState<string>(LEARNING_PATHWAY_MODE.DISABLED);
   const [isModeResolved, setIsModeResolved] = useState(false);
+  const [courseCode, setCourseCode] = useState<string | undefined>(undefined);
 
   let student = Util.getCurrentStudent();
 
@@ -37,6 +38,12 @@ const LearningPathway: React.FC = () => {
     student,
     gb,
   });
+
+  const updateCourseCodeFromSubject = async (subjectId?: string | null) => {
+    if (!subjectId) return;
+    const selectedCourse = await api.getCourse(subjectId);
+    setCourseCode(selectedCourse?.code ?? undefined);
+  };
   /* -----------------------------------
    * 2️⃣ Resolve mode from GrowthBook
    * ----------------------------------- */
@@ -92,6 +99,16 @@ const LearningPathway: React.FC = () => {
           courses,
           student.language_id,
         );
+        const learningPath = student.learning_path
+          ? JSON.parse(student.learning_path)
+          : null;
+        const selectedCourseIndex = learningPath?.courses?.currentCourseIndex;
+        const selectedCourseId =
+          selectedCourseIndex !== undefined
+            ? learningPath?.courses?.courseList?.[selectedCourseIndex]
+                ?.course_id
+            : null;
+        await updateCourseCodeFromSubject(selectedCourseId);
         const learningPathMode = localStorage.getItem(CURRENT_PATHWAY_MODE);
         const mode = learningPathMode ?? LEARNING_PATHWAY_MODE.DISABLED;
         updateStarCount(student);
@@ -147,12 +164,17 @@ const LearningPathway: React.FC = () => {
   return (
     <div className="learning-pathway-container">
       <div className="pathway_section">
-        <DropdownMenu />
+        <DropdownMenu
+          onSubjectChange={(subjectId) => {
+            updateCourseCodeFromSubject(subjectId);
+          }}
+        />
         <PathwayStructure />
       </div>
 
       <div className="chapter-egg-container">
         <ChapterLessonBox
+          courseCode={courseCode}
           containerStyle={{
             width: '35vw',
           }}

--- a/src/components/assignment/HomeworkPathway.tsx
+++ b/src/components/assignment/HomeworkPathway.tsx
@@ -39,6 +39,7 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
   const [boxDetails, setBoxDetails] = useState<{
     cName: string;
     lName: string;
+    courseCode?: string;
   } | null>(null);
 
   const [from, setFrom] = useState<number>(0);
@@ -412,11 +413,17 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
 
         const lessonName = currentObj.lesson?.name || 'Lesson';
         let chapterName = 'Chapter';
+        let courseCode: string | undefined;
 
         try {
           if (currentObj.chapter_id) {
             const chapter = await api.getChapterById(currentObj.chapter_id);
             chapterName = chapter?.name || chapterName;
+          }
+          const resolvedSubjectId = subjectId ?? currentObj.course_id ?? null;
+          if (resolvedSubjectId) {
+            const course = await api.getCourse(resolvedSubjectId);
+            courseCode = course?.code ?? undefined;
           }
         } catch (error) {
           logger.error('Failed fetching chapter details', error);
@@ -425,6 +432,7 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
         setBoxDetails({
           cName: chapterName,
           lName: lessonName,
+          courseCode,
         });
       }
 
@@ -660,6 +668,7 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
         <ChapterLessonBox
           chapterName={boxDetails?.cName || 'Loading'}
           lessonName={boxDetails?.lName || '...'}
+          courseCode={boxDetails?.courseCode}
           containerStyle={{
             width: '35vw',
           }}

--- a/src/components/learningPathway/chapterLessonBox.tsx
+++ b/src/components/learningPathway/chapterLessonBox.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import './chpaterLessonBox.css';
 import { Util } from '../../utility/util';
 import { ServiceConfig } from '../../services/ServiceConfig';
-import { COURSE_CHANGED } from '../../common/constants';
+import { COURSE_CHANGED, COURSES } from '../../common/constants';
 import { useTranslation } from 'react-i18next';
 import { LessonNode } from '../../hooks/useLearningPath';
 import logger from '../../utility/logger';
@@ -11,20 +11,32 @@ interface ChapterLessonBoxProps {
   containerStyle?: React.CSSProperties;
   chapterName?: string;
   lessonName?: string;
+  courseCode?: string;
 }
 
 const ChapterLessonBox: React.FC<ChapterLessonBoxProps> = ({
   containerStyle,
   chapterName,
   lessonName,
+  courseCode,
 }) => {
   const api = ServiceConfig.getI().apiHandler;
   const [currentChapterName, setCurrentChapterName] = useState<string>('');
   const { t } = useTranslation();
+
   useEffect(() => {
     // SCENARIO 1: Props are provided (Homework Page)
     if (chapterName && lessonName) {
-      setCurrentChapterName(`${t(chapterName)} : ${t(lessonName)}`);
+      const isEnglishSubject = courseCode === COURSES.ENGLISH;
+      const translatedChapterName = isEnglishSubject
+        ? chapterName
+        : t(chapterName);
+      const translatedLessonName = isEnglishSubject
+        ? lessonName
+        : t(lessonName);
+      const renderedText = `${translatedChapterName} : ${translatedLessonName}`;
+
+      setCurrentChapterName(renderedText);
       return; // Stop here, don't do the API fetch
     }
     const updateChapter = async () => {
@@ -51,11 +63,27 @@ const ChapterLessonBox: React.FC<ChapterLessonBoxProps> = ({
         : null;
 
       // 3️⃣ Build chapter name safely
-      const chapterName = chapter?.name
-        ? `${t(chapter.name)} : ${t(lesson?.name ?? '')}`
-        : t(lesson?.name ?? 'default.chapter');
+      const rawChapterName = chapter?.name ?? null;
+      const rawLessonName = lesson?.name ?? null;
+      const resolvedCourseCode = courseCode ?? course?.code ?? null;
+      const isEnglishSubject = resolvedCourseCode === COURSES.ENGLISH;
+      const translatedChapterName = rawChapterName
+        ? isEnglishSubject
+          ? rawChapterName
+          : t(rawChapterName)
+        : null;
+      const translatedLessonName = rawLessonName
+        ? isEnglishSubject
+          ? rawLessonName
+          : t(rawLessonName)
+        : null;
+      const renderedText = translatedChapterName
+        ? `${translatedChapterName} : ${translatedLessonName ?? ''}`
+        : isEnglishSubject
+          ? (rawLessonName ?? '')
+          : t(rawLessonName ?? '');
 
-      setCurrentChapterName(chapterName);
+      setCurrentChapterName(renderedText);
     };
 
     // Fetch the initial chapter on component mount
@@ -75,7 +103,7 @@ const ChapterLessonBox: React.FC<ChapterLessonBoxProps> = ({
     return () => {
       window.removeEventListener(COURSE_CHANGED, syncHandleCourseChange);
     };
-  }, [chapterName, lessonName]);
+  }, [chapterName, lessonName, courseCode, t]);
 
   return (
     <div

--- a/src/components/learningPathway/chapterLessonBox.tsx
+++ b/src/components/learningPathway/chapterLessonBox.tsx
@@ -23,18 +23,38 @@ const ChapterLessonBox: React.FC<ChapterLessonBoxProps> = ({
   const api = ServiceConfig.getI().apiHandler;
   const [currentChapterName, setCurrentChapterName] = useState<string>('');
   const { t } = useTranslation();
+  const getRenderedChapterLessonText = (
+    rawChapterName: string | null,
+    rawLessonName: string | null,
+    resolvedCourseCode: string | null,
+  ) => {
+    const isEnglishSubject = resolvedCourseCode === COURSES.ENGLISH;
+    const translatedChapterName = rawChapterName
+      ? isEnglishSubject
+        ? rawChapterName
+        : t(rawChapterName)
+      : null;
+    const translatedLessonName = rawLessonName
+      ? isEnglishSubject
+        ? rawLessonName
+        : t(rawLessonName)
+      : null;
+
+    if (translatedChapterName) {
+      return `${translatedChapterName} : ${translatedLessonName ?? ''}`;
+    }
+
+    return isEnglishSubject ? (rawLessonName ?? '') : t(rawLessonName ?? '');
+  };
 
   useEffect(() => {
     // SCENARIO 1: Props are provided (Homework Page)
     if (chapterName && lessonName) {
-      const isEnglishSubject = courseCode === COURSES.ENGLISH;
-      const translatedChapterName = isEnglishSubject
-        ? chapterName
-        : t(chapterName);
-      const translatedLessonName = isEnglishSubject
-        ? lessonName
-        : t(lessonName);
-      const renderedText = `${translatedChapterName} : ${translatedLessonName}`;
+      const renderedText = getRenderedChapterLessonText(
+        chapterName,
+        lessonName,
+        courseCode ?? null,
+      );
 
       setCurrentChapterName(renderedText);
       return; // Stop here, don't do the API fetch
@@ -66,22 +86,11 @@ const ChapterLessonBox: React.FC<ChapterLessonBoxProps> = ({
       const rawChapterName = chapter?.name ?? null;
       const rawLessonName = lesson?.name ?? null;
       const resolvedCourseCode = courseCode ?? course?.code ?? null;
-      const isEnglishSubject = resolvedCourseCode === COURSES.ENGLISH;
-      const translatedChapterName = rawChapterName
-        ? isEnglishSubject
-          ? rawChapterName
-          : t(rawChapterName)
-        : null;
-      const translatedLessonName = rawLessonName
-        ? isEnglishSubject
-          ? rawLessonName
-          : t(rawLessonName)
-        : null;
-      const renderedText = translatedChapterName
-        ? `${translatedChapterName} : ${translatedLessonName ?? ''}`
-        : isEnglishSubject
-          ? (rawLessonName ?? '')
-          : t(rawLessonName ?? '');
+      const renderedText = getRenderedChapterLessonText(
+        rawChapterName,
+        rawLessonName,
+        resolvedCourseCode,
+      );
 
       setCurrentChapterName(renderedText);
     };


### PR DESCRIPTION
- LearningPathway.tsx

- Track courseCode based on the currently selected dropdown course.
- Initialize from learning path currentCourseIndex.
- Update courseCode on dropdown course change.
- Pass courseCode to ChapterLessonBox.
- HomeworkPathway.tsx

- Resolve course from subjectId passed into fetchHomeworkPathway(currentStudent, subjectId) (fallback to current item course id).
- Store and pass resolved courseCode to ChapterLessonBox.
- chapterLessonBox.tsx

- Added courseCode prop support.
- Apply English bypass:
- if courseCode === COURSES.ENGLISH, render raw chapter/lesson names
- otherwise render translated names with t(...)
- Removed temporary debug logging.