### PR TITLE
fix: mascot/reward layering on pathway screens during speaking animation

### DIFF
--- a/src/components/assignment/HomeworkPathwayStructure.tsx
+++ b/src/components/assignment/HomeworkPathwayStructure.tsx
@@ -1147,6 +1147,7 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
           }
         }
 
+        let rewardNode: SVGGElement | null = null;
         const endPath = paths[paths.length - 1];
         if (endPath) {
           const endPoint = endPath.getPointAtLength(endPath.getTotalLength());
@@ -1193,6 +1194,7 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
             });
           }
           fragment.appendChild(Gift_Svg);
+          rewardNode = Gift_Svg;
         }
 
         const animateChimpleMovement = () => {
@@ -1479,6 +1481,11 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
           riveWrapper.appendChild(riveDiv);
           chimple.appendChild(riveWrapper);
           svg.appendChild(chimple);
+
+          // Keep the reward node above the mascot during speaking/celebration
+          if (rewardNode) {
+            svg.appendChild(rewardNode);
+          }
 
           setRiveContainer(riveDiv);
         }

--- a/src/hooks/usePathwaySVG.ts
+++ b/src/hooks/usePathwaySVG.ts
@@ -1030,6 +1030,9 @@ export function usePathwaySVG({
           chimple.appendChild(riveDiv);
           svg.appendChild(chimple);
 
+          // Keep the reward node above the mascot during speaking/celebration
+          svg.appendChild(rewardWrapper);
+
           setRiveContainer(riveDiv);
         }
 


### PR DESCRIPTION
Keep reward SVG node painted above mascot in learning pathway