### PR TITLE
fix: Centered homework popup and made responsive

### DIFF
--- a/src/pages/Assignment.css
+++ b/src/pages/Assignment.css
@@ -43,9 +43,13 @@
 
 .pending-assignment {
   display: flex;
-  position: relative;
-  height: 100vh;
-  top: 14vh;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 70vh;
+  padding: clamp(1rem, 3vh, 2rem) clamp(1rem, 3vw, 2rem);
+  box-sizing: border-box;
+  transform: translateY(clamp(-1.5rem, -3vh, -0.5rem));
 }
 
 .school-class-header {


### PR DESCRIPTION
Replace fixed positioning and 100vh height with flexible, centered layout for .pending-assignment. Uses flex centering (align-items/justify-content), width/min-height instead of height, responsive padding via clamp(), box-sizing: border-box, and a translateY() offset for vertical positioning. These changes improve responsiveness and avoid layout issues caused by absolute positioning and fixed top offsets.