### PR TITLE
fix: scope cold-start assessment abort logic by course

### DIFF
--- a/src/hooks/useLearningPath.test.ts
+++ b/src/hooks/useLearningPath.test.ts
@@ -172,6 +172,11 @@ describe('useLearningPath features used by Home tab', () => {
       is_assessment: true,
       isPlayed: false,
     });
+    expect(mockApi.getSubjectLessonsBySubjectId).toHaveBeenCalledWith(
+      's1',
+      { id: 'stu-1' },
+      'c1',
+    );
   });
 
   test('resumes same teacher-assigned assessment after exit', async () => {

--- a/src/hooks/useLearningPath.ts
+++ b/src/hooks/useLearningPath.ts
@@ -144,6 +144,7 @@ export async function recommendNextLesson({
     const res = await api.getSubjectLessonsBySubjectId(
       course.subject_id,
       student,
+      course.id,
     );
     if (res && res.id) {
       return {

--- a/src/services/api/ApiHandler.ts
+++ b/src/services/api/ApiHandler.ts
@@ -2117,8 +2117,13 @@ export class ApiHandler implements ServiceApi {
   public async getSubjectLessonsBySubjectId(
     subjectId: string,
     student?: TableTypes<'user'>,
+    courseId?: string,
   ): Promise<TableTypes<'subject_lesson'> | null> {
-    return await this.s.getSubjectLessonsBySubjectId(subjectId, student);
+    return await this.s.getSubjectLessonsBySubjectId(
+      subjectId,
+      student,
+      courseId,
+    );
   }
   public async getSkillById(
     skillId: string,

--- a/src/services/api/ServiceApi.ts
+++ b/src/services/api/ServiceApi.ts
@@ -2861,6 +2861,7 @@ export interface ServiceApi {
   getSubjectLessonsBySubjectId(
     subjectId: string,
     student?: TableTypes<'user'>,
+    courseId?: string,
   ): Promise<TableTypes<'subject_lesson'> | null>;
 
   getSkillById(skillId: string): Promise<TableTypes<'skill'> | undefined>;

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -8534,6 +8534,7 @@ order by
   async getSubjectLessonsBySubjectId(
     subjectId: string,
     student?: TableTypes<'user'>,
+    courseId?: string,
   ): Promise<TableTypes<'subject_lesson'>> {
     if (!student) return {} as TableTypes<'subject_lesson'>;
     const studentId = student.id;
@@ -8570,6 +8571,7 @@ order by
       /* ==========================================
        * 3️⃣ Abort Check (with assignment_id IS NULL)
        * ========================================== */
+      const courseFilter = courseId ? ' AND course_id = ?' : '';
       const abortQuery = `
         SELECT lesson_id, status
         FROM (
@@ -8581,6 +8583,7 @@ order by
             FROM result
             WHERE student_id = ?
               AND subject_id = ?
+              ${courseFilter}
               AND assignment_id IS NULL
               AND is_deleted = 0
         ) t
@@ -8589,10 +8592,11 @@ order by
         LIMIT 2;
       `;
 
-      const abortRes = await this.executeQuery(abortQuery, [
-        studentId,
-        subjectId,
-      ]);
+      const abortParams: (string | null)[] = [studentId, subjectId];
+      if (courseId) {
+        abortParams.push(courseId);
+      }
+      const abortRes = await this.executeQuery(abortQuery, abortParams);
 
       const lastTwo = ((abortRes as DBSQLiteValues | undefined)?.values ??
         []) as ResultStatusRow[];
@@ -8653,15 +8657,17 @@ order by
         FROM result
         WHERE student_id = ?
           AND subject_id = ?
+          ${courseFilter}
           AND assignment_id IS NULL
           AND is_deleted = 0
           AND lesson_id IN (${resultPlaceholders});
       `;
-      const resultRes = await this.executeQuery(resultQuery, [
-        studentId,
-        subjectId,
-        ...lessonIds,
-      ]);
+      const resultParams: (string | null)[] = [studentId, subjectId];
+      if (courseId) {
+        resultParams.push(courseId);
+      }
+      resultParams.push(...lessonIds);
+      const resultRes = await this.executeQuery(resultQuery, resultParams);
       const completedLessons = ((resultRes as DBSQLiteValues | undefined)
         ?.values ?? []) as ResultLessonRow[];
       const completedLessonIds = new Set(

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -12264,6 +12264,7 @@ export class SupabaseApi implements ServiceApi {
   async getSubjectLessonsBySubjectId(
     subjectId: string,
     student?: TableTypes<'user'>,
+    courseId?: string,
   ): Promise<TableTypes<'subject_lesson'>> {
     if (!this.supabase || !student) return {} as TableTypes<'subject_lesson'>;
 
@@ -12306,7 +12307,7 @@ export class SupabaseApi implements ServiceApi {
       /* ==========================================
        * 2️⃣ Abort Check (assignment_id IS NULL)
        * ========================================== */
-      const { data, error } = await this.supabase
+      let abortQuery = this.supabase
         .from('result')
         .select('lesson_id, status, created_at')
         .eq('student_id', studentId)
@@ -12315,6 +12316,12 @@ export class SupabaseApi implements ServiceApi {
         .eq('is_deleted', false)
         .order('created_at', { ascending: false })
         .limit(50);
+
+      if (courseId) {
+        abortQuery = abortQuery.eq('course_id', courseId);
+      }
+
+      const { data, error } = await abortQuery;
 
       if (error) {
         logger.error('Abort query error:', error);
@@ -12389,13 +12396,19 @@ export class SupabaseApi implements ServiceApi {
        * ========================================== */
       const lessonIds = candidateLessons.map((lesson) => lesson.lesson_id);
 
-      const { data: results } = await this.supabase
+      let resultsQuery = this.supabase
         .from('result')
         .select('lesson_id')
         .in('lesson_id', lessonIds)
         .eq('student_id', studentId)
         .is('assignment_id', null)
         .eq('is_deleted', false);
+
+      if (courseId) {
+        resultsQuery = resultsQuery.eq('course_id', courseId);
+      }
+
+      const { data: results } = await resultsQuery;
 
       const completedLessonIds = new Set(
         (results ?? []).map((r) => r.lesson_id),


### PR DESCRIPTION
Thread an optional courseId through the subject-lesson lookup to scope results by course when present. 
Added an optional courseId parameter to ServiceApi.getSubjectLessonsBySubjectId and implemented the plumbing in ApiHandler, SqliteApi and SupabaseApi (SQL and Supabase queries now add a course_id filter when courseId is provided). 
Updated useLearningPath to pass course.id into the call and adjusted the unit test to assert the new argument.