### PR TITLE
Add worker-based remote audio download

### DIFF
--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -119,6 +119,10 @@ jest.mock('./workers/backgroundWorkerClient', () => {
             svgText: await response.text(),
           };
         }
+        case 'DOWNLOAD_REMOTE_AUDIO':
+          return {
+            base64Data: 'd29ya2VyQXVkaW8=',
+          };
         default:
           return {};
       }

--- a/src/utility/AudioUtil.test.ts
+++ b/src/utility/AudioUtil.test.ts
@@ -6,10 +6,14 @@ import { store } from '../redux/store';
 import { ServiceConfig } from '../services/ServiceConfig';
 import { LANGUAGE } from '../common/constants';
 import logger from './logger';
+import { runBackgroundWorkerTask } from '../workers/backgroundWorkerClient';
 
 jest.mock('@capacitor/core');
 jest.mock('@capacitor/filesystem');
 jest.mock('@capacitor-community/text-to-speech');
+jest.mock('../workers/backgroundWorkerClient', () => ({
+  runBackgroundWorkerTask: jest.fn(),
+}));
 jest.mock('./logger', () => ({
   __esModule: true,
   default: {
@@ -64,6 +68,9 @@ describe('AudioUtil common audio helpers', () => {
     (Capacitor.convertFileSrc as jest.Mock).mockImplementation(
       (uri: string) => `converted:${uri}`,
     );
+    (runBackgroundWorkerTask as jest.Mock).mockResolvedValue({
+      base64Data: 'd29ya2VyQXVkaW8=',
+    });
     (TextToSpeech.stop as jest.Mock).mockResolvedValue(undefined);
     (TextToSpeech.speak as jest.Mock).mockResolvedValue(undefined);
 
@@ -117,28 +124,59 @@ describe('AudioUtil common audio helpers', () => {
     (Filesystem.getUri as jest.Mock).mockResolvedValue({
       uri: 'file:///downloaded-audio.mp3',
     });
-    (CapacitorHttp.get as jest.Mock).mockResolvedValue({
-      status: 200,
-      data: 'YmFzZTY0QXVkaW8=',
-    });
-
     await expect(
       AudioUtil.getCachedAudioUrl(
         'https://cdn.example.com/audio-native-miss.mp3',
       ),
     ).resolves.toBe('converted:file:///downloaded-audio.mp3');
 
+    expect(runBackgroundWorkerTask).toHaveBeenCalledWith(
+      'DOWNLOAD_REMOTE_AUDIO',
+      {
+        url: 'https://cdn.example.com/audio-native-miss.mp3',
+      },
+    );
+    expect(Filesystem.writeFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directory: Directory.Data,
+        data: 'd29ya2VyQXVkaW8=',
+        recursive: true,
+      }),
+    );
+    expect(CapacitorHttp.get).not.toHaveBeenCalled();
+  });
+
+  test('falls back to main-thread audio download when worker download fails', async () => {
+    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
+    (Filesystem.stat as jest.Mock).mockRejectedValueOnce(new Error('missing'));
+    (Filesystem.mkdir as jest.Mock).mockResolvedValue({});
+    (Filesystem.writeFile as jest.Mock).mockResolvedValue({});
+    (Filesystem.getUri as jest.Mock).mockResolvedValue({
+      uri: 'file:///downloaded-audio.mp3',
+    });
+    (runBackgroundWorkerTask as jest.Mock).mockRejectedValueOnce(
+      new Error('worker failed'),
+    );
+    (CapacitorHttp.get as jest.Mock).mockResolvedValue({
+      status: 200,
+      data: 'YmFsbGJhY2tBdWRpbw==',
+    });
+
+    await expect(
+      AudioUtil.getCachedAudioUrl(
+        'https://cdn.example.com/audio-native-fallback.mp3',
+      ),
+    ).resolves.toBe('converted:file:///downloaded-audio.mp3');
+
     expect(CapacitorHttp.get).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: 'https://cdn.example.com/audio-native-miss.mp3',
+        url: 'https://cdn.example.com/audio-native-fallback.mp3',
         responseType: 'blob',
       }),
     );
     expect(Filesystem.writeFile).toHaveBeenCalledWith(
       expect.objectContaining({
-        directory: Directory.Data,
-        data: 'YmFzZTY0QXVkaW8=',
-        recursive: true,
+        data: 'YmFsbGJhY2tBdWRpbw==',
       }),
     );
   });

--- a/src/utility/AudioUtil.ts
+++ b/src/utility/AudioUtil.ts
@@ -9,6 +9,7 @@ import { Directory, Filesystem } from '@capacitor/filesystem';
 import CryptoJS from 'crypto-js';
 import { store } from '../redux/store';
 import { ServiceConfig } from '../services/ServiceConfig';
+import { runBackgroundWorkerTask } from '../workers/backgroundWorkerClient';
 
 export class AudioUtil {
   private static readonly SUPPORTED_AUDIO_LANGUAGE_CODES = [
@@ -262,6 +263,43 @@ export class AudioUtil {
     }
   }
 
+  private static async downloadRemoteAudioBase64(
+    audioUrl: string,
+  ): Promise<string | null> {
+    try {
+      const result = await runBackgroundWorkerTask('DOWNLOAD_REMOTE_AUDIO', {
+        url: audioUrl,
+      });
+      if (result?.base64Data) {
+        return result.base64Data;
+      }
+    } catch (error) {
+      logger.warn(
+        '[CommonAudio] Background worker audio download failed, falling back to main thread',
+        error,
+      );
+    }
+
+    const response = await CapacitorHttp.get({
+      url: audioUrl,
+      responseType: 'blob',
+      readTimeout: 15000,
+      connectTimeout: 15000,
+    });
+
+    if (!response?.data || response.status !== 200) {
+      logger.warn(
+        '[CommonAudio] Audio download failed with empty response',
+        audioUrl,
+      );
+      return null;
+    }
+
+    return typeof response.data === 'string'
+      ? response.data
+      : await AudioUtil.blobToBase64(response.data as Blob);
+  }
+
   private static async triggerOnComplete({
     requestId,
     onComplete,
@@ -341,25 +379,11 @@ export class AudioUtil {
 
         try {
           // First use downloads the remote asset into app-local storage.
-          const response = await CapacitorHttp.get({
-            url: normalizedAudioUrl,
-            responseType: 'blob',
-            readTimeout: 15000,
-            connectTimeout: 15000,
-          });
-
-          if (!response?.data || response.status !== 200) {
-            logger.warn(
-              '[CommonAudio] Audio download failed with empty response',
-              normalizedAudioUrl,
-            );
+          const base64Audio =
+            await AudioUtil.downloadRemoteAudioBase64(normalizedAudioUrl);
+          if (!base64Audio) {
             return null;
           }
-
-          const base64Audio =
-            typeof response.data === 'string'
-              ? response.data
-              : await AudioUtil.blobToBase64(response.data as Blob);
 
           await Filesystem.writeFile({
             path,

--- a/src/workers/background.worker.ts
+++ b/src/workers/background.worker.ts
@@ -4,6 +4,7 @@ import {
   BackgroundWorkerTask,
   BuildXlsxFilePayload,
   ChecksumFile,
+  DownloadRemoteAudioPayload,
   DownloadStickerBookSvgPayload,
   GrowthBookAttributesPayload,
   ParseXlsxSheetsPayload,
@@ -528,6 +529,32 @@ const downloadStickerBookSvg = async (
   };
 };
 
+const bytesToBase64 = (bytes: Uint8Array): string => {
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+};
+
+const downloadRemoteAudio = async (
+  payload: DownloadRemoteAudioPayload,
+): Promise<{
+  base64Data: string;
+}> => {
+  const response = await fetch(payload.url);
+  if (response.ok === false) {
+    throw new Error(`Failed to download remote audio: ${response.status}`);
+  }
+
+  const audioBuffer = await response.arrayBuffer();
+  return {
+    base64Data: bytesToBase64(new Uint8Array(audioBuffer)),
+  };
+};
+
 const handlers: {
   [K in BackgroundWorkerTask]: (
     payload: WorkerRequest<K>['payload'],
@@ -542,6 +569,7 @@ const handlers: {
   PARSE_XLSX_SHEETS: (payload) => parseXlsxSheets(payload),
   BUILD_XLSX_FILE: (payload) => buildXlsxFile(payload),
   DOWNLOAD_STICKER_BOOK_SVG: (payload) => downloadStickerBookSvg(payload),
+  DOWNLOAD_REMOTE_AUDIO: (payload) => downloadRemoteAudio(payload),
 };
 
 const waitForAck = (id: string): Promise<void> =>

--- a/src/workers/background.worker.types.ts
+++ b/src/workers/background.worker.types.ts
@@ -88,6 +88,14 @@ export type DownloadStickerBookSvgResult = {
   svgText: string;
 };
 
+export type DownloadRemoteAudioPayload = {
+  url: string;
+};
+
+export type DownloadRemoteAudioResult = {
+  base64Data: string;
+};
+
 export type StreamSyncBatchesPayload = {
   tables: Record<string, SyncRow[]>;
   tableColumns: Record<string, string[]>;
@@ -106,6 +114,7 @@ export type WorkerTaskPayloadMap = {
   PARSE_XLSX_SHEETS: ParseXlsxSheetsPayload;
   BUILD_XLSX_FILE: BuildXlsxFilePayload;
   DOWNLOAD_STICKER_BOOK_SVG: DownloadStickerBookSvgPayload;
+  DOWNLOAD_REMOTE_AUDIO: DownloadRemoteAudioPayload;
 };
 
 export type WorkerTaskResultMap = {
@@ -117,6 +126,7 @@ export type WorkerTaskResultMap = {
   PARSE_XLSX_SHEETS: ParseXlsxSheetsResult;
   BUILD_XLSX_FILE: BuildXlsxFileResult;
   DOWNLOAD_STICKER_BOOK_SVG: DownloadStickerBookSvgResult;
+  DOWNLOAD_REMOTE_AUDIO: DownloadRemoteAudioResult;
 };
 
 export type BackgroundWorkerTask = keyof WorkerTaskPayloadMap;


### PR DESCRIPTION
Add support for downloading remote audio via the background worker and falling back to main-thread download when the worker fails.
