### PR TITLE
fix: Keep homework pathway on the current subject during assignment refreshes

### DIFF
--- a/src/components/assignment/HomeworkPathway.test.tsx
+++ b/src/components/assignment/HomeworkPathway.test.tsx
@@ -357,19 +357,26 @@ describe('HomeworkPathway – pathway logic', () => {
     ).toBeInTheDocument();
   });
 
-  test('reuses existing pathway even if assignments change', async () => {
+  test('rebuilds existing pathway when pending assignments change', async () => {
     (useFeatureIsOn as jest.Mock).mockReturnValue(true);
 
     const oldPathway = {
       path_id: 'old-path',
       lessons: [{ lesson: { id: 'l1' } }],
       currentIndex: 0,
+      pendingAssignmentIds: ['a-old'],
     };
     localStorage.setItem(HOMEWORK_PATHWAY, JSON.stringify(oldPathway));
 
     mockApi.getPendingAssignments.mockResolvedValue([
       { id: 'a-new', type: 'HOMEWORK', lesson_id: 'l-new', course_id: 's-new' },
     ]);
+    mockApi.getLesson.mockResolvedValue({
+      id: 'l-new',
+      subject_id: 's-new',
+      name: 'Lesson new',
+      chapter_id: 'c-new',
+    });
 
     render(
       <MemoryRouter>
@@ -379,7 +386,197 @@ describe('HomeworkPathway – pathway logic', () => {
 
     await waitFor(() => {
       const pathway = JSON.parse(localStorage.getItem(HOMEWORK_PATHWAY)!);
-      expect(pathway.path_id).toBe('old-path');
+      expect(pathway.path_id).not.toBe('old-path');
+      expect(pathway.pendingAssignmentIds).toEqual(['a-new']);
+    });
+  });
+
+  test('migrates legacy cached pathways without pending ids', async () => {
+    (useFeatureIsOn as jest.Mock).mockReturnValue(true);
+
+    const legacyPathway = {
+      path_id: 'legacy-path',
+      lessons: [{ lesson: { id: 'l1' } }],
+      currentIndex: 0,
+    };
+    localStorage.setItem(HOMEWORK_PATHWAY, JSON.stringify(legacyPathway));
+
+    mockApi.getPendingAssignments.mockResolvedValue([
+      { id: 'a-1', type: 'HOMEWORK', lesson_id: 'l-1', course_id: 's-1' },
+    ]);
+    mockApi.getLesson.mockResolvedValue({
+      id: 'l-1',
+      subject_id: 's-1',
+      name: 'Lesson 1',
+      chapter_id: 'c-1',
+    });
+
+    render(
+      <MemoryRouter>
+        <HomeworkPathway />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      const pathway = JSON.parse(localStorage.getItem(HOMEWORK_PATHWAY)!);
+      expect(pathway.path_id).toBe('legacy-path');
+      expect(pathway.pendingAssignmentIds).toEqual(['a-1']);
+    });
+  });
+
+  test('keeps the current subject when assignments refresh', async () => {
+    (useFeatureIsOn as jest.Mock).mockReturnValue(true);
+
+    const currentPathway = {
+      path_id: 'math-path',
+      lessons: [{ lesson: { id: 'math-1' }, course_id: 'math' }],
+      currentIndex: 0,
+      pendingAssignmentIds: ['math-1'],
+    };
+    localStorage.setItem(HOMEWORK_PATHWAY, JSON.stringify(currentPathway));
+
+    mockApi.getPendingAssignments
+      .mockResolvedValueOnce([
+        {
+          id: 'math-1',
+          type: 'HOMEWORK',
+          lesson_id: 'math-1',
+          course_id: 'math',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'math-2',
+          type: 'HOMEWORK',
+          lesson_id: 'math-2',
+          course_id: 'math',
+        },
+        {
+          id: 'science-1',
+          type: 'HOMEWORK',
+          lesson_id: 'science-1',
+          course_id: 'science',
+        },
+        {
+          id: 'science-2',
+          type: 'HOMEWORK',
+          lesson_id: 'science-2',
+          course_id: 'science',
+        },
+      ]);
+    mockApi.getLesson.mockImplementation((id: string) =>
+      Promise.resolve({
+        id,
+        subject_id: id.startsWith('math') ? 'math' : 'science',
+        name: `Lesson ${id}`,
+        chapter_id: 'c-1',
+      }),
+    );
+    mockApi.getChapterById.mockResolvedValue({ id: 'c-1', name: 'Chapter 1' });
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <HomeworkPathway refreshToken={0} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      const pathway = JSON.parse(localStorage.getItem(HOMEWORK_PATHWAY)!);
+      expect(pathway.lessons[0].course_id).toBe('math');
+    });
+
+    rerender(
+      <MemoryRouter>
+        <HomeworkPathway refreshToken={1} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      const pathway = JSON.parse(localStorage.getItem(HOMEWORK_PATHWAY)!);
+      expect(
+        pathway.lessons.every((lesson: any) => lesson.course_id === 'math'),
+      ).toBe(true);
+    });
+  });
+
+  test('does not jump to english or math when digital skills is the active path', async () => {
+    (useFeatureIsOn as jest.Mock).mockReturnValue(true);
+
+    const currentPathway = {
+      path_id: 'digital-path',
+      lessons: [{ lesson: { id: 'digital-1' }, course_id: 'digital-skills' }],
+      currentIndex: 0,
+      pendingAssignmentIds: ['digital-1'],
+    };
+    localStorage.setItem(HOMEWORK_PATHWAY, JSON.stringify(currentPathway));
+
+    mockApi.getPendingAssignments
+      .mockResolvedValueOnce([
+        {
+          id: 'digital-1',
+          type: 'HOMEWORK',
+          lesson_id: 'digital-1',
+          course_id: 'digital-skills',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'digital-2',
+          type: 'HOMEWORK',
+          lesson_id: 'digital-2',
+          course_id: 'digital-skills',
+        },
+        {
+          id: 'english-1',
+          type: 'HOMEWORK',
+          lesson_id: 'english-1',
+          course_id: 'english',
+        },
+        {
+          id: 'math-1',
+          type: 'HOMEWORK',
+          lesson_id: 'math-1',
+          course_id: 'math',
+        },
+      ]);
+    mockApi.getLesson.mockImplementation((id: string) =>
+      Promise.resolve({
+        id,
+        subject_id: id.startsWith('digital')
+          ? 'digital-skills'
+          : id.startsWith('english')
+            ? 'english'
+            : 'math',
+        name: `Lesson ${id}`,
+        chapter_id: 'c-1',
+      }),
+    );
+    mockApi.getChapterById.mockResolvedValue({ id: 'c-1', name: 'Chapter 1' });
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <HomeworkPathway refreshToken={0} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      const pathway = JSON.parse(localStorage.getItem(HOMEWORK_PATHWAY)!);
+      expect(pathway.lessons[0].course_id).toBe('digital-skills');
+    });
+
+    rerender(
+      <MemoryRouter>
+        <HomeworkPathway refreshToken={1} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      const pathway = JSON.parse(localStorage.getItem(HOMEWORK_PATHWAY)!);
+      expect(
+        pathway.lessons.every(
+          (lesson: any) => lesson.course_id === 'digital-skills',
+        ),
+      ).toBe(true);
     });
   });
 

