### PR TITLE
fix(startup): show loading during redux rehydration to avoid blank screen( grey screen )

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,6 +53,7 @@ import { persistor, store } from './redux/store';
 import { PersistGate } from 'redux-persist/integration/react';
 import { BrowserRouter } from 'react-router-dom';
 import logger from './utility/logger';
+import Loading from './components/Loading';
 
 Sentry.init(
   {
@@ -194,7 +195,7 @@ const serviceInstance = ServiceConfig.getInstance(APIMode.SQLITE);
 const renderApp = () => {
   root.render(
     <Provider store={store}>
-      <PersistGate loading={null} persistor={persistor}>
+      <PersistGate loading={<Loading isLoading={true} />} persistor={persistor}>
         <BrowserRouter>
           <GrowthBookProvider growthbook={gb}>
             <GbProvider>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -129,7 +129,6 @@ if (typeof window !== 'undefined') {
     (window as any).SpeechSynthesisUtterance = SpeechSynthesisUtterance;
   }
 }
-SplashScreen.hide();
 if (Capacitor.isNativePlatform()) {
   await ScreenOrientation.lock({ orientation: 'landscape' });
 }


### PR DESCRIPTION
- Updated app bootstrap to render a loader while redux-persist rehydrates state.
- Changed PersistGate from loading={null} to loading={<Loading isLoading={true} />} in src/index.tsx.
- This reduces visible blank/grey transition between splash and first screen on low-memory devices.