### PR TITLE
fix: make current student name editable if empty

### DIFF
--- a/src/components/assignment/JoinClass.tsx
+++ b/src/components/assignment/JoinClass.tsx
@@ -28,6 +28,8 @@ const JoinClass: FC<{
   const { online, presentToast } = useOnlineOfflineErrorMessageHandler();
   const [fullName, setFullName] = useState('');
   const [currStudent] = useState<any>(Util.getCurrentStudent());
+  const currentStudentName = currStudent?.name?.trim?.() ?? '';
+  const hasExistingStudentName = currentStudentName.length > 0;
 
   const api = ServiceConfig.getI().apiHandler;
   const containerRef = useRef<HTMLDivElement>(null);
@@ -188,7 +190,7 @@ const JoinClass: FC<{
   const isFormValid =
     !!codeResult &&
     !error &&
-    (fullName.length >= 3 || fullName === currStudent.name) &&
+    (fullName.trim().length >= 3 || fullName === currentStudentName) &&
     inviteCode?.length === 6;
 
   return (
@@ -206,10 +208,11 @@ const JoinClass: FC<{
             value={fullName}
             setValue={setFullName}
             icon="assets/icons/BusinessCard.svg"
-            readOnly={!!currStudent && fullName === currStudent.name}
+            readOnly={hasExistingStudentName && fullName === currentStudentName}
             statusIcon={
               fullName.length == 0 ? null : fullName &&
-                (fullName.length >= 3 || fullName === currStudent.name) ? (
+                (fullName.trim().length >= 3 ||
+                  fullName === currentStudentName) ? (
                 <img src="assets/icons/CheckIcon.svg" alt="Status icon" />
               ) : (
                 <img src="assets/icons/Vector.svg" alt="Status icon" />


### PR DESCRIPTION
Cache a trimmed current student name and a hasExistingStudentName flag, then use them for form validation, readOnly checks, and status icon logic. This prevents whitespace-only names from bypassing length checks and ensures comparisons use the normalized (trimmed) value.