--- a/src/components/assignment/HomeworkPathway.tsx
+++ b/src/components/assignment/HomeworkPathway.tsx
@@ -32,9 +32,12 @@ interface HomeworkPath {
 const areStringArraysEqual = (
   left: string[] = [],
   right: string[] = [],
-): boolean =>
-  left.length === right.length &&
-  left.every((value, index) => value === right[index]);
+): boolean => {
+  if (left.length !== right.length) return false;
+  const sortedLeft = [...left].sort();
+  const sortedRight = [...right].sort();
+  return sortedLeft.every((value, index) => value === sortedRight[index]);
+};
 interface HomeworkPathwayProps {
   onPlayMoreHomework?: () => void; // ✅ NEW
   refreshToken?: number;
@@ -248,12 +251,15 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
         : allPendingAssignments;
 
       const currentPendingAssignmentIds = pendingAssignmentsForCurrentView
-        .map((assignment) => String(assignment.id))
-        .filter(Boolean);
+        .map((assignment) => assignment.id)
+        .filter((id): id is string => !!id)
+        .map(String);
       const cachedPendingAssignmentIds = Array.isArray(
         existingPath?.pendingAssignmentIds,
       )
-        ? (existingPath?.pendingAssignmentIds ?? []).map((id) => String(id))
+        ? (existingPath?.pendingAssignmentIds ?? [])
+            .filter((id): id is string => !!id)
+            .map(String)
         : null;
       const hasCachedPendingAssignmentIds = cachedPendingAssignmentIds !== null;
       const canReuseExistingPath =

--- a/src/components/assignment/HomeworkPathway.tsx
+++ b/src/components/assignment/HomeworkPathway.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import '../LearningPathway.css';
 import './HomeworkPathway.css';
 import { v4 as uuidv4 } from 'uuid';
@@ -26,13 +26,23 @@ interface HomeworkPath {
   path_id: string;
   lessons: any[];
   currentIndex: number;
+  pendingAssignmentIds?: string[];
 }
+
+const areStringArraysEqual = (
+  left: string[] = [],
+  right: string[] = [],
+): boolean =>
+  left.length === right.length &&
+  left.every((value, index) => value === right[index]);
 interface HomeworkPathwayProps {
   onPlayMoreHomework?: () => void; // ✅ NEW
+  refreshToken?: number;
 }
 
 const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
   onPlayMoreHomework,
+  refreshToken,
 }) => {
   const api = ServiceConfig.getI().apiHandler;
   const [loading, setLoading] = useState<boolean>(true);
@@ -55,6 +65,7 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
   const isDropdownAlwaysEnabled = useFeatureIsOn(HOMEWORK_PATHWAY_DROPDOWN);
   const [selectedSubject, setSelectedSubject] = useState<string | null>(null);
   const [isHomeworkComplete, setIsHomeworkComplete] = useState(false);
+  const activeSubjectRef = useRef<string | null>(null);
 
   const [refreshKey, setRefreshKey] = useState(0);
 
@@ -64,9 +75,12 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
       return;
     }
     updateStarCount(currentStudent);
