### PR TITLE
Enhance leaderboard merging and Supabase queries

### DIFF
--- a/src/pages/Leaderboard.test.tsx
+++ b/src/pages/Leaderboard.test.tsx
@@ -649,8 +649,9 @@ describe('Leaderboard', () => {
     ).not.toHaveBeenCalled();
   });
 
-  // 5i) B2C fallback must not run when class id is empty but student is already present in leaderboard.
-  it('does not call B2C fallback when class id is empty and student is already present', async () => {
+  // 5i) No-class leaderboards should refresh the current student's row from B2C data,
+  // even when the generic leaderboard already contains that student.
+  it('uses B2C data when class id is empty and student is already present', async () => {
     mockApiHandler.getStudentClassesAndSchools.mockResolvedValue({
       classes: [],
       schools: [],
@@ -675,12 +676,32 @@ describe('Leaderboard', () => {
       monthly: [],
       allTime: [],
     });
+    mockApiHandler.getLeaderboardStudentResultFromB2CCollection.mockResolvedValue(
+      {
+        weekly: [
+          {
+            userId: 'student-1',
+            name: 'Current Student',
+            score: 99,
+            lessonsPlayed: 11,
+            timeSpent: 180,
+          },
+        ],
+        monthly: [],
+        allTime: [],
+      },
+    );
 
     const view = render(<Leaderboard />);
     expect(await view.findByText('Weekly Topper')).toBeInTheDocument();
-    expect(
-      mockApiHandler.getLeaderboardStudentResultFromB2CCollection,
-    ).not.toHaveBeenCalled();
+    await eventually(() => {
+      expect(
+        mockApiHandler.getLeaderboardStudentResultFromB2CCollection,
+      ).toHaveBeenCalledWith('student-1');
+      expect(view.getAllByText('99').length).toBeGreaterThanOrEqual(1);
+      expect(view.getAllByText('11').length).toBeGreaterThanOrEqual(1);
+      expect(view.getAllByText('3 min 0 sec').length).toBeGreaterThanOrEqual(1);
+    });
   });
 
   // 5j) If B2C fallback bucket is empty, component should use placeholder/dummy row values.

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -16,7 +16,10 @@ import { ServiceConfig } from '../services/ServiceConfig';
 import { useHistory } from 'react-router-dom';
 import { IonCol, IonPage, IonRow } from '@ionic/react';
 import React from 'react';
-import { LeaderboardInfo } from '../services/api/ServiceApi';
+import {
+  LeaderboardInfo,
+  StudentLeaderboardInfo,
+} from '../services/api/ServiceApi';
 import { AppBar, Box, Tab, Tabs } from '@mui/material';
 import { t } from 'i18next';
 import { Util } from '../utility/util';
@@ -30,6 +33,50 @@ import { App } from '@capacitor/app';
 import { updateLocalAttributes, useGbContext } from '../growthbook/Growthbook';
 import DialogBoxButtons from '../components/parent/DialogBoxButtons​';
 import DebugMode from '../teachers-module/components/DebugMode';
+
+const emptyLeaderboardInfo = (): LeaderboardInfo => ({
+  weekly: [],
+  allTime: [],
+  monthly: [],
+});
+
+const getLeaderboardListByType = (
+  leaderboardInfo: LeaderboardInfo,
+  leaderboardDropdownType: LeaderboardDropdownList,
+): StudentLeaderboardInfo[] =>
+  leaderboardDropdownType === LeaderboardDropdownList.WEEKLY
+    ? leaderboardInfo.weekly
+    : leaderboardDropdownType === LeaderboardDropdownList.MONTHLY
+      ? leaderboardInfo.monthly
+      : leaderboardInfo.allTime;
+
+const hasLeaderboardDataForType = (
+  leaderboardInfo: LeaderboardInfo,
+  leaderboardDropdownType: LeaderboardDropdownList,
+) =>
+  getLeaderboardListByType(leaderboardInfo, leaderboardDropdownType).length > 0;
+
+const mergeLeaderboardInfo = (
+  cachedData: LeaderboardInfo,
+  fetchedData: LeaderboardInfo,
+  leaderboardDropdownType: LeaderboardDropdownList,
+): LeaderboardInfo => ({
+  weekly:
+    fetchedData.weekly.length > 0 ||
+    leaderboardDropdownType === LeaderboardDropdownList.WEEKLY
+      ? fetchedData.weekly
+      : cachedData.weekly,
+  monthly:
+    fetchedData.monthly.length > 0 ||
+    leaderboardDropdownType === LeaderboardDropdownList.MONTHLY
+      ? fetchedData.monthly
+      : cachedData.monthly,
+  allTime:
+    fetchedData.allTime.length > 0 ||
+    leaderboardDropdownType === LeaderboardDropdownList.ALL_TIME
+      ? fetchedData.allTime
+      : cachedData.allTime,
+});
 
 const Leaderboard: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -193,16 +240,25 @@ const Leaderboard: React.FC = () => {
     setCurrentUserDataContent(currentUserDataContent);
     setLeaderboardData(leaderboardDataArray);
     setIsLoading(false);
-    const tempLeaderboardData: LeaderboardInfo = (leaderboardDataInfo.weekly
-      .length <= 0 ||
-    leaderboardDataInfo.allTime.length <= 0 ||
-    leaderboardDataInfo.monthly.length <= 0
-      ? await api.getLeaderboardResults(classId, leaderboardDropdownType)
-      : leaderboardDataInfo) || {
-      weekly: [],
-      allTime: [],
-      monthly: [],
-    };
+    const hasCachedLeaderboardData = hasLeaderboardDataForType(
+      leaderboardDataInfo,
+      leaderboardDropdownType,
+    );
+    const [leaderboardResult, b2cData] = await Promise.all([
+      hasCachedLeaderboardData
+        ? Promise.resolve(leaderboardDataInfo)
+        : api.getLeaderboardResults(classId, leaderboardDropdownType),
+      !classId
+        ? api.getLeaderboardStudentResultFromB2CCollection(currentStudent.id)
+        : Promise.resolve(undefined),
+    ]);
+    const tempLeaderboardData: LeaderboardInfo = hasCachedLeaderboardData
+      ? leaderboardDataInfo
+      : mergeLeaderboardInfo(
+          leaderboardDataInfo,
+          leaderboardResult || emptyLeaderboardInfo(),
+          leaderboardDropdownType,
+        );
 
     const leaderboardAttributes = {
       leaderboard_position_weekly:
@@ -223,12 +279,29 @@ const Leaderboard: React.FC = () => {
 
     setLeaderboardDataInfo(tempLeaderboardData);
 
-    const tempData =
-      leaderboardDropdownType === LeaderboardDropdownList.WEEKLY
-        ? tempLeaderboardData.weekly
-        : leaderboardDropdownType === LeaderboardDropdownList.MONTHLY
-          ? tempLeaderboardData.monthly
-          : tempLeaderboardData.allTime;
+    const currentStudentB2CData = b2cData
+      ? getLeaderboardListByType(b2cData, leaderboardDropdownType)[0]
+      : undefined;
+    const currentStudentLeaderboardEntry = currentStudentB2CData
+      ? {
+          ...currentStudentB2CData,
+          userId: currentStudentB2CData.userId || currentStudent.id,
+          name: currentStudentB2CData.name || currentStudent.name || '',
+        }
+      : undefined;
+
+    let tempData = [
+      ...getLeaderboardListByType(tempLeaderboardData, leaderboardDropdownType),
+    ];
+    if (!classId && currentStudentLeaderboardEntry) {
+      const currentStudentIndex = tempData.findIndex(
+        (item) => item.userId === currentStudent.id,
+      );
+      if (currentStudentIndex >= 0) {
+        tempData[currentStudentIndex] = currentStudentLeaderboardEntry;
+        tempData.sort((a, b) => b.score - a.score);
+      }
+    }
 
     let tempLeaderboardDataArray: any[][] = [];
     let tempCurrentUserDataContent: any[][] = [];
@@ -265,45 +338,33 @@ const Leaderboard: React.FC = () => {
         ];
       }
     }
-    if (!isCurrentStudentDataFetched && !classId) {
-      const b2cData = await api.getLeaderboardStudentResultFromB2CCollection(
-        currentStudent.id,
+    if (
+      !isCurrentStudentDataFetched &&
+      !classId &&
+      currentStudentLeaderboardEntry
+    ) {
+      var computeMinutes = Math.floor(
+        currentStudentLeaderboardEntry.timeSpent / 60,
       );
-      if (b2cData) {
-        const tempData =
-          leaderboardDropdownType === LeaderboardDropdownList.WEEKLY
-            ? b2cData.weekly
-            : leaderboardDropdownType === LeaderboardDropdownList.MONTHLY
-              ? b2cData.monthly
-              : b2cData.allTime;
-        if (tempData && tempData.length > 0) {
-          var computeMinutes = Math.floor(tempData[0].timeSpent / 60);
-          var computeSeconds = tempData[0].timeSpent % 60;
-          const cUserRank = tempLeaderboardDataArray.length.toString() + '+';
-          tempCurrentUserDataContent = [
-            // ["Name", element.name],
-            [t('Rank'), cUserRank],
-            [t('Lessons Played'), tempData[0].lessonsPlayed],
-            [t('Score'), tempData[0].score],
-            [
-              t('Time Spent'),
-              computeMinutes +
-                t(' min') +
-                ' ' +
-                computeSeconds +
-                ' ' +
-                t('sec'),
-            ],
-          ];
-          tempLeaderboardDataArray.push([
-            cUserRank,
-            tempData[0].name,
-            tempData[0].lessonsPlayed,
-            tempData[0].score,
-            computeMinutes + t(' min') + ' ' + computeSeconds + ' ' + t('sec'),
-          ]);
-        }
-      }
+      var computeSeconds = currentStudentLeaderboardEntry.timeSpent % 60;
+      const cUserRank = tempLeaderboardDataArray.length.toString() + '+';
+      tempCurrentUserDataContent = [
+        // ["Name", element.name],
+        [t('Rank'), cUserRank],
+        [t('Lessons Played'), currentStudentLeaderboardEntry.lessonsPlayed],
+        [t('Score'), currentStudentLeaderboardEntry.score],
+        [
+          t('Time Spent'),
+          computeMinutes + t(' min') + ' ' + computeSeconds + ' ' + t('sec'),
+        ],
+      ];
+      tempLeaderboardDataArray.push([
+        cUserRank,
+        currentStudentLeaderboardEntry.name,
+        currentStudentLeaderboardEntry.lessonsPlayed,
+        currentStudentLeaderboardEntry.score,
+        computeMinutes + t(' min') + ' ' + computeSeconds + ' ' + t('sec'),
+      ]);
     }
     if (tempCurrentUserDataContent.length <= 0) {
       tempCurrentUserDataContent = currentUserDataContent;

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -3745,8 +3745,10 @@ export class SqliteApi implements ServiceApi {
       return classLeaderboard;
     } else {
       // Getting Generic Leaderboard
-      let genericQueryResult =
-        await this._serverApi.getLeaderboardStudentResultFromB2CCollection();
+      let genericQueryResult = await this._serverApi.getLeaderboardResults(
+        '',
+        leaderboardDropdownType,
+      );
       if (!genericQueryResult) {
         return;
       }

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -64,6 +64,7 @@ import {
   SchoolProgramAccessResponse,
   SchoolProgramAccessRow,
   ServiceApi,
+  StudentLeaderboardInfo,
 } from './ServiceApi';
 import { Database, Json } from '../database';
 import {
@@ -93,6 +94,50 @@ import {
 import { FCSchoolStats } from '../../ops-console/pages/SchoolDetailsPage';
 import { store } from '../../redux/store';
 import logger from '../../utility/logger';
+
+const GENERIC_LEADERBOARD_LIMIT = 50;
+
+type LeaderboardDataType = 'weekly' | 'monthly' | 'allTime';
+
+const emptyLeaderboardInfo = (): LeaderboardInfo => ({
+  weekly: [],
+  allTime: [],
+  monthly: [],
+});
+
+const getLeaderboardDataType = (
+  leaderboardDropdownType: LeaderboardDropdownList,
+): LeaderboardDataType =>
+  leaderboardDropdownType === LeaderboardDropdownList.WEEKLY
+    ? 'weekly'
+    : leaderboardDropdownType === LeaderboardDropdownList.MONTHLY
+      ? 'monthly'
+      : 'allTime';
+
+const mapLeaderboardRow = (result: any): StudentLeaderboardInfo => ({
+  name: result.name || '',
+  score: result.total_score || 0,
+  timeSpent: result.total_time_spent || 0,
+  lessonsPlayed: result.lessons_played || 0,
+  userId: result.student_id || '',
+});
+
+const pushLeaderboardRow = (leaderBoardList: LeaderboardInfo, result: any) => {
+  const leaderboardEntry = mapLeaderboardRow(result);
+  switch (result.type) {
+    case 'allTime':
+      leaderBoardList.allTime.push(leaderboardEntry);
+      break;
+    case 'monthly':
+      leaderBoardList.monthly.push(leaderboardEntry);
+      break;
+    case 'weekly':
+      leaderBoardList.weekly.push(leaderboardEntry);
+      break;
+    default:
+      logger.warn('Unknown leaderboard type: ', result.type);
+  }
+};
 
 export class SupabaseApi implements ServiceApi {
   private _assignmetRealTime?: RealtimeChannel;
@@ -4936,7 +4981,27 @@ export class SupabaseApi implements ServiceApi {
       if (!this.supabase)
         throw new Error('Supabase instance is not initialized');
 
-      // Fetch leaderboard data using the Supabase RPC function
+      const leaderBoardList = emptyLeaderboardInfo();
+
+      if (!sectionId) {
+        const leaderboardType = getLeaderboardDataType(leaderboardDropdownType);
+        const { data, error } = await this.supabase
+          .from('get_leaderboard_generic_data')
+          .select(
+            'type, student_id, name, lessons_played, total_score, total_time_spent',
+          )
+          .eq('type', leaderboardType)
+          .order('total_score', { ascending: false, nullsFirst: false })
+          .limit(GENERIC_LEADERBOARD_LIMIT);
+
+        if (error) {
+          throw error;
+        }
+
+        data?.forEach((result) => pushLeaderboardRow(leaderBoardList, result));
+        return leaderBoardList;
+      }
+
       const rpcRes = await this.supabase.rpc('get_class_leaderboard', {
         current_class_id: sectionId,
       });
@@ -4948,76 +5013,48 @@ export class SupabaseApi implements ServiceApi {
 
       // Initialize the leaderboard structure
       const data: any = rpcRes.data;
-      let leaderBoardList: LeaderboardInfo = {
-        weekly: [],
-        allTime: [],
-        monthly: [],
-      };
 
       // Process the data and populate the leaderboard lists
       for (let i = 0; i < data.length; i++) {
         const result = data[i];
-        const leaderboardEntry = {
-          name: result.name || '',
-          score: result.total_score || 0,
-          timeSpent: result.total_time_spent || 0,
-          lessonsPlayed: result.lessons_played || 0,
-          userId: result.student_id || '',
-        };
-
-        switch (result.type) {
-          case 'allTime':
-            leaderBoardList.allTime.push(leaderboardEntry);
-            break;
-          case 'monthly':
-            leaderBoardList.monthly.push(leaderboardEntry);
-            break;
-          case 'weekly':
-            leaderBoardList.weekly.push(leaderboardEntry);
-            break;
-          default:
-            logger.warn('Unknown leaderboard type: ', result.type);
-        }
+        pushLeaderboardRow(leaderBoardList, result);
       }
 
       return leaderBoardList;
     } catch (e) {
       logger.error('Error in getLeaderboardResults: ', e);
       // Return an empty leaderboard structure in case of error
-      return {
-        weekly: [],
-        allTime: [],
-        monthly: [],
-      };
+      return emptyLeaderboardInfo();
     }
   }
 
-  async getLeaderboardStudentResultFromB2CCollection(): Promise<
-    LeaderboardInfo | undefined
-  > {
+  async getLeaderboardStudentResultFromB2CCollection(
+    studentId?: string,
+  ): Promise<LeaderboardInfo | undefined> {
     try {
       // Initialize leaderboard structure
-      let leaderBoardList: LeaderboardInfo = {
-        weekly: [],
-        allTime: [],
-        monthly: [],
-      };
-
-      // Define the query to fetch data from the view
-      const genericQuery = `
-      SELECT *
-      FROM get_leaderboard_generic_data
-    `;
+      let leaderBoardList = emptyLeaderboardInfo();
 
       if (!this.supabase) {
         logger.error('Supabase instance is not initialized');
         return;
       }
 
+      if (!studentId) {
+        logger.warn(
+          'getLeaderboardStudentResultFromB2CCollection called without studentId',
+        );
+        return leaderBoardList;
+      }
+
       // Execute the query
       const { data, error } = await this.supabase
         .from('get_leaderboard_generic_data')
-        .select();
+        .select(
+          'type, student_id, name, lessons_played, total_score, total_time_spent',
+        )
+        .eq('student_id', studentId)
+        .limit(3);
 
       // Handle errors in the query execution
       if (error) {
@@ -5034,28 +5071,7 @@ export class SupabaseApi implements ServiceApi {
       // Process the results
       data.forEach((result) => {
         if (!result) return;
-
-        const leaderboardEntry = {
-          name: result.name || '',
-          score: result.total_score || 0,
-          timeSpent: result.total_time_spent || 0,
-          lessonsPlayed: result.lessons_played || 0,
-          userId: result.student_id || '',
-        };
-
-        switch (result.type) {
-          case 'allTime':
-            leaderBoardList.allTime.push(leaderboardEntry);
-            break;
-          case 'monthly':
-            leaderBoardList.monthly.push(leaderboardEntry);
-            break;
-          case 'weekly':
-            leaderBoardList.weekly.push(leaderboardEntry);
-            break;
-          default:
-            logger.warn('Unknown leaderboard type: ', result.type);
-        }
+        pushLeaderboardRow(leaderBoardList, result);
       });
 
       return leaderBoardList;


### PR DESCRIPTION
### 🚀 Leaderboard Refactor & Optimization

#### Summary

Optimized leaderboard fetching and processing by reducing over-fetching, improving caching, and simplifying logic.

---

### Changes Made

* **Filtered leaderboard by type at DB level**

  * Added `.eq('type', selectedType)`
  * Fetches only required type instead of all (weekly/monthly/allTime)

* **Added sorting & limit**

  * `.order('total_score', DESC)`
  * `.limit(50)` → ensures top 50 only

* **Refactored mapping logic**

  * Introduced reusable helpers:

    * `mapLeaderboardRow`
    * `pushLeaderboardRow`
    * `getLeaderboardDataType`

* **Unified API method**

  * Single `getLeaderboardResults` now handles both class & generic leaderboard

* **Improved frontend caching**

  * Fetches data only if selected type is missing (instead of refetching all)

* **Parallelized API calls**

  * Used `Promise.all` for leaderboard + user data

* **Updated current user handling**

  * If user exists in list → replace & re-sort
  * If not → append with `"50+"` rank

---

### Impact

* Reduced data fetched (~150 → 50 rows)
* Faster response & rendering
* Cleaner and more maintainable code
