### PR TITLE
Restrict UI actions for external users

### DIFF
--- a/src/ops-console/components/SchoolDetailsComponents/ClassDetailsPage.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/ClassDetailsPage.tsx
@@ -14,6 +14,10 @@ import { NOTES_UPDATED_EVENT } from '../../../common/constants';
 import WhatsAppInfoCard from './WhatsAppInfoCard';
 import logger from '../../../utility/logger';
 import { parseGradeSection, toCommaString } from './ClassDetailsPageUtils';
+import { RoleType } from '../../../interface/modelInterfaces';
+import { useAppSelector } from '../../../redux/hooks';
+import { RootState } from '../../../redux/store';
+import { AuthState } from '../../../redux/slices/auth/authSlice';
 
 type ApiStudent = StudentInfo;
 const ROWS_PER_PAGE = 20;
@@ -58,6 +62,12 @@ const ClassDetailsPage: React.FC<Props> = ({
     [classRow],
   );
 
+  const { roles } = useAppSelector(
+    (state: RootState) => state.auth as AuthState,
+  );
+  const userRoles = roles || [];
+  const isExternalUser = userRoles.includes(RoleType.EXTERNAL_USER);
+
   const { grade: parsedGrade, section: parsedSection } = useMemo(
     () =>
       parseGradeSection(
@@ -77,6 +87,10 @@ const ClassDetailsPage: React.FC<Props> = ({
           1,
           ROWS_PER_PAGE,
         );
+        logger.info('Loaded class details:', {
+          students: res?.data,
+          total: res?.total,
+        });
         setInitialStudents(res?.data || []);
         setInitialTotal(res?.total || 0);
         const active = await api.getActiveStudentsCountByClass(classId);
@@ -152,14 +166,16 @@ const ClassDetailsPage: React.FC<Props> = ({
         </Button>
 
         {/* + Add Notes button on the right */}
-        <Button
-          variant="outlined"
-          onClick={() => setShowAddModal(true)}
-          className="classdetailspage-addnote-btn"
-          aria-label="+ Add Notes"
-        >
-          + {t('Add Notes')}
-        </Button>
+        {!isExternalUser && (
+          <Button
+            variant="outlined"
+            onClick={() => setShowAddModal(true)}
+            className="classdetailspage-addnote-btn"
+            aria-label="+ Add Notes"
+          >
+            + {t('Add Notes')}
+          </Button>
+        )}
       </Box>
 
       {/* AddNoteModal */}

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolPrincipals.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolPrincipals.tsx
@@ -624,16 +624,18 @@ const SchoolPrincipals: React.FC<SchoolPrincipalsProps> = ({
           <Typography className="school-principals-empty-state-message">
             {t('No principals data found for the selected school')}
           </Typography>
-          <MuiButton
-            variant="text"
-            onClick={handleAddNewPrincipal}
-            className="school-principals-emptyStateAddButton"
-            startIcon={
-              <AddIcon className="school-principals-emptyStateAddButton-icon" />
-            }
-          >
-            {t('Add Principal')}
-          </MuiButton>
+          {!isExternalUser && (
+            <MuiButton
+              variant="text"
+              onClick={handleAddNewPrincipal}
+              className="school-principals-emptyStateAddButton"
+              startIcon={
+                <AddIcon className="school-principals-emptyStateAddButton-icon" />
+              }
+            >
+              {t('Add Principal')}
+            </MuiButton>
+          )}
         </Box>
       )}
 

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolStudents.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolStudents.tsx
@@ -999,28 +999,35 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
           </Typography>
         ),
       },
-      {
-        key: 'schstudents_interact',
-        label: t('Interact'),
-        sortable: false,
-        render: (s) => (
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'left',
-              alignItems: 'left',
-            }}
-          >
-            <IconButton size="small" onClick={() => handleInteractClick(s)}>
-              <img
-                src="/assets/icons/Interact.svg"
-                alt="Interact"
-                style={{ width: 30, height: 30 }}
-              />
-            </IconButton>
-          </Box>
-        ),
-      },
+      ...(!isExternalUser
+        ? ([
+            {
+              key: 'schstudents_interact',
+              label: t('Interact'),
+              sortable: false,
+              render: (s) => (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'left',
+                    alignItems: 'left',
+                  }}
+                >
+                  <IconButton
+                    size="small"
+                    onClick={() => handleInteractClick(s)}
+                  >
+                    <img
+                      src="/assets/icons/Interact.svg"
+                      alt="Interact"
+                      style={{ width: 30, height: 30 }}
+                    />
+                  </IconButton>
+                </Box>
+              ),
+            },
+          ] as Column<DisplayStudent>[])
+        : []),
     ];
     const genderColumn: Column<DisplayStudent> = {
       key: 'gender',

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolTeachers.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolTeachers.tsx
@@ -1472,7 +1472,7 @@ const SchoolTeachers: React.FC<SchoolTeachersProps> = ({
               ? t('No teachers found matching your criteria.')
               : t('No teachers data found for the selected school')}
           </Typography>
-          {!isFilteringOrSearching && (
+          {!isFilteringOrSearching && isExternalUser && (
             <MuiButton
               variant="text"
               onClick={handleAddNewTeacher}

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolTeachers.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolTeachers.tsx
@@ -1472,7 +1472,7 @@ const SchoolTeachers: React.FC<SchoolTeachersProps> = ({
               ? t('No teachers found matching your criteria.')
               : t('No teachers data found for the selected school')}
           </Typography>
-          {!isFilteringOrSearching && isExternalUser && (
+          {!isFilteringOrSearching && !isExternalUser && (
             <MuiButton
               variant="text"
               onClick={handleAddNewTeacher}

--- a/src/ops-console/components/SchoolDetailsComponents/WhatsAppInfoCard.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/WhatsAppInfoCard.tsx
@@ -7,6 +7,11 @@ import { t } from 'i18next';
 import { ErrorOutlineOutlined } from '@mui/icons-material';
 import WhatsAppInviteLinkInput from './WhatsAppInviteLinkInput';
 import logger from '../../../utility/logger';
+import { RoleType } from '../../../interface/modelInterfaces';
+import { useAppSelector } from '../../../redux/hooks';
+import { RootState } from '../../../redux/store';
+import { AuthState } from '../../../redux/slices/auth/authSlice';
+import { isExternal } from 'util/types';
 
 type WhatsAppInfoCardProps = {
   classData?: TableTypes<'class'>;
@@ -35,13 +40,17 @@ const WhatsAppInfoCard: React.FC<WhatsAppInfoCardProps> = ({
   const [isChangingGroup, setIsChangingGroup] = useState(false);
   const [isDisconnectedGroup, setIsDisconnectedGroup] = useState(false);
   const [isStatusResolved, setIsStatusResolved] = useState(false);
+  const { roles } = useAppSelector(
+    (state: RootState) => state.auth as AuthState,
+  );
+  const userRoles = roles || [];
+  const isExternalUser = userRoles.includes(RoleType.EXTERNAL_USER);
   useEffect(() => {
     let isMounted = true;
     if (!classData?.id) {
       setIsStatusResolved(true);
       return;
     }
-
     const init = async () => {
       setIsStatusResolved(false);
       try {
@@ -244,93 +253,95 @@ const WhatsAppInfoCard: React.FC<WhatsAppInfoCardProps> = ({
               </Typography>
             </Box>
           )}
-          {isStatusResolved && !(isChangingGroup && isDisconnectedGroup) && (
-            <Box className="wa-section">
-              <Typography variant="caption" color="text.secondary">
-                {isChangingGroup ? t('Add an Invite Link') : t('Group Name')}
-              </Typography>
+          {isStatusResolved &&
+            !(isChangingGroup && isDisconnectedGroup) &&
+            !isExternalUser && (
+              <Box className="wa-section">
+                <Typography variant="caption" color="text.secondary">
+                  {isChangingGroup ? t('Add an Invite Link') : t('Group Name')}
+                </Typography>
 
-              <Box className="wa-input-row">
-                {isChangingGroup && (
-                  <WhatsAppInviteLinkInput
-                    inviteInput={inviteInput}
-                    setInviteInput={setInviteInput}
-                    error={error}
-                    loading={loading}
-                    groupId={groupId || classDoc?.group_id}
-                    onSubmit={handleInviteSubmit}
-                    onCancel={() => {
-                      const hasExistingGroupName =
-                        (groupName ?? '').trim().length > 0;
-                      setIsChangingGroup(!hasExistingGroupName);
-                      setInviteInput('');
-                      setError(null);
-                    }}
-                  />
-                )}
+                <Box className="wa-input-row">
+                  {isChangingGroup && (
+                    <WhatsAppInviteLinkInput
+                      inviteInput={inviteInput}
+                      setInviteInput={setInviteInput}
+                      error={error}
+                      loading={loading}
+                      groupId={groupId || classDoc?.group_id}
+                      onSubmit={handleInviteSubmit}
+                      onCancel={() => {
+                        const hasExistingGroupName =
+                          (groupName ?? '').trim().length > 0;
+                        setIsChangingGroup(!hasExistingGroupName);
+                        setInviteInput('');
+                        setError(null);
+                      }}
+                    />
+                  )}
 
-                {!isChangingGroup && isEditing && (
-                  <div
-                    className="wa-input-row-editing"
-                    id="wa-input-row-editing-id"
-                  >
-                    <Box className="wa-input-wrapper">
-                      <input
-                        className="wa-input"
-                        value={editedGroupName}
-                        autoFocus
-                        onChange={(e) => setEditedGroupName(e.target.value)}
-                      />
-                    </Box>
-
-                    <Box display="flex" gap={2}>
-                      <button
-                        className="wa-info-save-btn"
-                        onClick={handleSave}
-                        disabled={isSaving || !editedGroupName.trim()}
-                      >
-                        {isSaving ? t('Saving...') : t('Save')}
-                      </button>
-
-                      <button
-                        className="wa-info-cancel-btn"
-                        onClick={handleCancel}
-                        disabled={isSaving}
-                      >
-                        {t('Cancel')}
-                      </button>
-                    </Box>
-                  </div>
-                )}
-
-                {!isChangingGroup && !isEditing && (
-                  <>
-                    <Box className="wa-input-wrapper">
-                      <input
-                        className="wa-input"
-                        value={groupName ?? ''}
-                        disabled
-                      />
-
-                      <img
-                        src="/assets/icons/EditIcon2.svg"
-                        alt="Edit"
-                        className="wa-input-edit-icon"
-                        onClick={handleEdit}
-                      />
-                    </Box>
-
-                    <button
-                      className="wa-change-btn"
-                      onClick={openChangeGroupPopup}
+                  {!isChangingGroup && isEditing && (
+                    <div
+                      className="wa-input-row-editing"
+                      id="wa-input-row-editing-id"
                     >
-                      {t('Change')}
-                    </button>
-                  </>
-                )}
+                      <Box className="wa-input-wrapper">
+                        <input
+                          className="wa-input"
+                          value={editedGroupName}
+                          autoFocus
+                          onChange={(e) => setEditedGroupName(e.target.value)}
+                        />
+                      </Box>
+
+                      <Box display="flex" gap={2}>
+                        <button
+                          className="wa-info-save-btn"
+                          onClick={handleSave}
+                          disabled={isSaving || !editedGroupName.trim()}
+                        >
+                          {isSaving ? t('Saving...') : t('Save')}
+                        </button>
+
+                        <button
+                          className="wa-info-cancel-btn"
+                          onClick={handleCancel}
+                          disabled={isSaving}
+                        >
+                          {t('Cancel')}
+                        </button>
+                      </Box>
+                    </div>
+                  )}
+
+                  {!isChangingGroup && !isEditing && (
+                    <>
+                      <Box className="wa-input-wrapper">
+                        <input
+                          className="wa-input"
+                          value={groupName ?? ''}
+                          disabled
+                        />
+
+                        <img
+                          src="/assets/icons/EditIcon2.svg"
+                          alt="Edit"
+                          className="wa-input-edit-icon"
+                          onClick={handleEdit}
+                        />
+                      </Box>
+
+                      <button
+                        className="wa-change-btn"
+                        onClick={openChangeGroupPopup}
+                      >
+                        {t('Change')}
+                      </button>
+                    </>
+                  )}
+                </Box>
               </Box>
-            </Box>
-          )}
+            )}
 
           {isStatusResolved && !isChangingGroup && (
             <>


### PR DESCRIPTION
Use auth roles to detect external users and conditionally hide/adjust UI actions across school details components. Added RoleType/useAppSelector imports and isExternalUser derivation from Redux auth state. Changes: ClassDetailsPage (compute isExternalUser, log loaded class details, hide Add Notes for external users), SchoolPrincipals (hide Add Principal button for external users), SchoolStudents (omit Interact column for external users), SchoolTeachers (adjust Add Teacher button visibility based on external role), WhatsAppInfoCard (hide WhatsApp group actions for external users).