### PR TITLE
fix: Don't await audio stop before continue

### DIFF
--- a/src/components/parent/ScoreCard.test.tsx
+++ b/src/components/parent/ScoreCard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import ScoreCard from './ScoreCard';
 import { AudioUtil } from '../../utility/AudioUtil';
 
@@ -51,8 +51,14 @@ describe('ScoreCard', () => {
     expect(AudioUtil.playAudioOrTts).not.toHaveBeenCalled();
   });
 
-  test('stops audio before calling continue handler from CTA', async () => {
+  test('calls continue handler immediately from CTA while stopping audio in the background', () => {
     const onContinueButtonClicked = jest.fn();
+    let resolveStopAudio: (() => void) | undefined;
+    (AudioUtil.stopAudioUrlOrTtsPlayback as jest.Mock).mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveStopAudio = resolve;
+      }),
+    );
     const { getByRole } = render(
       <ScoreCard
         {...baseProps}
@@ -62,14 +68,9 @@ describe('ScoreCard', () => {
 
     fireEvent.click(getByRole('button', { name: 'Continue Playing' }));
 
-    await waitFor(() => {
-      expect(AudioUtil.stopAudioUrlOrTtsPlayback).toHaveBeenCalled();
-      expect(onContinueButtonClicked).toHaveBeenCalledTimes(1);
-    });
+    expect(AudioUtil.stopAudioUrlOrTtsPlayback).toHaveBeenCalledTimes(1);
+    expect(onContinueButtonClicked).toHaveBeenCalledTimes(1);
 
-    expect(
-      (AudioUtil.stopAudioUrlOrTtsPlayback as jest.Mock).mock
-        .invocationCallOrder[0],
-    ).toBeLessThan(onContinueButtonClicked.mock.invocationCallOrder[0]);
+    resolveStopAudio?.();
   });
 });

--- a/src/components/parent/ScoreCard.tsx
+++ b/src/components/parent/ScoreCard.tsx
@@ -30,10 +30,8 @@ const ScoreCard: React.FC<{
   onContinueButtonClicked,
 }) => {
   const handleContinueClick: MouseEventHandler<HTMLButtonElement> = (event) => {
-    void (async () => {
-      await AudioUtil.stopAudioUrlOrTtsPlayback();
-      onContinueButtonClicked(event);
-    })();
+    void AudioUtil.stopAudioUrlOrTtsPlayback();
+    onContinueButtonClicked(event);
   };
 
   useEffect(() => {


### PR DESCRIPTION
Invoke onContinueButtonClicked synchronously instead of awaiting AudioUtil.stopAudioUrlOrTtsPlayback so the continue action happens immediately while audio stopping runs in the background. Updated tests to remove waitFor, rename the test, mock stopAudio to return a deferred promise, and assert both stopAudio was called and the continue handler was invoked immediately (resolving the mock promise at the end).