-    fetchHomeworkPathway(currentStudent);
+    fetchHomeworkPathway(
+      currentStudent,
+      selectedSubject || activeSubjectRef.current || undefined,
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentStudent?.id, isDropdownAlwaysEnabled]);
+  }, [currentStudent?.id, isDropdownAlwaysEnabled, refreshToken]);
 
   const updateStarCount = async (currentStudent: TableTypes<'user'>) => {
     if (!currentStudent?.id) return;
@@ -120,10 +134,11 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
     const currentStudent = Util.getCurrentStudent();
     localStorage.removeItem(HOMEWORK_PATHWAY);
     setIsDropdownDisabled(false); // allow switching again until they start playing
+    activeSubjectRef.current = subjectId;
+    setSelectedSubject(subjectId);
     if (currentStudent) {
       await fetchHomeworkPathway(currentStudent, subjectId);
     }
-    setSelectedSubject(subjectId);
   };
 
   async function awardStarsForPathCompletion(
@@ -201,6 +216,12 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
     }
 
     let pathData: HomeworkPath | null = null;
+    const storedPathSubjectId =
+      existingPath?.lessons?.[0]?.course_id != null
+        ? String(existingPath.lessons[0].course_id)
+        : undefined;
+    const effectiveSubjectId =
+      subjectId ?? storedPathSubjectId ?? activeSubjectRef.current ?? undefined;
 
     try {
       const currClass = Util.getCurrentClass();
@@ -209,24 +230,68 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
         return;
       }
 
