### PR TITLE
fix: Use id-based localSrc for SelectIconImage

### DIFF
--- a/src/teachers-module/components/ChapterWiseLessons.tsx
+++ b/src/teachers-module/components/ChapterWiseLessons.tsx
@@ -160,7 +160,11 @@ const ChapterWiseLessons: React.FC<Props> = ({
                         className="chapter-wise-media-frame"
                       >
                         <SelectIconImage
-                          localSrc=""
+                          localSrc={
+                            lesson.id
+                              ? `teacher/lessons/icons/${lesson.id}.webp`
+                              : undefined
+                          }
                           defaultSrc="assets/icons/DefaultIcon.png"
                           webSrc={lesson.image ?? ''}
                           imageHeight="100%"

--- a/src/teachers-module/components/homePage/assignment/QRAssignments.tsx
+++ b/src/teachers-module/components/homePage/assignment/QRAssignments.tsx
@@ -199,8 +199,13 @@ const QRAssignments: React.FC = () => {
                     className="qrAssignments-lesson-image-wrapper"
                   >
                     <SelectIconImage
+                      localSrc={
+                        lesson.id
+                          ? `teacher/lessons/icons/${lesson.id}.webp`
+                          : undefined
+                      }
                       defaultSrc="assets/icons/DefaultIcon.png"
-                      webSrc={lesson.image}
+                      webSrc={lesson.image ?? ''}
                       imageWidth="80px"
                       imageHeight="80px"
                     />

--- a/src/teachers-module/components/homePage/assignment/RecommendedAssignments.tsx
+++ b/src/teachers-module/components/homePage/assignment/RecommendedAssignments.tsx
@@ -177,6 +177,11 @@ const RecommendedAssignments: React.FC<Props> = ({
                       id={`recommended-assignments-list-item-thumb-${subjectId}-${index}`}
                     >
                       <SelectIconImage
+                        localSrc={
+                          assignment.id
+                            ? `teacher/lessons/icons/${assignment.id}.webp`
+                            : undefined
+                        }
                         defaultSrc="assets/icons/DefaultIcon.png"
                         webSrc={assignment.image ?? ''}
                         imageWidth="100%"

--- a/src/teachers-module/components/homePage/assignment/TeacherAssignment.tsx
+++ b/src/teachers-module/components/homePage/assignment/TeacherAssignment.tsx
@@ -483,8 +483,13 @@ const TeacherAssignment: FC<{
                 return (
                   <div key={index} className="assignment-list-item">
                     <SelectIconImage
+                      localSrc={
+                        assignment?.id
+                          ? `teacher/lessons/icons/${assignment.id}.webp`
+                          : undefined
+                      }
                       defaultSrc={'assets/icons/DefaultIcon.png'}
-                      webSrc={assignment?.image}
+                      webSrc={assignment?.image ?? ''}
                       imageWidth="100px"
                       imageHeight="100px"
                     />

--- a/src/teachers-module/components/library/LessonComponent.tsx
+++ b/src/teachers-module/components/library/LessonComponent.tsx
@@ -76,9 +76,11 @@ const LessonComponent: React.FC<LessonComponentProps> = ({
           className="lessoncomponent-lesson-image"
         >
           <SelectIconImage
-            localSrc={`courses/en/icons/en00.webp`}
+            localSrc={
+              lesson.id ? `teacher/lessons/icons/${lesson.id}.webp` : undefined
+            }
             defaultSrc={'assets/icons/DefaultIcon.png'}
-            webSrc={`${lesson.image}`}
+            webSrc={lesson.image ?? ''}
             // imageWidth="100%"
             imageHeight="100%"
             webImageHeight="0px"

--- a/src/teachers-module/pages/LessonDetails.tsx
+++ b/src/teachers-module/pages/LessonDetails.tsx
@@ -346,9 +346,13 @@ const LessonDetails: React.FC<LessonDetailsProps> = ({}) => {
                 </div>
 
                 <SelectIconImage
-                  localSrc={''}
+                  localSrc={
+                    lesson?.id
+                      ? `teacher/lessons/icons/${lesson.id}.webp`
+                      : undefined
+                  }
                   defaultSrc={'assets/icons/DefaultIcon.png'}
-                  webSrc={`${lesson.image}`}
+                  webSrc={lesson.image ?? ''}
                 />
               </div>
 

--- a/src/teachers-module/pages/TeacherLibraryAssignments.tsx
+++ b/src/teachers-module/pages/TeacherLibraryAssignments.tsx
@@ -91,6 +91,11 @@ const TeacherLibraryAssignments: React.FC = () => {
                               className="teacher-assignments-item-thumb"
                             >
                               <SelectIconImage
+                                localSrc={
+                                  lesson.id
+                                    ? `teacher/lessons/icons/${lesson.id}.webp`
+                                    : undefined
+                                }
                                 defaultSrc={'assets/icons/DefaultIcon.png'}
                                 webSrc={lesson.image ?? ''}
                                 imageWidth="100%"


### PR DESCRIPTION
Set SelectIconImage.localSrc to teacher/lessons/icons/{id}.webp when a lesson/assignment id is available, otherwise leave it undefined. Also normalize webSrc props to use an empty-string fallback (image ?? '') to avoid passing undefined. Changes applied across ChapterWiseLessons, QRAssignments, RecommendedAssignments, TeacherAssignment, LessonComponent, LessonDetails, and TeacherLibraryAssignments to ensure consistent icon loading and remove hardcoded/empty localSrc usage.