### PR TITLE
feat: Add school list export to Excel

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -515,6 +515,8 @@
   "Exercise 2": "Exercise 2",
   "Exercise": "Exercise",
   "Exit": "Exit",
+  "Export": "Export",
+  "Exporting...": "Exporting...",
   "F2F- Discussions": "F2F- Discussions",
   "Facebook": "Facebook",
   "Failed Batches": "Failed Batches",

--- a/src/ops-console/components/SchoolListDateRangeDropdown.tsx
+++ b/src/ops-console/components/SchoolListDateRangeDropdown.tsx
@@ -60,9 +60,10 @@ const SchoolListDateRangeDropdown: React.FC<
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
         PaperProps={{ className: 'school-list-actions-menu' }}
       >
-        {DATE_RANGE_OPTIONS.map((option, index) => (
-          <React.Fragment key={option.value}>
+        {DATE_RANGE_OPTIONS.flatMap((option, index) => {
+          const nodes = [
             <MenuItem
+              key={option.value}
               className="school-list-actions-menu-item"
               onClick={() => handleSelect(option.value)}
             >
@@ -72,12 +73,20 @@ const SchoolListDateRangeDropdown: React.FC<
                   className: 'school-list-actions-menu-item-label',
                 }}
               />
-            </MenuItem>
-            {index < DATE_RANGE_OPTIONS.length - 1 && (
-              <Divider className="school-list-actions-menu-divider" />
-            )}
-          </React.Fragment>
-        ))}
+            </MenuItem>,
+          ];
+
+          if (index < DATE_RANGE_OPTIONS.length - 1) {
+            nodes.push(
+              <Divider
+                key={`${option.value}-divider`}
+                className="school-list-actions-menu-divider"
+              />,
+            );
+          }
+
+          return nodes;
+        })}
       </Menu>
     </>
   );

--- a/src/ops-console/components/SchoolListExportButton.css
+++ b/src/ops-console/components/SchoolListExportButton.css
@@ -1,0 +1,3 @@
+.school-list-export-button.MuiButton-root {
+  min-width: 124px !important;
+}