-      // 1️⃣ If we already have a good cached path and NO subject filter:
-      //    Use it and don't depend on network (offline friendly)
-      if (!subjectId && existingPath) {
+      let allPendingAssignments: TableTypes<'assignment'>[] = [];
+      let pendingAssignmentsFetched = false;
+      try {
+        const all = await api.getPendingAssignments(currClass.id, student.id);
+        allPendingAssignments = all.filter((a) => a.type !== LIVE_QUIZ);
+        pendingAssignmentsFetched = true;
+      } catch (error) {
+        logger.error('Failed to load pending assignments:', error);
+      }
+
+      const pendingAssignmentsForCurrentView = effectiveSubjectId
+        ? allPendingAssignments.filter(
+            (assignment) =>
+              String(assignment.course_id) === String(effectiveSubjectId),
+          )
+        : allPendingAssignments;
+
+      const currentPendingAssignmentIds = pendingAssignmentsForCurrentView
+        .map((assignment) => String(assignment.id))
+        .filter(Boolean);
+      const cachedPendingAssignmentIds = Array.isArray(
+        existingPath?.pendingAssignmentIds,
+      )
+        ? (existingPath?.pendingAssignmentIds ?? []).map((id) => String(id))
+        : null;
+      const hasCachedPendingAssignmentIds = cachedPendingAssignmentIds !== null;
+      const canReuseExistingPath =
+        existingPath &&
+        pendingAssignmentsFetched &&
+        (!hasCachedPendingAssignmentIds ||
+          areStringArraysEqual(
+            cachedPendingAssignmentIds,
+            currentPendingAssignmentIds,
+          ));
+
+      // 1️⃣ If we could not refresh pending assignments, fall back to cache.
+      if (!pendingAssignmentsFetched && existingPath) {
+        pathData = existingPath;
+      } else if (
+        existingPath &&
+        !hasCachedPendingAssignmentIds &&
+        !effectiveSubjectId
+      ) {
+        const migratedPath: HomeworkPath = {
+          ...existingPath,
+          pendingAssignmentIds: currentPendingAssignmentIds,
+        };
+        await saveHomeworkPath(student, migratedPath);
+        pathData = migratedPath;
+      } else if (canReuseExistingPath) {
+        // 1️⃣ If cached path still matches the current pending assignments, reuse it.
         pathData = existingPath;
       } else {
         // 2️⃣ Need (re)build from assignments (first time / subject change)
-        const all = await api.getPendingAssignments(currClass.id, student.id);
-        let allPendingAssignments = all.filter((a) => a.type !== LIVE_QUIZ);
-
         // 2a. Subject filter, if any
-        if (subjectId) {
-          allPendingAssignments = allPendingAssignments.filter(
-            (assignment) => String(assignment.course_id) === String(subjectId),
-          );
+        if (effectiveSubjectId) {
+          allPendingAssignments = pendingAssignmentsForCurrentView;
 
           if (!allPendingAssignments.length) {
             // No assignments for this subject → reset selection & fall back to global path
             setSelectedSubject(null);
+            activeSubjectRef.current = null;
 
             if (existingPath) {
               pathData = existingPath;
@@ -246,6 +311,7 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
                 path_id: uuidv4(),
                 lessons: [],
                 currentIndex: 0,
+                pendingAssignmentIds: currentPendingAssignmentIds,
               };
               await saveHomeworkPath(student, emptyPath);
               pathData = emptyPath;
@@ -276,6 +342,7 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
                   path_id: uuidv4(),
                   lessons: [],
                   currentIndex: 0,
+                  pendingAssignmentIds: currentPendingAssignmentIds,
                 };
                 await saveHomeworkPath(student, emptyPath);
                 pathData = emptyPath;
@@ -325,6 +392,7 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
                   path_id: uuidv4(),
                   lessons: lessonsWithDetails,
                   currentIndex: 0,
+                  pendingAssignmentIds: currentPendingAssignmentIds,
                 };
 
                 await saveHomeworkPath(student, newHomeworkPath);
@@ -365,7 +433,7 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
             pathData = await buildAndSaveInitialHomeworkPath(
               student,
               allPendingAssignments,
-              subjectId,
+              effectiveSubjectId,
             );
           }
         }
@@ -378,9 +446,12 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
       }
 
       // 4️⃣ Set dropdown default subject when no filter
