### PR TITLE
Keep current school/class state in sync during teacher navigation

### DIFF
--- a/src/teachers-module/components/homePage/SideMenu.tsx
+++ b/src/teachers-module/components/homePage/SideMenu.tsx
@@ -242,6 +242,7 @@ const SideMenu: React.FC<{
       const classCode = await getClassCodeById(firstClass.id);
       setClassCode(classCode);
       Util.dispatchClassOrSchoolChangeEvent();
+      void Util.validateCurrentSchoolContext();
     } catch (error) {
       logger.error('Error handling school selection:', error);
     }
@@ -291,6 +292,7 @@ const SideMenu: React.FC<{
       }
 
       Util.dispatchClassOrSchoolChangeEvent();
+      void Util.validateCurrentSchoolContext();
     } catch (error) {
       logger.error('Error handling class selection:', error);
     }

--- a/src/teachers-module/pages/DisplaySchools.tsx
+++ b/src/teachers-module/pages/DisplaySchools.tsx
@@ -273,6 +273,7 @@ const DisplaySchools: FC = () => {
         history.replace(PAGES.HOME_PAGE, { tabValue: 0 });
       }
     }
+    void Util.validateCurrentSchoolContext();
     setLoading(false);
   }
 

--- a/src/teachers-module/pages/SubjectSelection.tsx
+++ b/src/teachers-module/pages/SubjectSelection.tsx
@@ -438,12 +438,14 @@ const SubjectSelection: React.FC = () => {
         Util.setCurrentClass(currentClass!);
         Util.clearNavigationState();
         history.replace(PAGES.HOME_PAGE, { tabValue: 0 });
+        void Util.validateCurrentSchoolContext();
       } else {
         if (navigationState?.stage === School_Creation_Stages.CLASS_COURSE) {
           Util.setCurrentSchool(currentSchool!, finalRole);
           Util.setCurrentClass(currentClass!);
           Util.clearNavigationState();
           history.replace(PAGES.HOME_PAGE, { tabValue: 0 });
+          void Util.validateCurrentSchoolContext();
         }
         setIsSelecting(false);
       }

