### PR TITLE
Add close-shine animation to actions button and removed padding on ac…

### DIFF
--- a/src/ops-console/pages/SchoolList.css
+++ b/src/ops-console/pages/SchoolList.css
@@ -102,6 +102,9 @@
   text-transform: none !important;
   font-weight: 500 !important;
   min-width: 110px !important;
+  position: relative;
+  overflow: hidden !important;
+  isolation: isolate;
 }
 
 .school-list-actions-button.MuiButton-root:hover {
@@ -109,8 +112,60 @@
   background: #fff !important;
 }
 
+.school-list-actions-button-close-shine.MuiButton-root::after {
+  content: '';
+  position: absolute;
+  inset: -55%;
+  border-radius: 999px;
+  pointer-events: none;
+  z-index: 1;
+  background: radial-gradient(
+    circle at 38% 50%,
+    rgba(70, 63, 63, 0.34) 0%,
+    rgba(56, 51, 51, 0.3) 18%,
+    rgba(75, 76, 78, 0.2) 42%,
+    rgba(55, 57, 59, 0) 72%
+  );
+  transform-origin: 38% 50%;
+  transform: scale(0.18);
+  animation: school-list-actions-button-shine 0.65s
+    cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.school-list-actions-button-close-shine.MuiButton-root {
+  animation: school-list-actions-button-glow 0.65s ease-out;
+}
+
+@keyframes school-list-actions-button-shine {
+  0% {
+    transform: scale(0.18);
+    opacity: 0;
+  }
+  22% {
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1.42);
+    opacity: 0;
+  }
+}
+
+@keyframes school-list-actions-button-glow {
+  0% {
+    filter: brightness(1);
+  }
+  45% {
+    filter: brightness(0.94);
+  }
+  100% {
+    filter: brightness(1);
+  }
+}
+
 .school-list-actions-chevron {
   color: #1a71f6;
+  transform: rotate(0deg);
+  transform-origin: center;
   transition: transform 0.2s ease;
 }
 

--- a/src/ops-console/pages/SchoolList.tsx
+++ b/src/ops-console/pages/SchoolList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import {
   Box,
   Button,
@@ -109,6 +109,10 @@ const SchoolList: React.FC = () => {
   const [actionsAnchorEl, setActionsAnchorEl] = useState<null | HTMLElement>(
     null,
   );
+  const [isActionsButtonCloseShine, setIsActionsButtonCloseShine] =
+    useState(false);
+  const actionsButtonCloseShineTimeoutRef = useRef<number | null>(null);
+  const actionsButtonCloseShineRafRef = useRef<number | null>(null);
   const [openDetails, setOpenDetails] = useState(false);
   const [visitId, setVisitId] = useState<string | null>(null);
   const { roles } = useAppSelector(
@@ -126,6 +130,36 @@ const SchoolList: React.FC = () => {
     rolesWithAccess.includes(role as RoleType),
   );
   const isActionsMenuOpen = Boolean(actionsAnchorEl);
+
+  const triggerActionsButtonCloseShine = useCallback(() => {
+    setIsActionsButtonCloseShine(false);
+
+    if (actionsButtonCloseShineRafRef.current !== null) {
+      window.cancelAnimationFrame(actionsButtonCloseShineRafRef.current);
+    }
+    actionsButtonCloseShineRafRef.current = window.requestAnimationFrame(() => {
+      setIsActionsButtonCloseShine(true);
+    });
+
+    if (actionsButtonCloseShineTimeoutRef.current !== null) {
+      window.clearTimeout(actionsButtonCloseShineTimeoutRef.current);
+    }
+    actionsButtonCloseShineTimeoutRef.current = window.setTimeout(() => {
+      setIsActionsButtonCloseShine(false);
+      actionsButtonCloseShineTimeoutRef.current = null;
+    }, 700);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (actionsButtonCloseShineTimeoutRef.current !== null) {
+        window.clearTimeout(actionsButtonCloseShineTimeoutRef.current);
+      }
+      if (actionsButtonCloseShineRafRef.current !== null) {
+        window.cancelAnimationFrame(actionsButtonCloseShineRafRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     const params = new URLSearchParams();
@@ -301,6 +335,7 @@ const SchoolList: React.FC = () => {
 
   const handleCloseActionsMenu = () => {
     setActionsAnchorEl(null);
+    triggerActionsButtonCloseShine();
   };
 
   const handleOpenUploadPage = () => {
@@ -470,7 +505,11 @@ const SchoolList: React.FC = () => {
                   <Button
                     variant="outlined"
                     id="school-list-actions-button"
-                    className="school-list-actions-button"
+                    className={`school-list-actions-button${
+                      isActionsButtonCloseShine
+                        ? ' school-list-actions-button-close-shine'
+                        : ''
+                    }`}
                     onClick={handleOpenActionsMenu}
                     aria-controls={
                       isActionsMenuOpen ? 'school-list-actions-menu' : undefined
@@ -497,6 +536,7 @@ const SchoolList: React.FC = () => {
                   onClose={handleCloseActionsMenu}
                   anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                   transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                  MenuListProps={{ disablePadding: true }}
                   PaperProps={{
                     className: 'school-list-actions-menu',
                   }}


### PR DESCRIPTION
…tion menu

Introduce a close-shine visual effect for the actions button when the actions menu is closed. Changes include CSS for the shine pseudo-element and keyframe animations, and button layout tweaks (position: relative, overflow: hidden, isolation) so the effect renders correctly. In TSX, add state, refs and a triggerActionsButtonCloseShine callback using requestAnimationFrame + timeout to toggle the shine class, plus cleanup in useEffect. Also wire the trigger into handleCloseActionsMenu, apply the conditional className, and set MenuListProps.disablePadding on the menu.