### PR TITLE
fix(ops-console): preserve exact class names in student flows

### DIFF
--- a/src/ops-console/components/SchoolDetailsComponents/SchoolClass.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolClass.tsx
@@ -28,6 +28,8 @@ import { RootState } from '../../../redux/store';
 import { AuthState } from '../../../redux/slices/auth/authSlice';
 import {
   filterByProgramGrades,
+  getClassDisplayLabel,
+  getExactClassName,
   getProgramAllowedGrades,
   ProgramGradeScopeData,
 } from './ClassDetailsPageUtils';
@@ -746,7 +748,11 @@ const SchoolClasses: React.FC<Props> = ({
         open={isAddStudentModalOpen}
         title={
           classForStudent
-            ? `${t('Add New Student')} - ${classForStudent.name}`
+            ? `${t('Add New Student')} - ${getClassDisplayLabel(
+                classForStudent.grade,
+                classForStudent.section,
+                getExactClassName(classForStudent),
+              )}`
             : t('Add New Student')
         }
         submitLabel={isStudentSubmitting ? t('Adding...') : t('Add Student')}

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolStudents.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolStudents.tsx
@@ -1273,14 +1273,17 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
   }, [programScopedClasses]);
 
   const currentClass = useMemo(() => {
-    if (
-      !issTotal &&
-      optionalGrade !== undefined &&
-      optionalSection !== undefined
-    ) {
+    if (!issTotal) {
       const classDataArray = data.classData || [];
+      const scopedClassId = String(optionalClassId ?? '').trim();
       if (classDataArray.length > 0) {
-        const classFromData = classDataArray[0];
+        const classFromData =
+          (scopedClassId
+            ? classDataArray.find(
+                (classRow) =>
+                  String(classRow?.id ?? '').trim() === scopedClassId,
+              )
+            : classDataArray[0]) ?? null;
         if (classFromData?.id && classFromData?.name) {
           return { id: classFromData.id, name: classFromData.name };
         }
@@ -1288,8 +1291,10 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
       const matchingStudent = baseStudents.find((student: any) => {
         const classInfo = student.classWithidname;
         return (
-          student.grade === optionalGrade &&
-          sameSection(student.classSection, optionalSection) &&
+          (!scopedClassId ||
+            String(classInfo?.id ?? '').trim() === scopedClassId ||
+            (student.grade === optionalGrade &&
+              sameSection(student.classSection, optionalSection))) &&
           classInfo?.id &&
           classInfo?.class_name
         );
@@ -1304,7 +1309,14 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
       return null;
     }
     return null;
-  }, [issTotal, optionalGrade, optionalSection, baseStudents, data.classData]);
+  }, [
+    issTotal,
+    optionalClassId,
+    optionalGrade,
+    optionalSection,
+    baseStudents,
+    data.classData,
+  ]);
 
   const addStudentFields: FieldConfig[] = useMemo(() => {
     if (issTotal) {

--- a/src/ops-console/pages/UserDetailsPage.tsx
+++ b/src/ops-console/pages/UserDetailsPage.tsx
@@ -159,6 +159,11 @@ const UserDetailsPage: React.FC = () => {
     (user.name === userData?.user?.name &&
       userRole === userData?.userRole &&
       previewUrl == null);
+  const editRoleOptions = availableEditRoles.includes(userRole as RoleType)
+    ? availableEditRoles
+    : userRole
+      ? [userRole as RoleType]
+      : availableEditRoles;
 
   return (
     <div className="user-details-page">
@@ -262,7 +267,7 @@ const UserDetailsPage: React.FC = () => {
             onChange={(e) => setUserRole(e.target.value)}
           >
             {isEdit
-              ? availableEditRoles.map((role: string) => (
+              ? editRoleOptions.map((role: string) => (
                   <option key={role} value={role}>
                     {RoleLabels[role as RoleType]}
                   </option>

--- a/src/ops-console/pages/UserDetailsPage.tsx
+++ b/src/ops-console/pages/UserDetailsPage.tsx
@@ -29,6 +29,7 @@ const UserDetailsPage: React.FC = () => {
   const [availableEditRoles] = useState([
     RoleType.PROGRAM_MANAGER,
     RoleType.FIELD_COORDINATOR,
+    RoleType.EXTERNAL_USER,
   ]);
 
   const history = useHistory();
@@ -162,7 +163,7 @@ const UserDetailsPage: React.FC = () => {
   const editRoleOptions = availableEditRoles.includes(userRole as RoleType)
     ? availableEditRoles
     : userRole
-      ? [userRole as RoleType]
+      ? [...availableEditRoles, userRole as RoleType]
       : availableEditRoles;
 
   return (


### PR DESCRIPTION
Updated ops console student and user detail flows to better preserve source data in the UI.

- Use exact class names in add-student modal titles instead of rebuilding labels from grade/section. 
- Resolve the current class in SchoolStudents by optionalClassId when available, with safer fallbacks to class/student data. 
- Keep the user role select populated with the current role when editing a user whose role may not be in the default editable list.