--- a/src/teachers-module/pages/UserProfile.tsx
+++ b/src/teachers-module/pages/UserProfile.tsx
@@ -23,8 +23,12 @@ const UserProfile: React.FC = () => {
   const [languages, setLanguages] = useState<
     Array<{ label: string; value: string; id: string }>
   >([]);
-  const [currentClass, setCurrentClass] = useState<TableTypes<'class'>>();
-  const [currentSchool, setCurrentSchool] = useState<TableTypes<'school'>>();
+  const [currentClass, setCurrentClass] = useState<
+    TableTypes<'class'> | undefined
+  >(() => Util.getCurrentClass());
+  const [currentSchool, setCurrentSchool] = useState<
+    TableTypes<'school'> | undefined
+  >(() => Util.getCurrentSchool());
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
   const api = ServiceConfig.getI().apiHandler;
 

--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -1995,6 +1995,10 @@ export class Util {
   public static getCurrentSchool(): TableTypes<'school'> | undefined {
     const api = ServiceConfig.getI().apiHandler;
 
+    if (api.currentSchool) {
+      return api.currentSchool;
+    }
+
     const isSchoolConnected = async (schoolId: string): Promise<boolean> => {
       const roles = store.getState()?.auth?.roles ?? [];
       const isOpsUser = store.getState()?.auth?.isOpsUser === true;
@@ -2047,45 +2051,6 @@ export class Util {
       }
     };
 
-    //  IF WE ALREADY HAVE A SCHOOL IN MEMORY CHECK IF NOT CONNECTED
-    if (!!api.currentSchool) {
-      const classes = Util.getCurrentClass();
-      const schoolId = api.currentSchool.id;
-      const classId = classes?.id ?? undefined;
-
-      // SCHOOL CHECK
-      isSchoolConnected(api.currentSchool.id).then((res) => {
-        if (!res) {
-          api.currentSchool = undefined;
-          localStorage.removeItem(SCHOOL);
-          localStorage.removeItem(CLASS);
-          return;
-        }
-
-        // CLASS CHECK
-
-        if (classId) {
-          isClassConnected(schoolId, classId).then((cls) => {
-            if (!cls) return;
-
-            const { classExists, classCount } = cls;
-
-            if (!classExists) {
-              localStorage.removeItem(CLASS);
-              // If only one class existed and that gets removed → remove school too
-              if (classCount === 1) {
-                api.currentSchool = undefined;
-                localStorage.removeItem(SCHOOL);
-              }
-            }
-          });
-        }
-      });
-
-      return api.currentSchool;
-    }
-
-    //  B) IF SCHOOL IS LOADED FROM LOCAL STORAGE CHECK IF NOT CONNECTED
     const temp = localStorage.getItem(SCHOOL);
     if (!temp) return;
 
@@ -2126,11 +2091,9 @@ export class Util {
           const { classExists, classCount } = cls;
 
           if (!classExists) {
-            logger.info('Class no longer connected → removing class');
             localStorage.removeItem(CLASS);
 
             if (classCount === 1) {
-              logger.info('Last class removed → removing school as well');
               api.currentSchool = undefined;
               localStorage.removeItem(SCHOOL);
             }
@@ -2167,6 +2130,91 @@ export class Util {
     } catch (err) {
       logger.error('Failed to parse currentClass from localStorage', err);
       return;
+    }
+  }
+
+  public static async validateCurrentSchoolContext(): Promise<void> {
+    const api = ServiceConfig.getI().apiHandler;
+    const currentSchool = Util.getCurrentSchool();
+    const currentClass = Util.getCurrentClass();
+
+    if (!currentSchool) {
+      return;
+    }
+
+    const isSchoolConnected = async (schoolId: string): Promise<boolean> => {
+      const roles = store.getState()?.auth?.roles ?? [];
+      const isOpsUser = store.getState()?.auth?.isOpsUser === true;
+      if (
+        isOpsUser ||
+        [
+          RoleType.SUPER_ADMIN,
+          RoleType.FIELD_COORDINATOR,
+          RoleType.PROGRAM_MANAGER,
+          RoleType.OPERATIONAL_DIRECTOR,
+        ].some((role) => roles.includes(role))
+      ) {
+        return true;
+      }
+      try {
+        const authHandler = ServiceConfig.getI().authHandler;
+        const currentUser = await authHandler.getCurrentUser();
+        if (!currentUser) return false;
+
+        const schools = await api.getSchoolsForUser(currentUser.id);
+        return schools.some((item) => item.school.id === schoolId);
+      } catch (error) {
+        logger.error('Error checking school via user:', error);
+        return false;
+      }
+    };
+
+    const isClassConnected = async (
+      schoolId: string,
+      classId: string,
+    ): Promise<{ classExists: boolean; classCount: number } | undefined> => {
+      try {
+        const authHandler = ServiceConfig.getI().authHandler;
+        const currentUser = await authHandler.getCurrentUser();
+        if (!currentUser) return;
+
+        const classes = await api.getClassesForSchool(schoolId, currentUser.id);
+        return {
+          classExists: classes.some((cls) => cls.id === classId),
+          classCount: classes.length,
+        };
+      } catch (error) {
+        logger.error('Error checking class via user:', error);
+        return;
+      }
+    };
+
+    const schoolIsConnected = await isSchoolConnected(currentSchool.id);
+    if (!schoolIsConnected) {
+      api.currentSchool = undefined;
+      api.currentClass = undefined;
+      localStorage.removeItem(SCHOOL);
+      localStorage.removeItem(CLASS);
+      return;
+    }
+
+    if (!currentClass?.id) {
+      return;
+    }
+
+    const classCheck = await isClassConnected(
+      currentSchool.id,
+      currentClass.id,
+    );
+    if (!classCheck) return;
+
+    if (!classCheck.classExists) {
+      localStorage.removeItem(CLASS);
+      api.currentClass = undefined;
+      if (classCheck.classCount === 1) {
+        api.currentSchool = undefined;
+        localStorage.removeItem(SCHOOL);
+      }
     }
   }
 


### PR DESCRIPTION
- This change updates the teacher flows so the app revalidates the selected school/class context after school or class selection changes, and it initializes the profile page from the cached school/class state immediately on mount. It also preserves the existing school-cache cleanup behavior while adding a dedicated validation helper, so stale school/class selections can still be cleared when the user is no longer connected to them.