### PR TITLE
fix: earned sticker not showing in popup 2 : Use apiHandler for sticker progress

### DIFF
--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -3118,17 +3118,17 @@ export class Util {
       /* 5️⃣ Move course index if path completed */
       if (pathCompleted) {
         let preAwardCollectedStickerIds: string[] = [];
-        if (typeof navigator !== 'undefined' && navigator.onLine) {
-          try {
-            const currentBookWithProgress =
-              await ServiceConfig.getI().apiHandler.getCurrentStickerBookWithProgress(
-                currentStudent.id,
-              );
-            preAwardCollectedStickerIds =
-              currentBookWithProgress?.progress?.stickers_collected ?? [];
-          } catch {
-            preAwardCollectedStickerIds = [];
-          }
+        try {
+          // The active API handler already resolves to sqlite while offline,
+          // so use it for the drag-popup seed data in both modes.
+          const currentBookWithProgress =
+            await ServiceConfig.getI().apiHandler.getCurrentStickerBookWithProgress(
+              currentStudent.id,
+            );
+          preAwardCollectedStickerIds =
+            currentBookWithProgress?.progress?.stickers_collected ?? [];
+        } catch {
+          preAwardCollectedStickerIds = [];
         }
         const newpathId = uuidv4();
         course.path_id = newpathId;


### PR DESCRIPTION
…er progress

Remove the navigator.onLine guard and always call ServiceConfig.getI().apiHandler.getCurrentStickerBookWithProgress to collect pre-award sticker IDs. The active API handler resolves to sqlite while offline, so this ensures consistent drag-popup seed data both online and offline; errors still fall back to an empty array.