--- a/src/ops-console/components/SchoolListExportButton.test.tsx
+++ b/src/ops-console/components/SchoolListExportButton.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+const SchoolListExportButton = require('./SchoolListExportButton').default;
+
+jest.mock('i18next', () => ({
+  t: (key: string) => key,
+}));
+
+describe('SchoolListExportButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the export label when not exporting', () => {
+    render(
+      <SchoolListExportButton
+        disabled={false}
+        isExporting={false}
+        onClick={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Export' })).toBeInTheDocument();
+  });
+
+  it('shows the exporting label while export is in progress', () => {
+    render(
+      <SchoolListExportButton
+        disabled={true}
+        isExporting={true}
+        onClick={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Exporting...' }),
+    ).toBeInTheDocument();
+  });
+
+  it('disables the button when disabled is true', () => {
+    render(
+      <SchoolListExportButton
+        disabled={true}
+        isExporting={false}
+        onClick={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Export' })).toBeDisabled();
+  });
+
+  it('calls onClick when the button is pressed', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+
+    render(
+      <SchoolListExportButton
+        disabled={false}
+        isExporting={false}
+        onClick={handleClick}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Export' }));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the exporting label even if disabled while export is in progress', () => {
+    render(
+      <SchoolListExportButton
+        disabled={true}
+        isExporting={true}
+        onClick={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Exporting...' })).toBeDisabled();
+  });
+
+  it('keeps the same button id and styling hooks for the toolbar layout', () => {
+    render(
+      <SchoolListExportButton
+        disabled={false}
+        isExporting={false}
+        onClick={jest.fn()}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Export' });
+
+    expect(button).toHaveAttribute('id', 'school-list-export-button');
+    expect(button).toHaveClass(
+      'school-list-actions-button',
+      'school-list-export-button',
+    );
+  });
+});

--- a/src/ops-console/components/SchoolListExportButton.tsx
+++ b/src/ops-console/components/SchoolListExportButton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Button } from '@mui/material';
+import { FileDownloadOutlined } from '@mui/icons-material';
+import { t } from 'i18next';
+import './SchoolListExportButton.css';
+
+type SchoolListExportButtonProps = {
+  disabled: boolean;
+  isExporting: boolean;
+  onClick: () => void | Promise<void>;
+};
+
+// Dedicated export CTA keeps the page toolbar markup small and easier to maintain.
+const SchoolListExportButton: React.FC<SchoolListExportButtonProps> = ({
+  disabled,
+  isExporting,
+  onClick,
+}) => (
+  <Button
+    variant="outlined"
+    id="school-list-export-button"
+    className="school-list-actions-button school-list-export-button"
+    startIcon={<FileDownloadOutlined className="school-list-upload-icon" />}
+    onClick={onClick}
+    disabled={disabled}
+  >
+    {isExporting ? t('Exporting...') : t('Export')}
+  </Button>
+);
+
+export default SchoolListExportButton;

--- a/src/ops-console/pages/SchoolList.css
+++ b/src/ops-console/pages/SchoolList.css
@@ -95,6 +95,10 @@
   flex-shrink: 0;
 }
 
+.school-list-export-control {
+  flex-shrink: 0;
+}
+
 .school-list-actions-group {
   display: flex;
   align-items: center;
@@ -125,6 +129,17 @@
 .school-list-actions-button.MuiButton-root:hover {
   border: none !important;
   background: #fff !important;
+}
+
+.school-list-actions-button.MuiButton-root.Mui-disabled {
+  background: #fff !important;
+  color: rgba(18, 22, 25, 0.45) !important;
+  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.08) !important;
+}
+
+.school-list-actions-button.MuiButton-root.Mui-disabled
+  .school-list-upload-icon {
+  color: rgba(18, 22, 25, 0.45) !important;
 }
 
 .school-list-actions-button-close-shine.MuiButton-root::after {
@@ -230,6 +245,43 @@
   display: flex;
   flex-direction: column;
 }
+
+/* School List keeps the name column pinned while the metric columns scroll beside it. */
+.school-list-table-container .data-tablebody-container {
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-x pan-y;
+}
+
+.school-list-table-container .data-tablebody-head-cell:first-child,
+.school-list-table-container .data-tablebody-cell:first-child {
+  min-width: 220px;
+  max-width: 220px;
+  width: 220px;
+  box-sizing: border-box;
+}
+
+.school-list-table-container .data-tablebody-cell:first-child {
+  box-shadow: 8px 0 12px -12px rgba(18, 22, 25, 0.35);
+}
+
+@media (max-width: 768px) {
+  /* Mobile keeps a fixed name column while every metric column remains individually scrollable. */
+  .school-list-table-container .data-tablebody-head-cell:not(:first-child),
+  .school-list-table-container .data-tablebody-cell:not(:first-child) {
+    min-width: 128px;
+    max-width: 128px;
+    width: 128px;
+    box-sizing: border-box;
+  }
+
+  .school-list-table-container .data-tablebody-head-cell:first-child,
+  .school-list-table-container .data-tablebody-cell:first-child {
+    min-width: 168px;
+    max-width: 168px;
+    width: 168px;
+  }
+}
+
 @media (max-width: 768px) and (orientation: portrait) {
   .school-list-page-header {
     position: relative;
@@ -267,36 +319,77 @@
   }
 
   .school-list-button-and-search-filter {
-    justify-content: flex-end;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(88px, 0.82fr) minmax(
+        0,
+        0.98fr
+      );
+    align-items: center;
+    justify-content: stretch;
     padding-left: 4%;
     padding-right: 4%;
-    padding-bottom: 2%;
-  }
-
-  .school-list-date-range-button.MuiButton-root {
-    min-width: 124px !important;
+    padding-bottom: 1.5%;
+    gap: 6px;
   }
 
   .school-list-search-control {
-    flex-basis: 100%;
-    order: 1;
-    justify-content: flex-start;
+    grid-column: 1 / -1;
+    justify-content: stretch;
   }
 
-  .school-list-date-range-button.MuiButton-root {
-    order: 2;
+  .school-list-search-control > * {
+    width: 100%;
+  }
+
+  .school-list-export-control {
+    min-width: 0;
+    display: flex;
+    justify-content: center;
   }
 
   .school-list-actions-group {
-    margin-left: auto;
-    flex-shrink: 0;
-    order: 3;
+    margin-left: 0;
+    min-width: 0;
+    width: 100%;
   }
 
   .school-list-tab-wrapper {
     width: 100%;
   }
+
+  .school-list-date-range-control,
+  .school-list-export-control {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .school-list-date-range-button.MuiButton-root,
+  .school-list-export-button.MuiButton-root,
+  .school-list-actions-group .school-list-actions-button.MuiButton-root {
+    min-width: 0 !important;
+    width: 100%;
+    padding: 4px 8px !important;
+    height: 34px !important;
+  }
+
+  .school-list-date-range-button.MuiButton-root {
+    white-space: nowrap;
+  }
+
+  .school-list-export-button.MuiButton-root {
+    max-width: 102px;
+    padding: 4px 6px !important;
+  }
+
+  .school-list-date-range-button.MuiButton-root .MuiButton-endIcon,
+  .school-list-actions-group
+    .school-list-actions-button.MuiButton-root
+    .MuiButton-endIcon,
+  .school-list-export-button.MuiButton-root .MuiButton-startIcon {
+    margin-left: 4px;
+    margin-right: 0;
+  }
+
   .school-list-footer {
     overflow-x: auto;
     justify-content: center;

--- a/src/ops-console/pages/SchoolList.export.test.ts
+++ b/src/ops-console/pages/SchoolList.export.test.ts
@@ -1,0 +1,95 @@
+import { buildSchoolListExportSheetRows } from './SchoolList.export';
+import type { SchoolListSourceRow } from './SchoolList.fetcher';
+
+jest.mock('i18next', () => ({
+  t: (value: string) => value,
+}));
+
+describe('buildSchoolListExportSheetRows', () => {
+  it('builds plain-text export rows without table render metadata', () => {
+    const rows = [
+      {
+        school_name: 'Alpha School',
+        school_performance: 'green',
+        district: 'Pune',
+        udise: '1234567890',
+        onboarded_students: 100,
+        activated_students: 80,
+        active_students: 60,
+        avg_time_spent: 45,
+        active_teachers: 6,
+        activities_assigned: 14,
+        avg_assignments_completed: 10,
+        avg_activities_completed: 8,
+      },
+    ] as SchoolListSourceRow[];
+
+    expect(buildSchoolListExportSheetRows(rows)).toEqual([
+      [
+        'School Name',
+        'School Performance',
+        'Onboarded Students',
+        'Activated Students',
+        'Activated Students',
+        'Active Students',
+        'Active Students',
+        'Average Time Spent',
+        'Active Teachers',
+        'Active Teachers',
+        'Activities Assigned',
+        'Avg Assignments Completed',
+        'Avg Activities Completed',
+      ],
+      [
+        'Alpha School\n1234567890 - Pune',
+        'Performing Well',
+        '100',
+        '80',
+        '80%',
+        '60',
+        '75%',
+        '45m',
+        '6',
+        '100%',
+        '14',
+        '10',
+        '8',
+      ],
+    ]);
+  });
+
+  it('falls back to placeholder text when export metrics are missing', () => {
+    const rows = [
+      {
+        school_name: 'Beta School',
+        district: '',
+        udise: null,
+        school_performance: '',
+        onboarded_students: null,
+        activated_students: null,
+        active_students: null,
+        avg_time_spent: null,
+        active_teachers: null,
+        activities_assigned: null,
+        avg_assignments_completed: null,
+        avg_activities_completed: null,
+      },
+    ] as SchoolListSourceRow[];
+
+    expect(buildSchoolListExportSheetRows(rows)[1]).toEqual([
+      'Beta School',
+      '--',
+      '--',
+      '--',
+      '--',
+      '--',
+      '--',
+      '--',
+      '--',
+      '--',
+      '--',
+      '--',
+      '--',
+    ]);
+  });
+});

--- a/src/ops-console/pages/SchoolList.export.ts
+++ b/src/ops-console/pages/SchoolList.export.ts
@@ -1,0 +1,124 @@
+import { type SchoolListSourceRow } from './SchoolList.fetcher';
+import {
+  buildSchoolUdiseLocationLabel,
+  formatCompactNumber,
+  formatPercent,
+  getSchoolListExportColumns,
+  pickFirstNumber,
+  resolvePerformanceStatus,
+} from './SchoolList.helpers';
+
+type ExportMetricText = {
+  valueText: string;
+  percentText: string;
+};
+
+const formatMetricValue = (
+  value: unknown,
+  suffix = '',
+  options?: { maxFractionDigits?: number },
+) =>
+  value === null || value === undefined || value === ''
+    ? '--'
+    : `${formatCompactNumber(value, options)}${suffix}`;
+
+const buildMetricExportText = (
+  value: unknown,
+  suffix = '',
+  options?: { maxFractionDigits?: number },
+): ExportMetricText => ({
+  valueText: formatMetricValue(value, suffix, options),
+  percentText: '--',
+});
+
+const buildMetricWithPercentExportText = (
+  value: unknown,
+  percent: number | null,
+  suffix = '',
+  options?: { maxFractionDigits?: number },
+): ExportMetricText => ({
+  valueText: formatMetricValue(value, suffix, options),
+  percentText: percent === null ? '--' : (formatPercent(percent) ?? '--'),
+});
+
+const buildExportCellTextMap = (school: SchoolListSourceRow) => {
+  const onboardedStudents = pickFirstNumber(
+    school.onboarded_students,
+    school.total_students,
+  );
+  const activatedStudents = pickFirstNumber(school.activated_students);
+  const activeStudents = pickFirstNumber(school.active_students);
+  const activeTeachers = pickFirstNumber(school.active_teachers);
+  const completionAssignments = pickFirstNumber(
+    school.avg_assignments_completed,
+  );
+  const completionActivities = pickFirstNumber(school.avg_activities_completed);
+  const udiseLocation = buildSchoolUdiseLocationLabel(school);
+  const performanceStatus = resolvePerformanceStatus(school) || '--';
+  const metricTextByKey: Record<string, ExportMetricText> = {
+    name: {
+      valueText: udiseLocation
+        ? `${school.school_name}\n${udiseLocation}`
+        : school.school_name,
+      percentText: '--',
+    },
+    schoolPerformance: {
+      valueText: performanceStatus,
+      percentText: '--',
+    },
+    onboardedStudents: buildMetricExportText(onboardedStudents),
+    activatedStudents: buildMetricWithPercentExportText(
+      activatedStudents,
+      onboardedStudents && activatedStudents
+        ? (activatedStudents / onboardedStudents) * 100
+        : null,
+    ),
+    activeStudents: buildMetricWithPercentExportText(
+      activeStudents,
+      activatedStudents && activeStudents
+        ? (activeStudents / activatedStudents) * 100
+        : null,
+    ),
+    avgTimeSpent: buildMetricExportText(
+      pickFirstNumber(
+        school.avg_time_spent,
+        school.average_time_spent_mins,
+        school.avg_time_spent_minutes,
+      ),
+      'm',
+      { maxFractionDigits: 0 },
+    ),
+    activeTeachers: buildMetricWithPercentExportText(
+      activeTeachers,
+      activeTeachers && activeTeachers > 0 ? 100 : null,
+    ),
+    activitiesAssigned: buildMetricExportText(
+      pickFirstNumber(
+        school.activities_assigned,
+        school.total_activities_assigned,
+        school.assignments_assigned,
+      ),
+    ),
+    avgAssignmentsCompleted: buildMetricExportText(completionAssignments),
+    avgActivitiesCompleted: buildMetricExportText(completionActivities),
+  };
+  return metricTextByKey;
+};
+
+export const buildSchoolListExportSheetRows = (rows: SchoolListSourceRow[]) => {
+  const exportColumns = getSchoolListExportColumns();
+
+  return [
+    exportColumns.map((column) => column.label),
+    ...rows.map((school) => {
+      const exportCellTextMap = buildExportCellTextMap(school);
+      return exportColumns.map((column) => {
+        const metric = exportCellTextMap[column.key];
+        if (!metric) return '--';
+        return column.part === 'percent'
+          ? metric.percentText
+          : metric.valueText;
+      });
+    }),
+  ];
+};

--- a/src/ops-console/pages/SchoolList.fetcher.tsx
+++ b/src/ops-console/pages/SchoolList.fetcher.tsx
@@ -5,8 +5,21 @@ import {
 } from '../../common/constants';
 import { ServiceApi } from '../../services/api/ServiceApi';
 
+type SchoolListApiRequest = {
+  filters: Record<string, string[]>;
+  page: number;
+  page_size: number;
+  order_by: string;
+  order_dir: 'asc' | 'desc';
+  search: string;
+  date_range: string;
+};
+
 export type SchoolMetricCell = {
   value: unknown;
+  text: string;
+  exportValueText?: string;
+  exportPercentText?: string;
   render: import('react').ReactNode;
 };
 
@@ -25,6 +38,7 @@ export type SchoolListRow = SchoolListSourceRow & {
   id: string | number;
   fieldCoordinators?: string;
   name: SchoolMetricCell;
+  udiseLocation: SchoolMetricCell;
   schoolPerformance: SchoolMetricCell;
   onboardedStudents: SchoolMetricCell;
   activatedStudents: SchoolMetricCell;
@@ -49,7 +63,7 @@ const ORDER_BY_MAP: Record<string, string> = {
   avgActivitiesCompleted: 'avg_activities_completed',
 };
 
-const useDebouncedValue = <T,>(value: T, delay: number) => {
+export const useDebouncedValue = <T,>(value: T, delay: number) => {
   const [debouncedValue, setDebouncedValue] = useState(value);
 
   useEffect(() => {
@@ -58,6 +72,89 @@ const useDebouncedValue = <T,>(value: T, delay: number) => {
   }, [value, delay]);
 
   return debouncedValue;
+};
+
+export const buildSchoolListRequest = ({
+  filters,
+  selectedTab,
+  page,
+  pageSize,
+  orderBy,
+  orderDir,
+  searchTerm,
+  selectedDateRange,
+}: {
+  filters: Record<string, string[]>;
+  selectedTab: PROGRAM_TAB;
+  page: number;
+  pageSize: number;
+  orderBy: string;
+  orderDir: 'asc' | 'desc';
+  searchTerm: string;
+  selectedDateRange: string;
+}): SchoolListApiRequest => {
+  const cleanedFilters = Object.fromEntries(
+    Object.entries(filters).filter(
+      ([_, value]) => Array.isArray(value) && value.length > 0,
+    ),
+  );
+  const tabModelFilter =
+    selectedTab !== PROGRAM_TAB.ALL
+      ? ({ model: [selectedTab] } as Record<string, string[]>)
+      : {};
+
+  return {
+    filters: { ...cleanedFilters, ...tabModelFilter },
+    page,
+    page_size: pageSize,
+    order_by: ORDER_BY_MAP[orderBy] ?? orderBy,
+    order_dir: orderDir,
+    search: searchTerm,
+    date_range: selectedDateRange,
+  };
+};
+
+export const fetchSchoolListPage = async ({
+  api,
+  filters,
+  selectedTab,
+  page,
+  pageSize,
+  orderBy,
+  orderDir,
+  searchTerm,
+  selectedDateRange,
+}: {
+  api: ServiceApi;
+  filters: Record<string, string[]>;
+  selectedTab: PROGRAM_TAB;
+  page: number;
+  pageSize: number;
+  orderBy: string;
+  orderDir: 'asc' | 'desc';
+  searchTerm: string;
+  selectedDateRange: string;
+}) => {
+  const getSchoolListing =
+    api.getSchoolMetricsForSchoolListing?.bind(api) ??
+    api.getFilteredSchoolsForSchoolListing?.bind(api);
+
+  if (!getSchoolListing) {
+    throw new Error('School listing API is not available');
+  }
+
+  return getSchoolListing(
+    buildSchoolListRequest({
+      filters,
+      selectedTab,
+      page,
+      pageSize,
+      orderBy,
+      orderDir,
+      searchTerm,
+      selectedDateRange,
+    }),
+  );
 };
 
 export const useSchoolListData = ({
@@ -84,7 +181,6 @@ export const useSchoolListData = ({
   const [schools, setSchools] = useState<SchoolListSourceRow[]>([]);
   const [total, setTotal] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
-  const debouncedSearchTerm = useDebouncedValue(searchTerm, 500);
 
   useEffect(() => {
     let active = true;
@@ -92,33 +188,16 @@ export const useSchoolListData = ({
     const fetchData = async () => {
       setIsLoading(true);
       try {
-        const cleanedFilters = Object.fromEntries(
-          Object.entries(filters).filter(
-            ([_, v]) => Array.isArray(v) && v.length > 0,
-          ),
-        );
-        const tabModelFilter =
-          selectedTab !== PROGRAM_TAB.ALL
-            ? ({ model: [selectedTab] } as Record<string, string[]>)
-            : {};
-        const requestFilters = { ...cleanedFilters, ...tabModelFilter };
-        const backendOrderBy = ORDER_BY_MAP[orderBy] ?? orderBy;
-        const getSchoolListing =
-          api.getSchoolMetricsForSchoolListing?.bind(api) ??
-          api.getFilteredSchoolsForSchoolListing?.bind(api);
-
-        if (!getSchoolListing) {
-          throw new Error('School listing API is not available');
-        }
-
-        const response = await getSchoolListing({
-          filters: requestFilters,
+        const response = await fetchSchoolListPage({
+          api,
+          filters,
+          selectedTab,
           page,
-          page_size: pageSize,
-          order_by: backendOrderBy,
-          order_dir: orderDir,
-          search: debouncedSearchTerm,
-          date_range: selectedDateRange,
+          pageSize,
+          orderBy,
+          orderDir,
+          searchTerm,
+          selectedDateRange,
         });
 
         if (!active) return;
@@ -144,12 +223,12 @@ export const useSchoolListData = ({
     };
   }, [
     api,
-    debouncedSearchTerm,
     filters,
     orderBy,
     orderDir,
     page,
     pageSize,
+    searchTerm,
     selectedDateRange,
     selectedTab,
   ]);

--- a/src/ops-console/pages/SchoolList.helpers.tsx
+++ b/src/ops-console/pages/SchoolList.helpers.tsx
@@ -7,6 +7,8 @@ import {
   PROGRAM_TAB_LABELS,
   SCHOOL_LISTING_STATUS_META,
 } from '../../common/constants';
+import type { Column } from '../components/DataTableBody';
+import type { SchoolListRow } from './SchoolList.fetcher';
 
 export type SchoolMetricRow = FilteredSchoolsForSchoolListingOps;
 
@@ -21,6 +23,11 @@ export const DATE_RANGE_OPTIONS = [
 export type DateRangeValue = (typeof DATE_RANGE_OPTIONS)[number]['value'];
 
 export type Filters = Record<string, string[]>;
+export type SchoolListExportColumn = {
+  key: keyof SchoolListRow;
+  label: string;
+  part: 'value' | 'percent';
+};
 
 // Shared filter metadata for the school listing drawer.
 export const filterConfigsForSchool = [
@@ -34,7 +41,8 @@ export const filterConfigsForSchool = [
   { key: 'cluster', label: t('Select Cluster') },
 ];
 
-export const INITIAL_FILTERS: Filters = {
+// Fresh filter objects keep reset flows predictable across the page.
+export const createEmptySchoolFilters = (): Filters => ({
   programType: [],
   partner: [],
   programManager: [],
@@ -43,7 +51,36 @@ export const INITIAL_FILTERS: Filters = {
   district: [],
   block: [],
   cluster: [],
+});
+
+// Query-string parsing stays defensive so broken URLs do not break the page.
+export const parseSchoolListJsonParam = <T,>(
+  param: string | null,
+  fallback: T,
+) => {
+  try {
+    return param ? (JSON.parse(param) as T) : fallback;
+  } catch {
+    return fallback;
+  }
 };
+
+export const hasSchoolListFilters = (filters: Filters) =>
+  Object.values(filters).some((values) => values.length > 0);
+
+// Normalizes API filter payloads back into the UI filter shape.
+export const mapSchoolListFilterOptions = (
+  data?: Record<string, string[]>,
+): Filters => ({
+  programType: data?.programType || [],
+  partner: data?.partner || [],
+  programManager: data?.programManager || [],
+  fieldCoordinator: data?.fieldCoordinator || [],
+  state: data?.state || [],
+  district: data?.district || [],
+  block: data?.block || [],
+  cluster: data?.cluster || [],
+});
 
 // Tabs shown across the top of the school listing.
 export const tabOptions = Object.entries(PROGRAM_TAB_LABELS).map(
@@ -54,6 +91,125 @@ export const tabOptions = Object.entries(PROGRAM_TAB_LABELS).map(
 );
 
 export const DEFAULT_PAGE_SIZE = 8;
+
+// Centralized column config keeps the page component focused on behavior.
+export const getSchoolListColumns = (): Column<SchoolListRow>[] => [
+  {
+    key: 'name',
+    label: t('School Name'),
+    width: '20%',
+    sortable: true,
+    orderBy: 'name',
+  },
+  {
+    key: 'schoolPerformance',
+    label: t('School Performance'),
+    width: '7.78%',
+    align: 'center',
+    sortable: false,
+  },
+  {
+    key: 'onboardedStudents',
+    label: t('Onboarded Students'),
+    width: '7.78%',
+    align: 'center',
+    sortable: false,
+    orderBy: 'onboarded_students',
+  },
+  {
+    key: 'activatedStudents',
+    label: t('Activated Students'),
+    width: '7.78%',
+    align: 'center',
+    sortable: false,
+    orderBy: 'activated_students',
+  },
+  {
+    key: 'activeStudents',
+    label: t('Active Students'),
+    width: '7.78%',
+    align: 'center',
+    sortable: false,
+    orderBy: 'active_students',
+  },
+  {
+    key: 'avgTimeSpent',
+    label: t('Average Time Spent'),
+    width: '7.78%',
+    align: 'center',
+    sortable: false,
+    orderBy: 'avg_time_spent',
+  },
+  {
+    key: 'activeTeachers',
+    label: t('Active Teachers'),
+    width: '7.78%',
+    align: 'center',
+    sortable: false,
+    orderBy: 'active_teachers',
+  },
+  {
+    key: 'activitiesAssigned',
+    label: t('Activities Assigned'),
+    width: '7.78%',
+    align: 'center',
+    sortable: false,
+    orderBy: 'activities_assigned',
+  },
+  {
+    key: 'avgAssignmentsCompleted',
+    label: t('Avg Assignments Completed'),
+    width: '7.78%',
+    align: 'center',
+    sortable: false,
+    orderBy: 'avg_assignments_completed',
+  },
+  {
+    key: 'avgActivitiesCompleted',
+    label: t('Avg Activities Completed'),
+    width: '7.78%',
+    align: 'center',
+    sortable: false,
+    orderBy: 'avg_activities_completed',
+  },
+];
+
+// Export columns intentionally mirror the UI while keeping paired % columns.
+export const getSchoolListExportColumns = (): SchoolListExportColumn[] => [
+  { key: 'name', label: t('School Name'), part: 'value' },
+  {
+    key: 'schoolPerformance',
+    label: t('School Performance'),
+    part: 'value',
+  },
+  { key: 'onboardedStudents', label: t('Onboarded Students'), part: 'value' },
+  { key: 'activatedStudents', label: t('Activated Students'), part: 'value' },
+  {
+    key: 'activatedStudents',
+    label: t('Activated Students'),
+    part: 'percent',
+  },
+  { key: 'activeStudents', label: t('Active Students'), part: 'value' },
+  { key: 'activeStudents', label: t('Active Students'), part: 'percent' },
+  { key: 'avgTimeSpent', label: t('Average Time Spent'), part: 'value' },
+  { key: 'activeTeachers', label: t('Active Teachers'), part: 'value' },
+  { key: 'activeTeachers', label: t('Active Teachers'), part: 'percent' },
+  {
+    key: 'activitiesAssigned',
+    label: t('Activities Assigned'),
+    part: 'value',
+  },
+  {
+    key: 'avgAssignmentsCompleted',
+    label: t('Avg Assignments Completed'),
+    part: 'value',
+  },
+  {
+    key: 'avgActivitiesCompleted',
+    label: t('Avg Activities Completed'),
+    part: 'value',
+  },
+];
 
 export const formatCompactNumber = (
   value: unknown,
@@ -140,19 +296,18 @@ export const resolvePerformanceStatus = (school: SchoolMetricRow) => {
 
 // Kept for future table helpers that need a compact geographic breadcrumb.
 export const buildSchoolLocationLabel = (school: SchoolMetricRow) => {
-  const locationParts = [
-    getStringValue(school.state),
-    getStringValue(school.district),
-    getStringValue(school.block),
-    getStringValue(school.cluster),
-  ].filter((part) => part.length > 0);
-  return locationParts.join(' • ');
+  const locationParts = [getStringValue(school.district)].filter(
+    (part) => part.length > 0,
+  );
+  return locationParts.join(', ');
 };
 
-export const buildSchoolSubtitle = (school: SchoolMetricRow) => {
+export const buildSchoolUdiseLocationLabel = (school: SchoolMetricRow) => {
   const udise = getStringValue(school.udise);
-  const district = getStringValue(school.district);
-  return udise || district ? `${udise} - ${district}`.trim() : '';
+  const location = buildSchoolLocationLabel(school);
+
+  if (udise && location) return `${udise} - ${location}`;
+  return udise || location || '';
 };
 
 export const getSchoolCoordinatorList = (school: SchoolMetricRow) =>
@@ -170,6 +325,9 @@ export const renderMetricCell = (
       : `${formatCompactNumber(value, options)}${suffix}`;
   return {
     value,
+    text,
+    exportValueText: text,
+    exportPercentText: '',
     render: (
       <Typography
         variant="subtitle2"
@@ -212,9 +370,19 @@ export const renderMetricWithPercentCell = (
       ? '--'
       : formatCompactNumber(value, options);
   const percentLabel = percent === null ? null : formatPercent(percent);
+  const text = percentLabel
+    ? showValue
+      ? `${metricValue}${suffix} (${percentLabel})`
+      : percentLabel
+    : showValue
+      ? `${metricValue}${suffix}`
+      : '--';
 
   return {
     value,
+    text,
+    exportValueText: showValue ? `${metricValue}${suffix}` : '--',
+    exportPercentText: percentLabel ?? '--',
     render: (
       <Box display="flex" alignItems="center" gap={1} sx={{ minWidth: 0 }}>
         {showValue && (

--- a/src/ops-console/pages/SchoolList.test.tsx
+++ b/src/ops-console/pages/SchoolList.test.tsx
@@ -6,6 +6,8 @@ import { RoleType } from '../../interface/modelInterfaces';
 import { useAppSelector } from '../../redux/hooks';
 import { RootState } from '../../redux/store';
 import { AuthState } from '../../redux/slices/auth/authSlice';
+import { Util } from '../../utility/util';
+import { runBackgroundWorkerTask } from '../../workers/backgroundWorkerClient';
 import SchoolList from './SchoolList';
 
 jest.mock('i18next', () => ({
@@ -43,6 +45,36 @@ jest.mock('../../services/ServiceConfig', () => ({
   },
 }));
 
+jest.mock('xlsx-js-style', () => ({
+  utils: {
+    book_new: jest.fn(() => ({ Sheets: {}, SheetNames: [] })),
+    aoa_to_sheet: jest.fn(() => ({ A1: { v: 'sheet' } })),
+    encode_cell: jest.fn(({ r, c }: { r: number; c: number }) => {
+      const column = String.fromCharCode(65 + c);
+      return `${column}${r + 1}`;
+    }),
+    book_append_sheet: jest.fn(),
+  },
+  write: jest.fn(() => new ArrayBuffer(8)),
+}));
+
+const mockJsZipFile = jest.fn();
+const mockJsZipGenerateAsync = jest.fn();
+const mockJsZipLoadAsync = jest.fn();
+
+jest.mock('jszip', () => ({
+  __esModule: true,
+  default: {
+    loadAsync: (...args: unknown[]) => mockJsZipLoadAsync(...args),
+  },
+}));
+
+jest.mock('../../utility/util', () => ({
+  Util: {
+    handleBlobDownloadAndSave: jest.fn(),
+  },
+}));
+
 jest.mock('../components/DataTableBody', () => {
   return function MockDataTableBody() {
     return <div data-testid="data-table-body">table</div>;
@@ -56,15 +88,24 @@ jest.mock('../components/DataTablePagination', () => {
 });
 
 type MockSearchAndFilterProps = {
+  searchTerm?: string;
+  onSearchChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onFilterClick?: () => void;
 };
 
 jest.mock('../components/SearchAndFilter', () => {
   return function MockSearchAndFilter({
+    searchTerm,
+    onSearchChange,
     onFilterClick,
   }: MockSearchAndFilterProps) {
     return (
       <div data-testid="search-filter">
+        <input
+          aria-label="Search schools"
+          value={searchTerm}
+          onChange={onSearchChange}
+        />
         <button type="button" onClick={onFilterClick}>
           filter
         </button>
@@ -131,7 +172,32 @@ beforeEach(() => {
     data: [],
     total: 0,
   });
+  mockRunBackgroundWorkerTask.mockResolvedValue({
+    fileBuffer: new ArrayBuffer(8),
+  } as Awaited<ReturnType<typeof runBackgroundWorkerTask>>);
+  mockJsZipFile.mockImplementation((path: string, content?: string) => {
+    if (typeof content !== 'undefined') return undefined;
+    return {
+      async: jest
+        .fn()
+        .mockResolvedValue(
+          '<worksheet><sheetViews><sheetView workbookViewId="0"/></sheetViews></worksheet>',
+        ),
+    };
+  });
+  mockJsZipGenerateAsync.mockResolvedValue(new ArrayBuffer(8));
+  mockJsZipLoadAsync.mockResolvedValue({
+    file: mockJsZipFile,
+    generateAsync: mockJsZipGenerateAsync,
+  });
 });
+
+const mockHandleBlobDownloadAndSave =
+  Util.handleBlobDownloadAndSave as jest.Mock;
+const mockRunBackgroundWorkerTask =
+  runBackgroundWorkerTask as jest.MockedFunction<
+    typeof runBackgroundWorkerTask
+  >;
 
 describe('SchoolList actions menu', () => {
   it('shows migrate, upload and add school actions for privileged users', async () => {
@@ -246,5 +312,228 @@ describe('SchoolList actions menu', () => {
         screen.queryByRole('menuitem', { name: 'Upload' }),
       ).not.toBeInTheDocument(),
     );
+  });
+});
+
+describe('SchoolList export', () => {
+  it('disables export when there are no schools in the table', async () => {
+    renderPage();
+
+    const exportButton = await screen.findByRole('button', { name: 'Export' });
+
+    await waitFor(() => expect(exportButton).toBeDisabled());
+  });
+
+  it('exports the filtered school metrics rows to an xlsx file', async () => {
+    const user = userEvent.setup();
+    mockApiHandler.getFilteredSchoolsForSchoolListing.mockResolvedValue({
+      data: [
+        {
+          school_id: 'school-1',
+          school_name: 'Alpha School',
+          school_performance: 'green',
+          state: 'Maharashtra',
+          district: 'Pune',
+          udise: '1234567890',
+          num_students: 120,
+          num_teachers: 8,
+          onboarded_students: 100,
+          activated_students: 80,
+          active_students: 60,
+          avg_time_spent: 45,
+          active_teachers: 6,
+          activities_assigned: 14,
+          avg_assignments_completed: 10,
+          avg_activities_completed: 8,
+          program_managers: ['Program Manager 1'],
+          field_coordinators: ['Field Coordinator 1'],
+        },
+      ],
+      total: 1,
+    });
+
+    renderPage();
+
+    const exportButton = await screen.findByRole('button', { name: 'Export' });
+    await waitFor(() => expect(exportButton).toBeEnabled());
+
+    await user.click(exportButton);
+
+    expect(
+      mockApiHandler.getFilteredSchoolsForSchoolListing,
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      mockApiHandler.getFilteredSchoolsForSchoolListing,
+    ).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        page: 1,
+        page_size: 500,
+        date_range: '7d',
+      }),
+    );
+    expect(mockRunBackgroundWorkerTask).toHaveBeenCalledWith(
+      'BUILD_XLSX_FILE',
+      {
+        sheetNames: ['Schools'],
+        sheets: {
+          Schools: [
+            [
+              'School Name',
+              'School Performance',
+              'Onboarded Students',
+              'Activated Students',
+              'Activated Students',
+              'Active Students',
+              'Active Students',
+              'Average Time Spent',
+              'Active Teachers',
+              'Active Teachers',
+              'Activities Assigned',
+              'Avg Assignments Completed',
+              'Avg Activities Completed',
+            ],
+            [
+              'Alpha School\n1234567890 - Pune',
+              'Performing Well',
+              '100',
+              '80',
+              '80%',
+              '60',
+              '75%',
+              '45m',
+              '6',
+              '100%',
+              '14',
+              '10',
+              '8',
+            ],
+          ],
+        },
+        sheetFormats: {
+          Schools: 'aoa',
+        },
+        sheetWrapColumns: {
+          Schools: [0],
+        },
+        sheetFreeze: {
+          Schools: {
+            xSplit: 1,
+            ySplit: 1,
+            topLeftCell: 'B2',
+            activePane: 'bottomRight',
+          },
+        },
+        sheetMerges: {
+          Schools: [
+            {
+              s: { r: 0, c: 3 },
+              e: { r: 0, c: 4 },
+            },
+            {
+              s: { r: 0, c: 5 },
+              e: { r: 0, c: 6 },
+            },
+            {
+              s: { r: 0, c: 8 },
+              e: { r: 0, c: 9 },
+            },
+          ],
+        },
+      },
+    );
+    expect(mockHandleBlobDownloadAndSave).toHaveBeenCalledWith(
+      expect.any(Blob),
+      'SchoolMetrics.xlsx',
+    );
+  });
+
+  it('keeps export disabled while the debounced search is still pending', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    mockApiHandler.getFilteredSchoolsForSchoolListing.mockResolvedValue({
+      data: [
+        {
+          school_id: 'school-1',
+          school_name: 'Alpha School',
+          school_performance: 'green',
+          district: 'Pune',
+          udise: '1234567890',
+          num_students: 120,
+          num_teachers: 8,
+          onboarded_students: 100,
+          activated_students: 80,
+          active_students: 60,
+          avg_time_spent: 45,
+          active_teachers: 6,
+          activities_assigned: 14,
+          avg_assignments_completed: 10,
+          avg_activities_completed: 8,
+          program_managers: ['Program Manager 1'],
+          field_coordinators: ['Field Coordinator 1'],
+        },
+      ],
+      total: 1,
+    });
+
+    renderPage();
+
+    const exportButton = await screen.findByRole('button', { name: 'Export' });
+    await waitFor(() => expect(exportButton).toBeEnabled());
+
+    await user.type(screen.getByLabelText('Search schools'), 'new');
+
+    expect(exportButton).toBeDisabled();
+
+    jest.advanceTimersByTime(500);
+
+    await waitFor(() => expect(exportButton).toBeEnabled());
+    jest.useRealTimers();
+  });
+
+  it('falls back to the main thread workbook builder when the worker fails', async () => {
+    const user = userEvent.setup();
+    mockRunBackgroundWorkerTask.mockRejectedValueOnce(
+      new Error('worker failed'),
+    );
+    mockApiHandler.getFilteredSchoolsForSchoolListing.mockResolvedValue({
+      data: [
+        {
+          school_id: 'school-1',
+          school_name: 'Alpha School',
+          school_performance: 'green',
+          district: 'Pune',
+          udise: '1234567890',
+          num_students: 120,
+          num_teachers: 8,
+          onboarded_students: 100,
+          activated_students: 80,
+          active_students: 60,
+          avg_time_spent: 45,
+          active_teachers: 6,
+          activities_assigned: 14,
+          avg_assignments_completed: 10,
+          avg_activities_completed: 8,
+          program_managers: ['Program Manager 1'],
+          field_coordinators: ['Field Coordinator 1'],
+        },
+      ],
+      total: 1,
+    });
+
+    renderPage();
+
+    const exportButton = await screen.findByRole('button', { name: 'Export' });
+    await waitFor(() => expect(exportButton).toBeEnabled());
+
+    await user.click(exportButton);
+
+    await waitFor(() =>
+      expect(mockHandleBlobDownloadAndSave).toHaveBeenCalledWith(
+        expect.any(Blob),
+        'SchoolMetrics.xlsx',
+      ),
+    );
+    expect(mockJsZipLoadAsync).toHaveBeenCalled();
   });
 });

--- a/src/ops-console/pages/SchoolList.tsx
+++ b/src/ops-console/pages/SchoolList.tsx
@@ -145,7 +145,7 @@ const SchoolList: React.FC = () => {
     [schools],
   );
   const isLoading = isFilterLoading || isDataLoading;
-  const columns = getSchoolListColumns();
+  const columns = useMemo(() => getSchoolListColumns(), []);
   const { isExporting, isExportDisabled, handleExportSchools } =
     useSchoolListExport({
       api,

--- a/src/ops-console/pages/SchoolList.tsx
+++ b/src/ops-console/pages/SchoolList.tsx
@@ -1,8 +1,13 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import React, {
+  useEffect,
+  useState,
+  useCallback,
+  useRef,
+  useMemo,
+} from 'react';
 import {
   Box,
   Button,
-  Chip,
   Divider,
   IconButton,
   ListItemIcon,
@@ -12,32 +17,36 @@ import {
   CircularProgress,
   Tab,
   Tabs,
-  Typography,
 } from '@mui/material';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { ServiceConfig } from '../../services/ServiceConfig';
 import { PAGES, PROGRAM_TAB } from '../../common/constants';
 import {
+  createEmptySchoolFilters,
   DEFAULT_DATE_RANGE,
   DATE_RANGE_OPTIONS,
   DEFAULT_PAGE_SIZE,
   filterConfigsForSchool,
-  INITIAL_FILTERS,
+  getSchoolListColumns,
+  hasSchoolListFilters,
+  mapSchoolListFilterOptions,
+  parseSchoolListJsonParam,
   tabOptions,
   type DateRangeValue,
   type Filters,
 } from './SchoolList.helpers';
-import { SchoolListRow, useSchoolListData } from './SchoolList.fetcher';
+import { useDebouncedValue, useSchoolListData } from './SchoolList.fetcher';
 import { mapSchoolRowsToRenderRows } from './SchoolListRowRenderer';
 import './SchoolList.css';
 import DataTablePagination from '../components/DataTablePagination';
-import DataTableBody, { Column } from '../components/DataTableBody';
+import DataTableBody from '../components/DataTableBody';
 import { t } from 'i18next';
 import SearchAndFilter from '../components/SearchAndFilter';
 import FilterSlider from '../components/FilterSlider';
 import SelectedFilters from '../components/SelectedFilters';
 import FileUpload from '../components/FileUpload';
 import SchoolListDateRangeDropdown from '../components/SchoolListDateRangeDropdown';
+import SchoolListExportButton from '../components/SchoolListExportButton';
 import { FileUploadOutlined, Add } from '@mui/icons-material';
 import { BsFillBellFill } from 'react-icons/bs';
 import { useLocation, useHistory } from 'react-router';
@@ -46,6 +55,7 @@ import { useAppSelector } from '../../redux/hooks';
 import { RootState } from '../../redux/store';
 import { AuthState } from '../../redux/slices/auth/authSlice';
 import logger from '../../utility/logger';
+import { useSchoolListExport } from './useSchoolListExport';
 
 const SchoolList: React.FC = () => {
   const api = ServiceConfig.getI().apiHandler;
@@ -54,13 +64,6 @@ const SchoolList: React.FC = () => {
   const history = useHistory();
   const qs = new URLSearchParams(location.search);
 
-  function parseJSONParam<T>(param: string | null, fallback: T): T {
-    try {
-      return param ? (JSON.parse(param) as T) : fallback;
-    } catch {
-      return fallback;
-    }
-  }
   const [selectedTab, setSelectedTab] = useState(() => {
     const v = qs.get('tab') || PROGRAM_TAB.ALL;
     return Object.values(PROGRAM_TAB).includes(v as PROGRAM_TAB)
@@ -69,7 +72,7 @@ const SchoolList: React.FC = () => {
   });
   const [searchTerm, setSearchTerm] = useState(() => qs.get('search') || '');
   const [filters, setFilters] = useState<Filters>(() =>
-    parseJSONParam(qs.get('filters'), INITIAL_FILTERS),
+    parseSchoolListJsonParam(qs.get('filters'), createEmptySchoolFilters()),
   );
   const [selectedDateRange, setSelectedDateRange] = useState<DateRangeValue>(
     () => {
@@ -88,11 +91,15 @@ const SchoolList: React.FC = () => {
 
   const [showUploadPage, setShowUploadPage] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
-  const [tempFilters, setTempFilters] = useState<Filters>(INITIAL_FILTERS);
-  const [filterOptions, setFilterOptions] = useState<Filters>(INITIAL_FILTERS);
+  const [tempFilters, setTempFilters] = useState<Filters>(() =>
+    createEmptySchoolFilters(),
+  );
+  const [filterOptions, setFilterOptions] = useState<Filters>(() =>
+    createEmptySchoolFilters(),
+  );
   const [orderBy, setOrderBy] = useState('');
   const [orderDir, setOrderDir] = useState<'asc' | 'desc'>('asc');
-  const [pageSize] = useState(DEFAULT_PAGE_SIZE);
+  const pageSize = DEFAULT_PAGE_SIZE;
   const [actionsAnchorEl, setActionsAnchorEl] = useState<null | HTMLElement>(
     null,
   );
@@ -100,14 +107,14 @@ const SchoolList: React.FC = () => {
     useState(false);
   const actionsButtonCloseShineTimeoutRef = useRef<number | null>(null);
   const actionsButtonCloseShineRafRef = useRef<number | null>(null);
-  const [openDetails, setOpenDetails] = useState(false);
-  const [visitId, setVisitId] = useState<string | null>(null);
   const isFirstSearchRenderRef = useRef(true);
   const { roles } = useAppSelector(
     (state: RootState) => state.auth as AuthState,
   );
   const userRoles = roles || [];
   const isExternalUser = userRoles.includes(RoleType.EXTERNAL_USER);
+  const debouncedSearchTerm = useDebouncedValue(searchTerm, 500);
+  const isSearchPending = searchTerm !== debouncedSearchTerm;
 
   const rolesWithAccess = [
     RoleType.SUPER_ADMIN,
@@ -130,11 +137,28 @@ const SchoolList: React.FC = () => {
     pageSize,
     orderBy,
     orderDir,
-    searchTerm,
+    searchTerm: debouncedSearchTerm,
     selectedDateRange,
   });
-  const renderedSchools = mapSchoolRowsToRenderRows(schools);
+  const renderedSchools = useMemo(
+    () => mapSchoolRowsToRenderRows(schools),
+    [schools],
+  );
   const isLoading = isFilterLoading || isDataLoading;
+  const columns = getSchoolListColumns();
+  const { isExporting, isExportDisabled, handleExportSchools } =
+    useSchoolListExport({
+      api,
+      filters,
+      selectedTab,
+      orderBy,
+      orderDir,
+      searchTerm: debouncedSearchTerm,
+      selectedDateRange,
+      total,
+      isLoading,
+      isSearchPending,
+    });
 
   useEffect(() => {
     setTempFilters(filters);
@@ -174,8 +198,9 @@ const SchoolList: React.FC = () => {
     const params = new URLSearchParams();
     if (selectedTab !== PROGRAM_TAB.ALL) params.set('tab', String(selectedTab));
     if (searchTerm) params.set('search', searchTerm);
-    if (Object.values(filters).some((arr) => arr.length))
+    if (hasSchoolListFilters(filters)) {
       params.set('filters', JSON.stringify(filters));
+    }
     if (selectedDateRange !== DEFAULT_DATE_RANGE)
       params.set('range', selectedDateRange);
     if (page !== 1) params.set('page', String(page));
@@ -196,16 +221,7 @@ const SchoolList: React.FC = () => {
       try {
         const data = await api.getSchoolFilterOptionsForSchoolListing();
         if (data) {
-          setFilterOptions({
-            programType: data.programType || [],
-            partner: data.partner || [],
-            programManager: data.programManager || [],
-            fieldCoordinator: data.fieldCoordinator || [],
-            state: data.state || [],
-            district: data.district || [],
-            block: data.block || [],
-            cluster: data.cluster || [],
-          });
+          setFilterOptions(mapSchoolListFilterOptions(data));
         }
       } catch (error) {
         logger.error('Failed to fetch filter options', error);
@@ -215,89 +231,7 @@ const SchoolList: React.FC = () => {
     };
 
     fetchFilterOptions();
-  }, []);
-
-  // Column widths are tuned for horizontal scrolling on smaller screens.
-  const columns: Column<SchoolListRow>[] = [
-    {
-      key: 'name',
-      label: t('School Name'),
-      width: '20%',
-      sortable: true,
-      orderBy: 'name',
-    },
-    {
-      key: 'schoolPerformance',
-      label: t('School Performance'),
-      width: '7.78%',
-      align: 'center',
-      sortable: false,
-    },
-    {
-      key: 'onboardedStudents',
-      label: t('Onboarded Students'),
-      width: '7.78%',
-      align: 'center',
-      sortable: false,
-      orderBy: 'onboarded_students',
-    },
-    {
-      key: 'activatedStudents',
-      label: t('Activated Students'),
-      width: '7.78%',
-      align: 'center',
-      sortable: false,
-      orderBy: 'activated_students',
-    },
-    {
-      key: 'activeStudents',
-      label: t('Active Students'),
-      width: '7.78%',
-      align: 'center',
-      sortable: false,
-      orderBy: 'active_students',
-    },
-    {
-      key: 'avgTimeSpent',
-      label: t('Average Time Spent'),
-      width: '7.78%',
-      align: 'center',
-      sortable: false,
-      orderBy: 'avg_time_spent',
-    },
-    {
-      key: 'activeTeachers',
-      label: t('Active Teachers'),
-      width: '7.78%',
-      align: 'center',
-      sortable: false,
-      orderBy: 'active_teachers',
-    },
-    {
-      key: 'activitiesAssigned',
-      label: t('Activities Assigned'),
-      width: '7.78%',
-      align: 'center',
-      sortable: false,
-      orderBy: 'activities_assigned',
-    },
-    {
-      key: 'avgAssignmentsCompleted',
-      label: t('Avg Assignments Completed'),
-      width: '7.78%',
-      align: 'center',
-      sortable: false,
-      orderBy: 'avg_assignments_completed',
-    },
-    {
-      key: 'avgActivitiesCompleted',
-      label: t('Avg Activities Completed'),
-      width: '7.78%',
-      align: 'center',
-      sortable: false,
-      orderBy: 'avg_activities_completed',
-    },
-  ];
+  }, [api]);
 
   const handleSort = (colKey: string) => {
     const sortableKeys = ['name'];
@@ -311,42 +245,44 @@ const SchoolList: React.FC = () => {
     setPage(1);
   };
 
-  function onCancleClick(): void {
+  const handleCloseUploadPage = useCallback((): void => {
     setShowUploadPage(false);
-  }
+  }, []);
 
-  const handleOpenActionsMenu = (
-    event: React.MouseEvent<HTMLButtonElement>,
-  ) => {
-    setActionsAnchorEl(event.currentTarget);
-  };
+  const handleOpenActionsMenu = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      setActionsAnchorEl(event.currentTarget);
+    },
+    [],
+  );
 
-  const handleCloseActionsMenu = () => {
+  const handleCloseActionsMenu = useCallback(() => {
     setActionsAnchorEl(null);
     triggerActionsButtonCloseShine();
-  };
+  }, [triggerActionsButtonCloseShine]);
 
-  const handleSelectDateRange = (nextRange: DateRangeValue) => {
+  const handleSelectDateRange = useCallback((nextRange: DateRangeValue) => {
     setSelectedDateRange(nextRange);
     setPage(1);
-  };
+  }, []);
 
-  const handleOpenUploadPage = () => {
+  const handleOpenUploadPage = useCallback(() => {
     setShowUploadPage(true);
-  };
+  }, []);
 
-  const handleOpenAddSchoolPage = () => {
+  const handleOpenAddSchoolPage = useCallback(() => {
     history.push({
       pathname: `${PAGES.SIDEBAR_PAGE}${PAGES.SCHOOL_LIST}${PAGES.ADD_SCHOOL_PAGE}`,
     });
-  };
+  }, [history]);
 
-  const handleOpenMigratePage = () => {
+  const handleOpenMigratePage = useCallback(() => {
     history.push(
       `${PAGES.SIDEBAR_PAGE}${PAGES.SCHOOL_LIST}${PAGES.MIGRATE_SCHOOLS_PAGE}`,
     );
-  };
+  }, [history]);
 
+  // Centralized action metadata keeps the menu rendering compact and predictable.
   const actionItems = !isExternalUser
     ? [
         ...(haveAccess
@@ -418,32 +354,26 @@ const SchoolList: React.FC = () => {
     return nodes;
   });
 
-  const handleCancelFilters = () => {
-    const reset = {
-      partner: [],
-      programManager: [],
-      fieldCoordinator: [],
-      programType: [],
-      state: [],
-      district: [],
-      block: [],
-      cluster: [],
-    };
+  const handleCancelFilters = useCallback(() => {
+    const reset = createEmptySchoolFilters();
     setTempFilters(reset);
     setFilters(reset);
     setSelectedDateRange(DEFAULT_DATE_RANGE);
     setIsFilterOpen(false);
     setPage(1);
-  };
+  }, []);
 
-  const pageCount = Math.ceil(total / pageSize);
+  const pageCount = useMemo(
+    () => Math.ceil(total / pageSize),
+    [pageSize, total],
+  );
 
   if (showUploadPage) {
     return (
       <div>
         <div className="school-list-upload-text">{t('Upload File')}</div>
         <div>
-          <FileUpload onCancleClick={onCancleClick} />
+          <FileUpload onCancleClick={handleCloseUploadPage} />
         </div>
       </div>
     );
@@ -484,10 +414,6 @@ const SchoolList: React.FC = () => {
             </div>
 
             <div className="school-list-button-and-search-filter">
-              <SchoolListDateRangeDropdown
-                value={selectedDateRange}
-                onChange={handleSelectDateRange}
-              />
               <div className="school-list-search-control">
                 <SearchAndFilter
                   searchTerm={searchTerm}
@@ -498,6 +424,19 @@ const SchoolList: React.FC = () => {
                   filters={filters}
                   onFilterClick={() => setIsFilterOpen(true)}
                   onClearFilters={handleCancelFilters}
+                />
+              </div>
+              <div className="school-list-date-range-control">
+                <SchoolListDateRangeDropdown
+                  value={selectedDateRange}
+                  onChange={handleSelectDateRange}
+                />
+              </div>
+              <div className="school-list-export-control">
+                <SchoolListExportButton
+                  disabled={isExportDisabled}
+                  isExporting={isExporting}
+                  onClick={handleExportSchools}
                 />
               </div>
               <div className="school-list-actions-group">
@@ -579,15 +518,7 @@ const SchoolList: React.FC = () => {
               setPage(1);
             }}
             onCancel={() => {
-              const empty = {
-                state: [],
-                district: [],
-                block: [],
-                programType: [],
-                partner: [],
-                programManager: [],
-                fieldCoordinator: [],
-              };
+              const empty = createEmptySchoolFilters();
               setTempFilters(empty);
               setFilters(empty);
               setIsFilterOpen(false);

--- a/src/ops-console/pages/SchoolListRowRenderer.tsx
+++ b/src/ops-console/pages/SchoolListRowRenderer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box, Chip, Typography } from '@mui/material';
 import { t } from 'i18next';
 import {
-  buildSchoolSubtitle,
+  buildSchoolUdiseLocationLabel,
   getSchoolCoordinatorList,
   getStatusMeta,
   resolvePerformanceStatus,
@@ -39,6 +39,8 @@ export const mapSchoolRowsToRenderRows = (
     const completionActivities = pickFirstNumber(
       school.avg_activities_completed,
     );
+    const udiseLocation = buildSchoolUdiseLocationLabel(school);
+    const performanceStatus = resolvePerformanceStatus(school);
 
     return {
       ...school,
@@ -48,27 +50,51 @@ export const mapSchoolRowsToRenderRows = (
         String(t('not assigned yet')),
       name: {
         value: school.school_name,
+        text: udiseLocation
+          ? `${school.school_name}\n${udiseLocation}`
+          : school.school_name,
+        exportValueText: school.school_name,
+        exportPercentText: '',
         render: (
           <Box display="flex" flexDirection="column" alignItems="flex-start">
             <Typography variant="subtitle2">{school.school_name}</Typography>
-            <Typography
-              variant="subtitle2"
-              color="text.secondary"
-              fontSize={'12px'}
-            >
-              {buildSchoolSubtitle(school)}
-            </Typography>
+            {udiseLocation && (
+              <Typography
+                variant="subtitle2"
+                color="text.secondary"
+                fontSize={'12px'}
+              >
+                {udiseLocation}
+              </Typography>
+            )}
           </Box>
         ),
       },
+      udiseLocation: {
+        value: udiseLocation,
+        text: udiseLocation || '--',
+        exportValueText: udiseLocation || '--',
+        exportPercentText: '',
+        render: (
+          <Typography
+            variant="subtitle2"
+            color="text.secondary"
+            fontSize={'12px'}
+          >
+            {udiseLocation || '--'}
+          </Typography>
+        ),
+      },
       schoolPerformance: (() => {
-        const status = resolvePerformanceStatus(school);
-        const meta = getStatusMeta(status);
+        const meta = getStatusMeta(performanceStatus);
         return {
-          value: status || '--',
+          value: performanceStatus || '--',
+          text: performanceStatus || '--',
+          exportValueText: performanceStatus || '--',
+          exportPercentText: '',
           render: (
             <Chip
-              label={status ? t(status) : '--'}
+              label={performanceStatus ? t(performanceStatus) : '--'}
               size="small"
               sx={{
                 backgroundColor: `${meta.bg} !important`,

--- a/src/ops-console/pages/useSchoolListExport.ts
+++ b/src/ops-console/pages/useSchoolListExport.ts
@@ -7,38 +7,25 @@ import logger from '../../utility/logger';
 import { runBackgroundWorkerTask } from '../../workers/backgroundWorkerClient';
 import {
   fetchSchoolListPage,
-  type SchoolListRow,
   type SchoolListSourceRow,
 } from './SchoolList.fetcher';
+import { type DateRangeValue, type Filters } from './SchoolList.helpers';
+import { buildSchoolListExportSheetRows } from './SchoolList.export';
 import {
-  getSchoolListExportColumns,
-  type DateRangeValue,
-  type Filters,
-} from './SchoolList.helpers';
-import {
-  isSchoolMetricCell,
-  mapSchoolRowsToRenderRows,
-} from './SchoolListRowRenderer';
+  applyFreezePanesToWorkbook,
+  type FreezePaneConfig,
+  XLSX_EXPORT_BORDER_COLOR,
+  XLSX_EXPORT_FONT_NAME,
+  XLSX_EXPORT_FONT_SIZE,
+} from '../../utility/xlsxExportUtils';
 
 const EXPORT_SHEET_NAME = 'Schools';
 const EXPORT_FILE_NAME = 'SchoolMetrics.xlsx';
-const EXPORT_BORDER_COLOR = 'D0D7DE';
 const EXPORT_PAGE_SIZE = 500;
-const EXPORT_FONT_NAME = 'Inter';
-const EXPORT_FONT_SIZE = 10;
 type XlsxModule = typeof XLSXModule;
 type XlsxWorkSheet = XLSXModule.WorkSheet;
 
 let xlsxModulePromise: Promise<XlsxModule> | null = null;
-
-type FreezePaneConfig = {
-  xSplit: number;
-  ySplit: number;
-  topLeftCell: string;
-  activePane: 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
-  activeCell?: string;
-  sqref?: string;
-};
 
 type UseSchoolListExportParams = {
   api: ServiceApi;
@@ -63,68 +50,6 @@ const getXlsx = async (): Promise<XlsxModule> => {
     xlsxModulePromise = import('xlsx-js-style');
   }
   return xlsxModulePromise;
-};
-
-const getExportCellText = (cellValue: unknown) => {
-  if (isSchoolMetricCell(cellValue)) {
-    return cellValue.text.trim().length > 0 ? cellValue.text : '--';
-  }
-
-  if (cellValue === null || cellValue === undefined || cellValue === '') {
-    return '--';
-  }
-
-  return String(cellValue);
-};
-
-// Converts row cells into the exact export-friendly value or paired % cell text.
-const getExportCellPartText = (
-  row: SchoolListRow,
-  key: keyof SchoolListRow,
-  part: 'value' | 'percent',
-) => {
-  if (key === 'name' && part === 'value') {
-    const schoolName =
-      row.name.exportValueText?.trim().length &&
-      row.name.exportValueText !== '--'
-        ? row.name.exportValueText
-        : getExportCellText(row.name);
-    const udiseLocation = getExportCellText(row.udiseLocation);
-    return udiseLocation === '--'
-      ? schoolName
-      : `${schoolName}\n${udiseLocation}`;
-  }
-
-  const cellValue = row[key];
-
-  if (isSchoolMetricCell(cellValue)) {
-    if (part === 'percent') {
-      return cellValue.exportPercentText?.trim().length
-        ? cellValue.exportPercentText
-        : '--';
-    }
-
-    return cellValue.exportValueText?.trim().length
-      ? cellValue.exportValueText
-      : cellValue.text.trim().length > 0
-        ? cellValue.text
-        : '--';
-  }
-
-  if (part === 'percent') return '--';
-  return getExportCellText(cellValue);
-};
-
-const buildExportSheetRows = (rows: SchoolListRow[]) => {
-  const exportColumns = getSchoolListExportColumns();
-  return [
-    exportColumns.map((column) => column.label),
-    ...rows.map((row) =>
-      exportColumns.map((column) =>
-        getExportCellPartText(row, column.key, column.part),
-      ),
-    ),
-  ];
 };
 
 // Adjacent duplicate headers are merged so value and % columns stay grouped.
@@ -204,14 +129,14 @@ const applyCellBorders = (
         ...cell.s,
         font: {
           ...(cell.s?.font ?? {}),
-          name: EXPORT_FONT_NAME,
-          sz: EXPORT_FONT_SIZE,
+          name: XLSX_EXPORT_FONT_NAME,
+          sz: XLSX_EXPORT_FONT_SIZE,
         },
         border: {
-          top: { style: 'thin', color: { rgb: EXPORT_BORDER_COLOR } },
-          bottom: { style: 'thin', color: { rgb: EXPORT_BORDER_COLOR } },
-          left: { style: 'thin', color: { rgb: EXPORT_BORDER_COLOR } },
-          right: { style: 'thin', color: { rgb: EXPORT_BORDER_COLOR } },
+          top: { style: 'thin', color: { rgb: XLSX_EXPORT_BORDER_COLOR } },
+          bottom: { style: 'thin', color: { rgb: XLSX_EXPORT_BORDER_COLOR } },
+          left: { style: 'thin', color: { rgb: XLSX_EXPORT_BORDER_COLOR } },
+          right: { style: 'thin', color: { rgb: XLSX_EXPORT_BORDER_COLOR } },
         },
       };
     }
@@ -232,8 +157,8 @@ const applyHeaderRowFormatting = (
       ...cell.s,
       font: {
         ...(cell.s?.font ?? {}),
-        name: EXPORT_FONT_NAME,
-        sz: EXPORT_FONT_SIZE,
+        name: XLSX_EXPORT_FONT_NAME,
+        sz: XLSX_EXPORT_FONT_SIZE,
         bold: true,
         color: { rgb: 'FFFFFF' },
       },
@@ -317,47 +242,17 @@ const applyMergedHeaderFormatting = (
   });
 };
 
-// Main-thread fallback still patches freeze panes so Excel opens in the right view.
-const applyFreezePanesToWorkbook = async (
-  fileBuffer: ArrayBuffer,
-  freeze: FreezePaneConfig,
-) => {
-  const { default: JSZip } = await import('jszip');
-  const zip = await JSZip.loadAsync(fileBuffer);
-  const worksheetPath = 'xl/worksheets/sheet1.xml';
-  const worksheetFile = zip.file(worksheetPath);
-  if (!worksheetFile) return fileBuffer;
-
-  const paneXml = `<pane xSplit="${freeze.xSplit}" ySplit="${freeze.ySplit}" topLeftCell="${freeze.topLeftCell}" activePane="${freeze.activePane}" state="frozen"/>`;
-  const selectionXml = `<selection pane="${freeze.activePane}" activeCell="${freeze.activeCell ?? freeze.topLeftCell}" sqref="${freeze.sqref ?? freeze.topLeftCell}"/>`;
-
-  const worksheetXml = await worksheetFile.async('string');
-  const updatedWorksheetXml = worksheetXml.replace(
-    /<sheetViews>([\s\S]*?)<\/sheetViews>/,
-    (sheetViewsXml) => {
-      if (/<sheetView([^>]*)\/>/.test(sheetViewsXml)) {
-        return sheetViewsXml.replace(
-          /<sheetView([^>]*)\/>/,
-          `<sheetView$1>${paneXml}${selectionXml}</sheetView>`,
-        );
-      }
-
-      const withoutPane = sheetViewsXml.replace(/<pane[^>]*\/>/, '');
-      const withoutSelection = withoutPane.replace(/<selection[^>]*\/>/g, '');
-      return withoutSelection.replace(
-        /<sheetView([^>]*)>/,
-        `<sheetView$1>${paneXml}${selectionXml}`,
-      );
-    },
-  );
-
-  zip.file(worksheetPath, updatedWorksheetXml);
-  return zip.generateAsync({ type: 'arraybuffer' });
-};
-
 const buildExportWorkbook = async (sheetRows: string[][]) => {
   const headers = sheetRows[0] ?? [];
   const headerMerges = buildHeaderMerges(headers);
+  const sheetFreeze = {
+    [EXPORT_SHEET_NAME]: {
+      xSplit: 1,
+      ySplit: 1,
+      topLeftCell: 'B2',
+      activePane: 'bottomRight',
+    } satisfies FreezePaneConfig,
+  };
 
   try {
     const builtWorkbook = await runBackgroundWorkerTask('BUILD_XLSX_FILE', {
@@ -371,14 +266,7 @@ const buildExportWorkbook = async (sheetRows: string[][]) => {
       sheetWrapColumns: {
         [EXPORT_SHEET_NAME]: [0],
       },
-      sheetFreeze: {
-        [EXPORT_SHEET_NAME]: {
-          xSplit: 1,
-          ySplit: 1,
-          topLeftCell: 'B2',
-          activePane: 'bottomRight',
-        },
-      },
+      sheetFreeze,
       sheetMerges: {
         [EXPORT_SHEET_NAME]: headerMerges,
       },
@@ -403,12 +291,7 @@ const buildExportWorkbook = async (sheetRows: string[][]) => {
       bookType: 'xlsx',
       type: 'array',
     }) as ArrayBuffer;
-    return applyFreezePanesToWorkbook(output, {
-      xSplit: 1,
-      ySplit: 1,
-      topLeftCell: 'B2',
-      activePane: 'bottomRight',
-    });
+    return applyFreezePanesToWorkbook(output, [EXPORT_SHEET_NAME], sheetFreeze);
   }
 };
 
@@ -487,9 +370,7 @@ export const useSchoolListExport = ({
         searchTerm,
         selectedDateRange,
       });
-      const exportSheetRows = buildExportSheetRows(
-        mapSchoolRowsToRenderRows(exportSchools),
-      );
+      const exportSheetRows = buildSchoolListExportSheetRows(exportSchools);
       const output = await buildExportWorkbook(exportSheetRows);
 
       const blob = new Blob([output], {

--- a/src/ops-console/pages/useSchoolListExport.ts
+++ b/src/ops-console/pages/useSchoolListExport.ts
@@ -1,0 +1,524 @@
+import { useCallback, useState } from 'react';
+import type * as XLSXModule from 'xlsx-js-style';
+import { PROGRAM_TAB } from '../../common/constants';
+import type { ServiceApi } from '../../services/api/ServiceApi';
+import { Util } from '../../utility/util';
+import logger from '../../utility/logger';
+import { runBackgroundWorkerTask } from '../../workers/backgroundWorkerClient';
+import {
+  fetchSchoolListPage,
+  type SchoolListRow,
+  type SchoolListSourceRow,
+} from './SchoolList.fetcher';
+import {
+  getSchoolListExportColumns,
+  type DateRangeValue,
+  type Filters,
+} from './SchoolList.helpers';
+import {
+  isSchoolMetricCell,
+  mapSchoolRowsToRenderRows,
+} from './SchoolListRowRenderer';
+
+const EXPORT_SHEET_NAME = 'Schools';
+const EXPORT_FILE_NAME = 'SchoolMetrics.xlsx';
+const EXPORT_BORDER_COLOR = 'D0D7DE';
+const EXPORT_PAGE_SIZE = 500;
+const EXPORT_FONT_NAME = 'Inter';
+const EXPORT_FONT_SIZE = 10;
+type XlsxModule = typeof XLSXModule;
+type XlsxWorkSheet = XLSXModule.WorkSheet;
+
+let xlsxModulePromise: Promise<XlsxModule> | null = null;
+
+type FreezePaneConfig = {
+  xSplit: number;
+  ySplit: number;
+  topLeftCell: string;
+  activePane: 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
+  activeCell?: string;
+  sqref?: string;
+};
+
+type UseSchoolListExportParams = {
+  api: ServiceApi;
+  filters: Filters;
+  selectedTab: PROGRAM_TAB;
+  orderBy: string;
+  orderDir: 'asc' | 'desc';
+  searchTerm: string;
+  selectedDateRange: DateRangeValue;
+  total: number;
+  isLoading: boolean;
+  isSearchPending: boolean;
+};
+
+type FetchAllSchoolsForExportParams = Omit<
+  UseSchoolListExportParams,
+  'total' | 'isLoading' | 'isSearchPending'
+>;
+
+const getXlsx = async (): Promise<XlsxModule> => {
+  if (!xlsxModulePromise) {
+    xlsxModulePromise = import('xlsx-js-style');
+  }
+  return xlsxModulePromise;
+};
+
+const getExportCellText = (cellValue: unknown) => {
+  if (isSchoolMetricCell(cellValue)) {
+    return cellValue.text.trim().length > 0 ? cellValue.text : '--';
+  }
+
+  if (cellValue === null || cellValue === undefined || cellValue === '') {
+    return '--';
+  }
+
+  return String(cellValue);
+};
+
+// Converts row cells into the exact export-friendly value or paired % cell text.
+const getExportCellPartText = (
+  row: SchoolListRow,
+  key: keyof SchoolListRow,
+  part: 'value' | 'percent',
+) => {
+  if (key === 'name' && part === 'value') {
+    const schoolName =
+      row.name.exportValueText?.trim().length &&
+      row.name.exportValueText !== '--'
+        ? row.name.exportValueText
+        : getExportCellText(row.name);
+    const udiseLocation = getExportCellText(row.udiseLocation);
+    return udiseLocation === '--'
+      ? schoolName
+      : `${schoolName}\n${udiseLocation}`;
+  }
+
+  const cellValue = row[key];
+
+  if (isSchoolMetricCell(cellValue)) {
+    if (part === 'percent') {
+      return cellValue.exportPercentText?.trim().length
+        ? cellValue.exportPercentText
+        : '--';
+    }
+
+    return cellValue.exportValueText?.trim().length
+      ? cellValue.exportValueText
+      : cellValue.text.trim().length > 0
+        ? cellValue.text
+        : '--';
+  }
+
+  if (part === 'percent') return '--';
+  return getExportCellText(cellValue);
+};
+
+const buildExportSheetRows = (rows: SchoolListRow[]) => {
+  const exportColumns = getSchoolListExportColumns();
+  return [
+    exportColumns.map((column) => column.label),
+    ...rows.map((row) =>
+      exportColumns.map((column) =>
+        getExportCellPartText(row, column.key, column.part),
+      ),
+    ),
+  ];
+};
+
+// Adjacent duplicate headers are merged so value and % columns stay grouped.
+const buildHeaderMerges = (headers: string[]) => {
+  const merges: Array<{
+    s: { r: number; c: number };
+    e: { r: number; c: number };
+  }> = [];
+
+  let startIndex = 0;
+  while (startIndex < headers.length) {
+    let endIndex = startIndex;
+    while (
+      endIndex + 1 < headers.length &&
+      headers[endIndex + 1] === headers[startIndex]
+    ) {
+      endIndex += 1;
+    }
+
+    if (endIndex > startIndex) {
+      merges.push({
+        s: { r: 0, c: startIndex },
+        e: { r: 0, c: endIndex },
+      });
+    }
+
+    startIndex = endIndex + 1;
+  }
+
+  return merges;
+};
+
+// Wrapped first-column rows preserve the stacked school name and location.
+const applyWrappedSheetFormatting = (
+  xlsx: XlsxModule,
+  worksheet: XlsxWorkSheet,
+  wrappedColumns: number[],
+  rowCount: number,
+) => {
+  wrappedColumns.forEach((columnIndex) => {
+    for (let rowIndex = 1; rowIndex < rowCount; rowIndex += 1) {
+      const cellRef = xlsx.utils.encode_cell({
+        r: rowIndex,
+        c: columnIndex,
+      });
+      const cell = worksheet[cellRef];
+      if (!cell) continue;
+      cell.s = {
+        ...cell.s,
+        alignment: {
+          ...(cell.s?.alignment ?? {}),
+          wrapText: true,
+          vertical: 'top',
+        },
+      };
+    }
+  });
+
+  worksheet['!rows'] = Array.from({ length: rowCount }, (_, rowIndex) =>
+    rowIndex === 0 ? {} : { hpt: 30 },
+  );
+};
+
+// Borders and font are applied to every populated cell in the sheet.
+const applyCellBorders = (
+  xlsx: XlsxModule,
+  worksheet: XlsxWorkSheet,
+  rowCount: number,
+  columnCount: number,
+) => {
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex += 1) {
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex += 1) {
+      const cellRef = xlsx.utils.encode_cell({ r: rowIndex, c: columnIndex });
+      const cell = worksheet[cellRef];
+      if (!cell) continue;
+      cell.s = {
+        ...cell.s,
+        font: {
+          ...(cell.s?.font ?? {}),
+          name: EXPORT_FONT_NAME,
+          sz: EXPORT_FONT_SIZE,
+        },
+        border: {
+          top: { style: 'thin', color: { rgb: EXPORT_BORDER_COLOR } },
+          bottom: { style: 'thin', color: { rgb: EXPORT_BORDER_COLOR } },
+          left: { style: 'thin', color: { rgb: EXPORT_BORDER_COLOR } },
+          right: { style: 'thin', color: { rgb: EXPORT_BORDER_COLOR } },
+        },
+      };
+    }
+  }
+};
+
+// Header styling matches the worker-generated sheet so both paths stay aligned.
+const applyHeaderRowFormatting = (
+  xlsx: XlsxModule,
+  worksheet: XlsxWorkSheet,
+  headerCount: number,
+) => {
+  for (let columnIndex = 0; columnIndex < headerCount; columnIndex += 1) {
+    const cellRef = xlsx.utils.encode_cell({ r: 0, c: columnIndex });
+    const cell = worksheet[cellRef];
+    if (!cell) continue;
+    cell.s = {
+      ...cell.s,
+      font: {
+        ...(cell.s?.font ?? {}),
+        name: EXPORT_FONT_NAME,
+        sz: EXPORT_FONT_SIZE,
+        bold: true,
+        color: { rgb: 'FFFFFF' },
+      },
+      fill: {
+        patternType: 'solid',
+        fgColor: { rgb: '1976D2' },
+        bgColor: { rgb: '1976D2' },
+      },
+      alignment: {
+        ...(cell.s?.alignment ?? {}),
+        vertical: 'center',
+      },
+    };
+  }
+};
+
+// Widths are based on headers, with a wider first column for wrapped school labels.
+const applyHeaderColumnWidths = (
+  worksheet: XlsxWorkSheet,
+  sheetRows: string[][],
+  headers: string[],
+  merges: Array<{
+    s: { r: number; c: number };
+    e: { r: number; c: number };
+  }>,
+) => {
+  const mergeWidths = new Map<number, number>();
+
+  merges.forEach((merge) => {
+    const span = merge.e.c - merge.s.c + 1;
+    const headerText = headers[merge.s.c] ?? '';
+    const widthPerColumn = Math.max(
+      12,
+      Math.ceil(headerText.length / span) + 2,
+    );
+    for (
+      let columnIndex = merge.s.c;
+      columnIndex <= merge.e.c;
+      columnIndex += 1
+    ) {
+      mergeWidths.set(columnIndex, widthPerColumn);
+    }
+  });
+
+  const firstColumnWidth = sheetRows.reduce((maxWidth, row) => {
+    const cellText = String(row[0] ?? '');
+    const longestLineLength = cellText
+      .split('\n')
+      .reduce((maxLineLength, line) => Math.max(maxLineLength, line.length), 0);
+    return Math.max(maxWidth, longestLineLength);
+  }, headers[0]?.length ?? 0);
+
+  worksheet['!cols'] = headers.map((header, columnIndex) => ({
+    wch:
+      columnIndex === 0
+        ? Math.max(20, firstColumnWidth + 4)
+        : (mergeWidths.get(columnIndex) ?? Math.max(12, header.length + 2)),
+  }));
+};
+
+const applyMergedHeaderFormatting = (
+  xlsx: XlsxModule,
+  worksheet: XlsxWorkSheet,
+  merges: Array<{
+    s: { r: number; c: number };
+    e: { r: number; c: number };
+  }>,
+) => {
+  merges.forEach((merge) => {
+    const cellRef = xlsx.utils.encode_cell(merge.s);
+    const cell = worksheet[cellRef];
+    if (!cell) return;
+    cell.s = {
+      ...cell.s,
+      alignment: {
+        ...(cell.s?.alignment ?? {}),
+        horizontal: 'center',
+        vertical: 'center',
+      },
+    };
+  });
+};
+
+// Main-thread fallback still patches freeze panes so Excel opens in the right view.
+const applyFreezePanesToWorkbook = async (
+  fileBuffer: ArrayBuffer,
+  freeze: FreezePaneConfig,
+) => {
+  const { default: JSZip } = await import('jszip');
+  const zip = await JSZip.loadAsync(fileBuffer);
+  const worksheetPath = 'xl/worksheets/sheet1.xml';
+  const worksheetFile = zip.file(worksheetPath);
+  if (!worksheetFile) return fileBuffer;
+
+  const paneXml = `<pane xSplit="${freeze.xSplit}" ySplit="${freeze.ySplit}" topLeftCell="${freeze.topLeftCell}" activePane="${freeze.activePane}" state="frozen"/>`;
+  const selectionXml = `<selection pane="${freeze.activePane}" activeCell="${freeze.activeCell ?? freeze.topLeftCell}" sqref="${freeze.sqref ?? freeze.topLeftCell}"/>`;
+
+  const worksheetXml = await worksheetFile.async('string');
+  const updatedWorksheetXml = worksheetXml.replace(
+    /<sheetViews>([\s\S]*?)<\/sheetViews>/,
+    (sheetViewsXml) => {
+      if (/<sheetView([^>]*)\/>/.test(sheetViewsXml)) {
+        return sheetViewsXml.replace(
+          /<sheetView([^>]*)\/>/,
+          `<sheetView$1>${paneXml}${selectionXml}</sheetView>`,
+        );
+      }
+
+      const withoutPane = sheetViewsXml.replace(/<pane[^>]*\/>/, '');
+      const withoutSelection = withoutPane.replace(/<selection[^>]*\/>/g, '');
+      return withoutSelection.replace(
+        /<sheetView([^>]*)>/,
+        `<sheetView$1>${paneXml}${selectionXml}`,
+      );
+    },
+  );
+
+  zip.file(worksheetPath, updatedWorksheetXml);
+  return zip.generateAsync({ type: 'arraybuffer' });
+};
+
+const buildExportWorkbook = async (sheetRows: string[][]) => {
+  const headers = sheetRows[0] ?? [];
+  const headerMerges = buildHeaderMerges(headers);
+
+  try {
+    const builtWorkbook = await runBackgroundWorkerTask('BUILD_XLSX_FILE', {
+      sheetNames: [EXPORT_SHEET_NAME],
+      sheets: {
+        [EXPORT_SHEET_NAME]: sheetRows,
+      },
+      sheetFormats: {
+        [EXPORT_SHEET_NAME]: 'aoa',
+      },
+      sheetWrapColumns: {
+        [EXPORT_SHEET_NAME]: [0],
+      },
+      sheetFreeze: {
+        [EXPORT_SHEET_NAME]: {
+          xSplit: 1,
+          ySplit: 1,
+          topLeftCell: 'B2',
+          activePane: 'bottomRight',
+        },
+      },
+      sheetMerges: {
+        [EXPORT_SHEET_NAME]: headerMerges,
+      },
+    });
+    return builtWorkbook.fileBuffer;
+  } catch (workerError) {
+    logger.warn(
+      'School metrics export worker failed, falling back to main thread workbook generation.',
+      workerError,
+    );
+    const XLSX = await getXlsx();
+    const workbook = XLSX.utils.book_new();
+    const worksheet = XLSX.utils.aoa_to_sheet(sheetRows);
+    applyCellBorders(XLSX, worksheet, sheetRows.length, headers.length);
+    applyHeaderRowFormatting(XLSX, worksheet, headers.length);
+    applyHeaderColumnWidths(worksheet, sheetRows, headers, headerMerges);
+    applyWrappedSheetFormatting(XLSX, worksheet, [0], sheetRows.length);
+    worksheet['!merges'] = headerMerges;
+    applyMergedHeaderFormatting(XLSX, worksheet, headerMerges);
+    XLSX.utils.book_append_sheet(workbook, worksheet, EXPORT_SHEET_NAME);
+    const output = XLSX.write(workbook, {
+      bookType: 'xlsx',
+      type: 'array',
+    }) as ArrayBuffer;
+    return applyFreezePanesToWorkbook(output, {
+      xSplit: 1,
+      ySplit: 1,
+      topLeftCell: 'B2',
+      activePane: 'bottomRight',
+    });
+  }
+};
+
+const fetchAllSchoolsForExport = async ({
+  api,
+  filters,
+  selectedTab,
+  orderBy,
+  orderDir,
+  searchTerm,
+  selectedDateRange,
+}: FetchAllSchoolsForExportParams) => {
+  const allSchools: SchoolListSourceRow[] = [];
+  let currentPage = 1;
+  let exportTotal = 0;
+
+  while (currentPage === 1 || allSchools.length < exportTotal) {
+    const response = await fetchSchoolListPage({
+      api,
+      filters,
+      selectedTab,
+      page: currentPage,
+      pageSize: EXPORT_PAGE_SIZE,
+      orderBy,
+      orderDir,
+      searchTerm,
+      selectedDateRange,
+    });
+
+    const pageRows = (response?.data || []) as SchoolListSourceRow[];
+    exportTotal = response?.total ?? pageRows.length;
+    allSchools.push(...pageRows);
+
+    if (
+      pageRows.length === 0 ||
+      pageRows.length < EXPORT_PAGE_SIZE ||
+      allSchools.length >= exportTotal
+    ) {
+      break;
+    }
+
+    currentPage += 1;
+  }
+
+  return allSchools;
+};
+
+export const useSchoolListExport = ({
+  api,
+  filters,
+  selectedTab,
+  orderBy,
+  orderDir,
+  searchTerm,
+  selectedDateRange,
+  total,
+  isLoading,
+  isSearchPending,
+}: UseSchoolListExportParams) => {
+  const [isExporting, setIsExporting] = useState(false);
+  const isExportDisabled =
+    isLoading || isSearchPending || isExporting || total === 0;
+
+  // Export always respects the same filters, search, sort, and date range as the UI.
+  const handleExportSchools = useCallback(async () => {
+    if (isLoading || isSearchPending || isExporting || total === 0) return;
+
+    setIsExporting(true);
+    try {
+      const exportSchools = await fetchAllSchoolsForExport({
+        api,
+        filters,
+        selectedTab,
+        orderBy,
+        orderDir,
+        searchTerm,
+        selectedDateRange,
+      });
+      const exportSheetRows = buildExportSheetRows(
+        mapSchoolRowsToRenderRows(exportSchools),
+      );
+      const output = await buildExportWorkbook(exportSheetRows);
+
+      const blob = new Blob([output], {
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      });
+
+      await Util.handleBlobDownloadAndSave(blob, EXPORT_FILE_NAME);
+    } catch (error) {
+      logger.error('Failed to export school listing', error);
+    } finally {
+      setIsExporting(false);
+    }
+  }, [
+    api,
+    filters,
+    isExporting,
+    isLoading,
+    isSearchPending,
+    orderBy,
+    orderDir,
+    searchTerm,
+    selectedDateRange,
+    selectedTab,
+    total,
+  ]);
+
+  return {
+    isExporting,
+    isExportDisabled,
+    handleExportSchools,
+  };
+};

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -9020,73 +9020,46 @@ export class SupabaseApi implements ServiceApi {
     };
 
     try {
-      const { data, error } = await this.supabase
-        .from(TABLES.SchoolMetrics)
-        .select(
-          'state, district, block, cluster, program_type, partners, program_managers, field_coordinators',
-        )
-        .eq('is_deleted', false);
+      const { data, error } = await this.supabase.rpc(
+        'get_school_filter_options',
+      );
 
       if (error) {
-        logger.error('Error fetching school_metrics filter options:', error);
+        logger.error(
+          'RPC error in getSchoolFilterOptionsForSchoolListing:',
+          error,
+        );
         return emptyOptions;
       }
 
-      const parsed: Record<string, Set<string>> = {
-        state: new Set(),
-        district: new Set(),
-        block: new Set(),
-        programType: new Set(),
-        partner: new Set(),
-        programManager: new Set(),
-        fieldCoordinator: new Set(),
-        cluster: new Set(),
-      };
-
-      for (const row of (data ?? []) as Array<{
-        state?: string | null;
-        district?: string | null;
-        block?: string | null;
-        cluster?: string | null;
-        program_type?: string | null;
-        partners?: Array<string | null> | string[] | null;
-        program_managers?: Array<string | null> | string[] | null;
-        field_coordinators?: Array<string | null> | string[] | null;
-      }>) {
-        if (row.state) parsed.state.add(row.state);
-        if (row.district) parsed.district.add(row.district);
-        if (row.block) parsed.block.add(row.block);
-        if (row.cluster) parsed.cluster.add(row.cluster);
-        if (
-          row.program_type &&
-          Object.values(ProgramType).includes(row.program_type as ProgramType)
-        ) {
-          parsed.programType.add(row.program_type);
-        }
-
-        for (const partner of row.partners ?? []) {
-          if (partner) parsed.partner.add(partner);
-        }
-        for (const manager of row.program_managers ?? []) {
-          if (manager) parsed.programManager.add(manager);
-        }
-        for (const coordinator of row.field_coordinators ?? []) {
-          if (coordinator) parsed.fieldCoordinator.add(coordinator);
-        }
+      if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        return emptyOptions;
       }
 
-      const finalOptions: Record<string, string[]> = {
-        state: Array.from(parsed.state).sort(),
-        district: Array.from(parsed.district).sort(),
-        block: Array.from(parsed.block).sort(),
-        programType: Array.from(parsed.programType).sort(),
-        partner: Array.from(parsed.partner).sort(),
-        programManager: Array.from(parsed.programManager).sort(),
-        fieldCoordinator: Array.from(parsed.fieldCoordinator).sort(),
-        cluster: Array.from(parsed.cluster).sort(),
-      };
+      const rpcData = data as Record<string, Json>;
 
-      return finalOptions;
+      return {
+        state: Array.isArray(rpcData.state) ? (rpcData.state as string[]) : [],
+        district: Array.isArray(rpcData.district)
+          ? (rpcData.district as string[])
+          : [],
+        block: Array.isArray(rpcData.block) ? (rpcData.block as string[]) : [],
+        programType: Array.isArray(rpcData.programType)
+          ? (rpcData.programType as string[])
+          : [],
+        partner: Array.isArray(rpcData.partner)
+          ? (rpcData.partner as string[])
+          : [],
+        programManager: Array.isArray(rpcData.programManager)
+          ? (rpcData.programManager as string[])
+          : [],
+        fieldCoordinator: Array.isArray(rpcData.fieldCoordinator)
+          ? (rpcData.fieldCoordinator as string[])
+          : [],
+        cluster: Array.isArray(rpcData.cluster)
+          ? (rpcData.cluster as string[])
+          : [],
+      };
     } catch (err) {
       logger.error('Unexpected error in getSchoolFilterOptions:', err);
       return emptyOptions;

--- a/src/utility/xlsxExportUtils.test.ts
+++ b/src/utility/xlsxExportUtils.test.ts
@@ -1,0 +1,46 @@
+import { injectFreezePaneXml } from './xlsxExportUtils';
+
+describe('injectFreezePaneXml', () => {
+  const freeze = {
+    xSplit: 1,
+    ySplit: 1,
+    topLeftCell: 'B2',
+    activePane: 'bottomRight' as const,
+  };
+
+  it('adds pane and selection to a self-closing sheetView', () => {
+    const xml =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+      '<sheetViews><sheetView workbookViewId="0" /></sheetViews>' +
+      '<sheetData />' +
+      '</worksheet>';
+
+    const patchedXml = injectFreezePaneXml(xml, freeze);
+
+    expect(patchedXml).toContain('<pane');
+    expect(patchedXml).toContain('xSplit="1"');
+    expect(patchedXml).toContain('topLeftCell="B2"');
+    expect(patchedXml).toContain('<selection');
+    expect(patchedXml).toContain('pane="bottomRight"');
+  });
+
+  it('replaces existing pane and selection nodes instead of duplicating them', () => {
+    const xml =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+      '<sheetViews><sheetView workbookViewId="0">' +
+      '<pane xSplit="2" ySplit="2" topLeftCell="C3" activePane="bottomRight" state="frozen" />' +
+      '<selection pane="bottomRight" activeCell="C3" sqref="C3" />' +
+      '</sheetView></sheetViews>' +
+      '<sheetData />' +
+      '</worksheet>';
+
+    const patchedXml = injectFreezePaneXml(xml, freeze);
+
+    expect(patchedXml.match(/<pane\b/g)).toHaveLength(1);
+    expect(patchedXml.match(/<selection\b/g)).toHaveLength(1);
+    expect(patchedXml).toContain('topLeftCell="B2"');
+    expect(patchedXml).toContain('activeCell="B2"');
+  });
+});

--- a/src/utility/xlsxExportUtils.ts
+++ b/src/utility/xlsxExportUtils.ts
@@ -1,0 +1,123 @@
+export type FreezePaneConfig = {
+  xSplit: number;
+  ySplit: number;
+  topLeftCell: string;
+  activePane: 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
+  activeCell?: string;
+  sqref?: string;
+};
+
+type JsZipWorksheetFile = {
+  async: (type: 'string') => Promise<string>;
+};
+
+type JsZipWorkbook = {
+  file: {
+    (path: string): JsZipWorksheetFile | null;
+    (path: string, data: string): unknown;
+  };
+  generateAsync: (options: { type: 'arraybuffer' }) => Promise<ArrayBuffer>;
+};
+
+type JsZipStatic = {
+  loadAsync: (input: ArrayBuffer) => Promise<JsZipWorkbook>;
+};
+
+export const XLSX_EXPORT_BORDER_COLOR = 'D0D7DE';
+export const XLSX_EXPORT_FONT_NAME = 'Inter';
+export const XLSX_EXPORT_FONT_SIZE = 10;
+
+const createXmlElement = (
+  doc: XMLDocument,
+  namespaceUri: string | null,
+  name: string,
+) =>
+  namespaceUri
+    ? doc.createElementNS(namespaceUri, name)
+    : doc.createElement(name);
+
+export const injectFreezePaneXml = (
+  xml: string,
+  freeze: FreezePaneConfig,
+): string => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xml, 'application/xml');
+
+  if (doc.getElementsByTagName('parsererror').length > 0) {
+    return xml;
+  }
+
+  const worksheet = doc.documentElement;
+  const namespaceUri = worksheet.namespaceURI;
+
+  let sheetViews = worksheet.getElementsByTagName('sheetViews')[0];
+  if (!sheetViews) {
+    sheetViews = createXmlElement(doc, namespaceUri, 'sheetViews');
+    const firstElementChild = Array.from(worksheet.childNodes).find(
+      (node) => node.nodeType === Node.ELEMENT_NODE,
+    );
+    worksheet.insertBefore(sheetViews, firstElementChild ?? null);
+  }
+
+  let sheetView = sheetViews.getElementsByTagName('sheetView')[0];
+  if (!sheetView) {
+    sheetView = createXmlElement(doc, namespaceUri, 'sheetView');
+    sheetView.setAttribute('workbookViewId', '0');
+    sheetViews.appendChild(sheetView);
+  }
+
+  Array.from(sheetView.getElementsByTagName('pane')).forEach((pane) => {
+    if (pane.parentNode === sheetView) {
+      sheetView.removeChild(pane);
+    }
+  });
+  Array.from(sheetView.getElementsByTagName('selection')).forEach(
+    (selection) => {
+      if (selection.parentNode === sheetView) {
+        sheetView.removeChild(selection);
+      }
+    },
+  );
+
+  const pane = createXmlElement(doc, namespaceUri, 'pane');
+  pane.setAttribute('xSplit', String(freeze.xSplit));
+  pane.setAttribute('ySplit', String(freeze.ySplit));
+  pane.setAttribute('topLeftCell', freeze.topLeftCell);
+  pane.setAttribute('activePane', freeze.activePane);
+  pane.setAttribute('state', 'frozen');
+  sheetView.appendChild(pane);
+
+  const selection = createXmlElement(doc, namespaceUri, 'selection');
+  selection.setAttribute('pane', freeze.activePane);
+  selection.setAttribute('activeCell', freeze.activeCell ?? freeze.topLeftCell);
+  selection.setAttribute('sqref', freeze.sqref ?? freeze.topLeftCell);
+  sheetView.appendChild(selection);
+
+  return new XMLSerializer().serializeToString(doc);
+};
+
+export const applyFreezePanesToWorkbook = async (
+  fileBuffer: ArrayBuffer,
+  sheetNames: string[],
+  sheetFreeze?: Record<string, FreezePaneConfig>,
+) => {
+  const freezeEntries = Object.entries(sheetFreeze ?? {});
+  if (freezeEntries.length === 0) return fileBuffer;
+
+  const JSZip = (await import('jszip')).default as JsZipStatic;
+  const zip = await JSZip.loadAsync(fileBuffer);
+
+  for (const [sheetName, freeze] of freezeEntries) {
+    const sheetIndex = sheetNames.indexOf(sheetName);
+    if (sheetIndex < 0) continue;
+
+    const worksheetPath = `xl/worksheets/sheet${sheetIndex + 1}.xml`;
+    const worksheetFile = zip.file(worksheetPath);
+    if (!worksheetFile) continue;
+
+    const worksheetXml = await worksheetFile.async('string');
+    zip.file(worksheetPath, injectFreezePaneXml(worksheetXml, freeze));
+  }
+
+  return zip.generateAsync({ type: 'arraybuffer' });
+};

--- a/src/workers/background.worker.test.ts
+++ b/src/workers/background.worker.test.ts
@@ -4,7 +4,12 @@ const mockRead = jest.fn();
 const mockSheetToJson = jest.fn();
 const mockBookNew = jest.fn();
 const mockJsonToSheet = jest.fn();
+const mockAoaToSheet = jest.fn();
 const mockBookAppendSheet = jest.fn();
+const mockEncodeCell = jest.fn(({ r, c }: { r: number; c: number }) => {
+  const column = String.fromCharCode(65 + c);
+  return `${column}${r + 1}`;
+});
 const mockWrite = jest.fn();
 
 jest.mock('xlsx-js-style', () => ({
@@ -14,6 +19,9 @@ jest.mock('xlsx-js-style', () => ({
     sheet_to_json: (...args: unknown[]) => mockSheetToJson(...args),
     book_new: (...args: unknown[]) => mockBookNew(...args),
     json_to_sheet: (...args: unknown[]) => mockJsonToSheet(...args),
+    aoa_to_sheet: (...args: unknown[]) => mockAoaToSheet(...args),
+    encode_cell: (arg: unknown) =>
+      mockEncodeCell(arg as { r: number; c: number }),
     book_append_sheet: (...args: unknown[]) => mockBookAppendSheet(...args),
   },
 }));
@@ -36,7 +44,9 @@ describe('background.worker', () => {
     });
     await import('./background.worker');
     return (
-      globalThis as unknown as { onmessage: (event: any) => Promise<void> }
+      globalThis as unknown as {
+        onmessage: (event: unknown) => Promise<void>;
+      }
     ).onmessage;
   };
 

--- a/src/workers/background.worker.ts
+++ b/src/workers/background.worker.ts
@@ -1,5 +1,11 @@
 import logger from '../utility/logger';
 import {
+  applyFreezePanesToWorkbook,
+  XLSX_EXPORT_BORDER_COLOR,
+  XLSX_EXPORT_FONT_NAME,
+  XLSX_EXPORT_FONT_SIZE,
+} from '../utility/xlsxExportUtils';
+import {
   WorkerAckMessage,
   BackgroundWorkerTask,
   BuildXlsxFilePayload,
@@ -23,8 +29,6 @@ import {
 
 const workerScope = globalThis as unknown as DedicatedWorkerGlobalScope;
 let xlsxModulePromise: Promise<typeof import('xlsx-js-style')> | null = null;
-const EXPORT_FONT_NAME = 'Inter';
-const EXPORT_FONT_SIZE = 10;
 type XlsxModule = typeof import('xlsx-js-style');
 type XlsxSheetRow = Record<string, unknown>;
 type XlsxWorksheetStyle = {
@@ -42,24 +46,10 @@ type WritableWorksheet = Record<string, unknown> & {
   ['!rows']?: unknown;
   ['!merges']?: unknown;
 };
-type JsZipWorksheetFile = {
-  async: (type: 'string') => Promise<string>;
-};
-type JsZipWorkbook = {
-  file: {
-    (path: string): JsZipWorksheetFile | null;
-    (path: string, data: string): unknown;
-  };
-  generateAsync: (options: { type: 'arraybuffer' }) => Promise<ArrayBuffer>;
-};
-type JsZipStatic = {
-  loadAsync: (input: ArrayBuffer) => Promise<JsZipWorkbook>;
-};
 const getWrappedCellMaxLineLength = (value: string | number | undefined) =>
   String(value ?? '')
     .split('\n')
     .reduce((maxLength, line) => Math.max(maxLength, line.length), 0);
-const EXPORT_BORDER_COLOR = '7A8699';
 const getXlsx = async (): Promise<XlsxModule> => {
   if (!xlsxModulePromise) {
     xlsxModulePromise = import('xlsx-js-style');
@@ -621,7 +611,7 @@ const buildXlsxFile = async (
     const applyCellBorders = (
       rowCount: number,
       columnCount: number,
-      borderColor = EXPORT_BORDER_COLOR,
+      borderColor = XLSX_EXPORT_BORDER_COLOR,
     ) => {
       for (let rowIndex = 0; rowIndex < rowCount; rowIndex += 1) {
         for (let columnIndex = 0; columnIndex < columnCount; columnIndex += 1) {
@@ -635,8 +625,8 @@ const buildXlsxFile = async (
             ...cell.s,
             font: {
               ...(cell.s?.font ?? {}),
-              name: EXPORT_FONT_NAME,
-              sz: EXPORT_FONT_SIZE,
+              name: XLSX_EXPORT_FONT_NAME,
+              sz: XLSX_EXPORT_FONT_SIZE,
             },
             border: {
               top: { style: 'thin', color: { rgb: borderColor } },
@@ -660,8 +650,8 @@ const buildXlsxFile = async (
           ...cell.s,
           font: {
             ...(cell.s?.font ?? {}),
-            name: EXPORT_FONT_NAME,
-            sz: EXPORT_FONT_SIZE,
+            name: XLSX_EXPORT_FONT_NAME,
+            sz: XLSX_EXPORT_FONT_SIZE,
             bold: true,
             color: { rgb: 'FFFFFF' },
           },
@@ -767,7 +757,11 @@ const buildXlsxFile = async (
     type: 'array',
   });
   const outputBuffer = toArrayBuffer(output);
-  const frozenBuffer = await applyFreezePanesToWorkbook(outputBuffer, payload);
+  const frozenBuffer = await applyFreezePanesToWorkbook(
+    outputBuffer,
+    payload.sheetNames,
+    payload.sheetFreeze,
+  );
   return {
     fileBuffer: frozenBuffer,
   };
@@ -796,75 +790,6 @@ const bytesToBase64 = (bytes: Uint8Array): string => {
     binary += String.fromCharCode(...chunk);
   }
   return btoa(binary);
-};
-
-const FREEZE_PANE_REGEX = /<sheetViews>([\s\S]*?)<\/sheetViews>/;
-const SELF_CLOSING_SHEET_VIEW_REGEX = /<sheetView([^>]*)\/>/;
-const OPEN_SHEET_VIEW_REGEX = /<sheetView([^>]*)>/;
-const EXISTING_PANE_REGEX = /<pane[^>]*\/>/;
-const EXISTING_SELECTION_REGEX = /<selection[^>]*\/>/g;
-
-const injectFreezePaneXml = (
-  xml: string,
-  freeze: {
-    xSplit: number;
-    ySplit: number;
-    topLeftCell: string;
-    activePane: 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
-    activeCell?: string;
-    sqref?: string;
-  },
-) => {
-  const paneXml = `<pane xSplit="${freeze.xSplit}" ySplit="${freeze.ySplit}" topLeftCell="${freeze.topLeftCell}" activePane="${freeze.activePane}" state="frozen"/>`;
-  const selectionXml = `<selection pane="${freeze.activePane}" activeCell="${freeze.activeCell ?? freeze.topLeftCell}" sqref="${freeze.sqref ?? freeze.topLeftCell}"/>`;
-
-  return xml.replace(FREEZE_PANE_REGEX, (sheetViewsXml) => {
-    if (SELF_CLOSING_SHEET_VIEW_REGEX.test(sheetViewsXml)) {
-      return sheetViewsXml.replace(
-        SELF_CLOSING_SHEET_VIEW_REGEX,
-        `<sheetView$1>${paneXml}${selectionXml}</sheetView>`,
-      );
-    }
-
-    if (OPEN_SHEET_VIEW_REGEX.test(sheetViewsXml)) {
-      const withoutPane = sheetViewsXml.replace(EXISTING_PANE_REGEX, '');
-      const withoutSelection = withoutPane.replace(
-        EXISTING_SELECTION_REGEX,
-        '',
-      );
-      return withoutSelection.replace(
-        OPEN_SHEET_VIEW_REGEX,
-        `<sheetView$1>${paneXml}${selectionXml}`,
-      );
-    }
-
-    return sheetViewsXml;
-  });
-};
-
-const applyFreezePanesToWorkbook = async (
-  fileBuffer: ArrayBuffer,
-  payload: BuildXlsxFilePayload,
-) => {
-  const freezeEntries = Object.entries(payload.sheetFreeze ?? {});
-  if (freezeEntries.length === 0) return fileBuffer;
-
-  const JSZip = (await import('jszip')).default as JsZipStatic;
-  const zip = await JSZip.loadAsync(fileBuffer);
-
-  for (const [sheetName, freeze] of freezeEntries) {
-    const sheetIndex = payload.sheetNames.indexOf(sheetName);
-    if (sheetIndex < 0) continue;
-
-    const worksheetPath = `xl/worksheets/sheet${sheetIndex + 1}.xml`;
-    const worksheetFile = zip.file(worksheetPath);
-    if (!worksheetFile) continue;
-
-    const worksheetXml = await worksheetFile.async('string');
-    zip.file(worksheetPath, injectFreezePaneXml(worksheetXml, freeze));
-  }
-
-  return zip.generateAsync({ type: 'arraybuffer' });
 };
 
 const downloadRemoteAudio = async (

--- a/src/workers/background.worker.ts
+++ b/src/workers/background.worker.ts
@@ -23,12 +23,54 @@ import {
 
 const workerScope = globalThis as unknown as DedicatedWorkerGlobalScope;
 let xlsxModulePromise: Promise<typeof import('xlsx-js-style')> | null = null;
-const getXlsx = async (): Promise<typeof import('xlsx-js-style')> => {
+const EXPORT_FONT_NAME = 'Inter';
+const EXPORT_FONT_SIZE = 10;
+type XlsxModule = typeof import('xlsx-js-style');
+type XlsxSheetRow = Record<string, unknown>;
+type XlsxWorksheetStyle = {
+  font?: Record<string, unknown>;
+  border?: Record<string, unknown>;
+  fill?: Record<string, unknown>;
+  alignment?: Record<string, unknown>;
+};
+type XlsxWorksheetCell = {
+  s?: XlsxWorksheetStyle;
+  [key: string]: unknown;
+};
+type WritableWorksheet = Record<string, unknown> & {
+  ['!cols']?: unknown;
+  ['!rows']?: unknown;
+  ['!merges']?: unknown;
+};
+type JsZipWorksheetFile = {
+  async: (type: 'string') => Promise<string>;
+};
+type JsZipWorkbook = {
+  file: {
+    (path: string): JsZipWorksheetFile | null;
+    (path: string, data: string): unknown;
+  };
+  generateAsync: (options: { type: 'arraybuffer' }) => Promise<ArrayBuffer>;
+};
+type JsZipStatic = {
+  loadAsync: (input: ArrayBuffer) => Promise<JsZipWorkbook>;
+};
+const getWrappedCellMaxLineLength = (value: string | number | undefined) =>
+  String(value ?? '')
+    .split('\n')
+    .reduce((maxLength, line) => Math.max(maxLength, line.length), 0);
+const EXPORT_BORDER_COLOR = '7A8699';
+const getXlsx = async (): Promise<XlsxModule> => {
   if (!xlsxModulePromise) {
     xlsxModulePromise = import('xlsx-js-style');
   }
   return xlsxModulePromise;
 };
+const getWorksheetCell = (
+  sheet: WritableWorksheet,
+  cellRef: string,
+): XlsxWorksheetCell | undefined =>
+  sheet[cellRef] as XlsxWorksheetCell | undefined;
 const pendingAckResolvers = new Map<string, () => void>();
 const safeTableName = (tableName: string): string => {
   if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(tableName)) {
@@ -522,17 +564,17 @@ const parseXlsxSheets = async (
   payload: ParseXlsxSheetsPayload,
 ): Promise<{
   sheetNames: string[];
-  sheets: Record<string, Record<string, any>[]>;
+  sheets: Record<string, XlsxSheetRow[]>;
 }> => {
   const XLSX = await getXlsx();
   const workbook = XLSX.read(payload.fileBuffer, { type: 'array' });
-  const sheets: Record<string, Record<string, any>[]> = {};
+  const sheets: Record<string, XlsxSheetRow[]> = {};
   for (const sheetName of workbook.SheetNames) {
     const worksheet = workbook.Sheets[sheetName];
     sheets[sheetName] = XLSX.utils.sheet_to_json(worksheet, {
       raw: false,
       defval: '',
-    }) as Record<string, any>[];
+    }) as XlsxSheetRow[];
   }
   return {
     sheetNames: workbook.SheetNames,
@@ -569,15 +611,165 @@ const buildXlsxFile = async (
   const workbook = XLSX.utils.book_new();
   for (const sheetName of payload.sheetNames) {
     const rows = payload.sheets[sheetName] ?? [];
-    const sheet = XLSX.utils.json_to_sheet(rows);
+    const sheetFormat = payload.sheetFormats?.[sheetName] ?? 'json';
+    const sheet =
+      sheetFormat === 'aoa'
+        ? XLSX.utils.aoa_to_sheet(rows as Array<Array<string | number>>)
+        : XLSX.utils.json_to_sheet(rows as XlsxSheetRow[]);
+    const writableSheet = sheet as WritableWorksheet;
+
+    const applyCellBorders = (
+      rowCount: number,
+      columnCount: number,
+      borderColor = EXPORT_BORDER_COLOR,
+    ) => {
+      for (let rowIndex = 0; rowIndex < rowCount; rowIndex += 1) {
+        for (let columnIndex = 0; columnIndex < columnCount; columnIndex += 1) {
+          const cellRef = XLSX.utils.encode_cell({
+            r: rowIndex,
+            c: columnIndex,
+          });
+          const cell = getWorksheetCell(writableSheet, cellRef);
+          if (!cell) continue;
+          cell.s = {
+            ...cell.s,
+            font: {
+              ...(cell.s?.font ?? {}),
+              name: EXPORT_FONT_NAME,
+              sz: EXPORT_FONT_SIZE,
+            },
+            border: {
+              top: { style: 'thin', color: { rgb: borderColor } },
+              bottom: { style: 'thin', color: { rgb: borderColor } },
+              left: { style: 'thin', color: { rgb: borderColor } },
+              right: { style: 'thin', color: { rgb: borderColor } },
+            },
+          };
+        }
+      }
+    };
+
+    if (sheetFormat === 'aoa') {
+      const headers = (rows as Array<Array<string | number>>)[0] ?? [];
+      const headerCount = headers.length;
+      for (let columnIndex = 0; columnIndex < headerCount; columnIndex += 1) {
+        const cellRef = XLSX.utils.encode_cell({ r: 0, c: columnIndex });
+        const cell = getWorksheetCell(writableSheet, cellRef);
+        if (!cell) continue;
+        cell.s = {
+          ...cell.s,
+          font: {
+            ...(cell.s?.font ?? {}),
+            name: EXPORT_FONT_NAME,
+            sz: EXPORT_FONT_SIZE,
+            bold: true,
+            color: { rgb: 'FFFFFF' },
+          },
+          fill: {
+            patternType: 'solid',
+            fgColor: { rgb: '1976D2' },
+            bgColor: { rgb: '1976D2' },
+          },
+          alignment: {
+            ...(cell.s?.alignment ?? {}),
+            vertical: 'center',
+          },
+        };
+      }
+
+      const merges = payload.sheetMerges?.[sheetName] ?? [];
+      const mergeWidths = new Map<number, number>();
+      merges.forEach((merge) => {
+        const span = merge.e.c - merge.s.c + 1;
+        const headerText = String(headers[merge.s.c] ?? '');
+        const widthPerColumn = Math.max(
+          12,
+          Math.ceil(headerText.length / span) + 2,
+        );
+        for (
+          let columnIndex = merge.s.c;
+          columnIndex <= merge.e.c;
+          columnIndex += 1
+        ) {
+          mergeWidths.set(columnIndex, widthPerColumn);
+        }
+      });
+      const firstColumnWidth = (rows as Array<Array<string | number>>).reduce(
+        (maxWidth, row) =>
+          Math.max(maxWidth, getWrappedCellMaxLineLength(row[0])),
+        getWrappedCellMaxLineLength(headers[0]),
+      );
+      writableSheet['!cols'] = headers.map((header, columnIndex) => ({
+        wch:
+          columnIndex === 0
+            ? Math.max(20, firstColumnWidth + 4)
+            : (mergeWidths.get(columnIndex) ??
+              Math.max(12, String(header ?? '').length + 2)),
+      }));
+    }
+
+    const wrappedColumns = payload.sheetWrapColumns?.[sheetName] ?? [];
+    if (sheetFormat === 'aoa' && wrappedColumns.length > 0) {
+      const rowCount = (rows as Array<Array<string | number>>).length;
+      wrappedColumns.forEach((columnIndex) => {
+        for (let rowIndex = 1; rowIndex < rowCount; rowIndex += 1) {
+          const cellRef = XLSX.utils.encode_cell({
+            r: rowIndex,
+            c: columnIndex,
+          });
+          const cell = getWorksheetCell(writableSheet, cellRef);
+          if (!cell) continue;
+          cell.s = {
+            ...cell.s,
+            alignment: {
+              ...(cell.s?.alignment ?? {}),
+              wrapText: true,
+              vertical: 'top',
+            },
+          };
+        }
+      });
+      writableSheet['!rows'] = Array.from(
+        { length: rowCount },
+        (_, rowIndex) => (rowIndex === 0 ? {} : { hpt: 30 }),
+      );
+    }
+
+    const merges = payload.sheetMerges?.[sheetName] ?? [];
+    if (merges.length > 0) {
+      writableSheet['!merges'] = merges;
+      merges.forEach((merge) => {
+        const cellRef = XLSX.utils.encode_cell(merge.s);
+        const cell = getWorksheetCell(writableSheet, cellRef);
+        if (!cell) return;
+        cell.s = {
+          ...cell.s,
+          alignment: {
+            ...(cell.s?.alignment ?? {}),
+            horizontal: 'center',
+            vertical: 'center',
+          },
+        };
+      });
+    }
+
+    if (sheetFormat === 'aoa') {
+      const rowCount = (rows as Array<Array<string | number>>).length;
+      const columnCount = ((rows as Array<Array<string | number>>)[0] ?? [])
+        .length;
+      applyCellBorders(rowCount, columnCount);
+    }
+
     XLSX.utils.book_append_sheet(workbook, sheet, sheetName);
   }
   const output = XLSX.write(workbook, {
     bookType: 'xlsx',
     type: 'array',
   });
+  const outputBuffer = toArrayBuffer(output);
+  const frozenBuffer = await applyFreezePanesToWorkbook(outputBuffer, payload);
   return {
-    fileBuffer: toArrayBuffer(output),
+    fileBuffer: frozenBuffer,
   };
 };
 
@@ -604,6 +796,75 @@ const bytesToBase64 = (bytes: Uint8Array): string => {
     binary += String.fromCharCode(...chunk);
   }
   return btoa(binary);
+};
+
+const FREEZE_PANE_REGEX = /<sheetViews>([\s\S]*?)<\/sheetViews>/;
+const SELF_CLOSING_SHEET_VIEW_REGEX = /<sheetView([^>]*)\/>/;
+const OPEN_SHEET_VIEW_REGEX = /<sheetView([^>]*)>/;
+const EXISTING_PANE_REGEX = /<pane[^>]*\/>/;
+const EXISTING_SELECTION_REGEX = /<selection[^>]*\/>/g;
+
+const injectFreezePaneXml = (
+  xml: string,
+  freeze: {
+    xSplit: number;
+    ySplit: number;
+    topLeftCell: string;
+    activePane: 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
+    activeCell?: string;
+    sqref?: string;
+  },
+) => {
+  const paneXml = `<pane xSplit="${freeze.xSplit}" ySplit="${freeze.ySplit}" topLeftCell="${freeze.topLeftCell}" activePane="${freeze.activePane}" state="frozen"/>`;
+  const selectionXml = `<selection pane="${freeze.activePane}" activeCell="${freeze.activeCell ?? freeze.topLeftCell}" sqref="${freeze.sqref ?? freeze.topLeftCell}"/>`;
+
+  return xml.replace(FREEZE_PANE_REGEX, (sheetViewsXml) => {
+    if (SELF_CLOSING_SHEET_VIEW_REGEX.test(sheetViewsXml)) {
+      return sheetViewsXml.replace(
+        SELF_CLOSING_SHEET_VIEW_REGEX,
+        `<sheetView$1>${paneXml}${selectionXml}</sheetView>`,
+      );
+    }
+
+    if (OPEN_SHEET_VIEW_REGEX.test(sheetViewsXml)) {
+      const withoutPane = sheetViewsXml.replace(EXISTING_PANE_REGEX, '');
+      const withoutSelection = withoutPane.replace(
+        EXISTING_SELECTION_REGEX,
+        '',
+      );
+      return withoutSelection.replace(
+        OPEN_SHEET_VIEW_REGEX,
+        `<sheetView$1>${paneXml}${selectionXml}`,
+      );
+    }
+
+    return sheetViewsXml;
+  });
+};
+
+const applyFreezePanesToWorkbook = async (
+  fileBuffer: ArrayBuffer,
+  payload: BuildXlsxFilePayload,
+) => {
+  const freezeEntries = Object.entries(payload.sheetFreeze ?? {});
+  if (freezeEntries.length === 0) return fileBuffer;
+
+  const JSZip = (await import('jszip')).default as JsZipStatic;
+  const zip = await JSZip.loadAsync(fileBuffer);
+
+  for (const [sheetName, freeze] of freezeEntries) {
+    const sheetIndex = payload.sheetNames.indexOf(sheetName);
+    if (sheetIndex < 0) continue;
+
+    const worksheetPath = `xl/worksheets/sheet${sheetIndex + 1}.xml`;
+    const worksheetFile = zip.file(worksheetPath);
+    if (!worksheetFile) continue;
+
+    const worksheetXml = await worksheetFile.async('string');
+    zip.file(worksheetPath, injectFreezePaneXml(worksheetXml, freeze));
+  }
+
+  return zip.generateAsync({ type: 'arraybuffer' });
 };
 
 const downloadRemoteAudio = async (

--- a/src/workers/background.worker.types.ts
+++ b/src/workers/background.worker.types.ts
@@ -73,7 +73,30 @@ export type ParseXlsxSheetsResult = {
 
 export type BuildXlsxFilePayload = {
   sheetNames: string[];
-  sheets: Record<string, Record<string, any>[]>;
+  sheets: Record<
+    string,
+    Record<string, unknown>[] | Array<Array<string | number>>
+  >;
+  sheetFormats?: Record<string, 'json' | 'aoa'>;
+  sheetWrapColumns?: Record<string, number[]>;
+  sheetFreeze?: Record<
+    string,
+    {
+      xSplit: number;
+      ySplit: number;
+      topLeftCell: string;
+      activePane: 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
+      activeCell?: string;
+      sqref?: string;
+    }
+  >;
+  sheetMerges?: Record<
+    string,
+    Array<{
+      s: { r: number; c: number };
+      e: { r: number; c: number };
+    }>
+  >;
 };
 
 export type BuildXlsxFileResult = {


### PR DESCRIPTION

<img width="1349" height="456" alt="image" src="https://github.com/user-attachments/assets/605e5f7d-c9f2-47e8-adf0-4e4aae7aab82" />

Introduce Excel export for the Ops Console school list, with support for the current search, filters, tab, sort order, and date range. The export builds a formatted workbook with merged headers, frozen panes, wrapped school labels, and a worker-backed generation path with a safe main-thread fallback.

Includes:

- export button in the School List toolbar
- export hook to fetch all matching school rows across pages formatted XLSX generation for school metrics
- debounce-safe export behavior for search
- English translation strings for Export and Exporting... test coverage for export flow and fallback behavior