-      if (!subjectId && pathData.lessons && pathData.lessons.length > 0) {
+      if (pathData.lessons && pathData.lessons.length > 0) {
         const firstCourseId = String(pathData.lessons[0].course_id);
-        setSelectedSubject(firstCourseId);
+        activeSubjectRef.current = firstCourseId;
+        if (!subjectId || selectedSubject == null) {
+          setSelectedSubject(firstCourseId);
+        }
       }
 
       // 5️⃣ Effective current index
@@ -458,6 +529,7 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
         path_id: uuidv4(),
         lessons: [],
         currentIndex: 0,
+        pendingAssignmentIds: [],
       };
       await saveHomeworkPath(student, emptyPath);
       return emptyPath;
@@ -512,6 +584,9 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
       path_id: uuidv4(),
       lessons: lessonsWithDetails,
       currentIndex: 0,
+      pendingAssignmentIds: pendingAssignments
+        .map((assignment) => String(assignment.id))
+        .filter(Boolean),
     };
 
     await saveHomeworkPath(student, newHomeworkPath);
@@ -649,7 +724,10 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
             onCourseChange={() => {
               const currentStudent = Util.getCurrentStudent();
               if (currentStudent) {
-                fetchHomeworkPathway(currentStudent);
+                fetchHomeworkPathway(
+                  currentStudent,
+                  selectedSubject || activeSubjectRef.current || undefined,
+                );
               }
             }}
             disabled={isDropdownDisabled}

--- a/src/pages/Assignment.tsx
+++ b/src/pages/Assignment.tsx
@@ -68,6 +68,7 @@ const AssignmentPage: React.FC<AssignmentPageProps> = ({
   }>({});
   const [showHomeworkCompleteModal, setShowHomeworkCompleteModal] =
     useState(false);
+  const [assignmentRefreshToken, setAssignmentRefreshToken] = useState(0);
   const debounceTimer = useRef<NodeJS.Timeout | null>(null);
   const isMounted = useRef(true);
   const { gbUpdated, setGbUpdated } = useGbContext();
@@ -202,6 +203,9 @@ const AssignmentPage: React.FC<AssignmentPageProps> = ({
     }
     debounceTimer.current = setTimeout(() => {
       if (isMounted.current) {
+        // One debounced refresh token is enough to tell HomeworkPathway to
+        // re-read the current assignments without triggering duplicate reloads.
+        setAssignmentRefreshToken((prev) => prev + 1);
         init();
       }
     }, 1000);
@@ -549,7 +553,10 @@ const AssignmentPage: React.FC<AssignmentPageProps> = ({
 
                   // <HomeworkPathway onPlayMoreHomework={onPlayMoreHomework} />
                   assignments.length > 0 ? (
-                    <HomeworkPathway onPlayMoreHomework={onPlayMoreHomework} />
+                    <HomeworkPathway
+                      onPlayMoreHomework={onPlayMoreHomework}
+                      refreshToken={assignmentRefreshToken}
+                    />
                   ) : (
                     <div className="pending-assignment">
                       {showHomeworkCompleteModal && (


### PR DESCRIPTION
- Preserved the currently active homework subject across assignment refreshes
- Reused cached homework paths when the current subject’s assignment set has not changed
- Kept immediate refresh behavior intact by using a debounced assignment refresh token
- Added comments to explain the subject-pinning and cache-reuse logic
- Added regression tests for legacy cache migration and subject stability during refresh