### PR TITLE
fix: Filter Classes in OPS School Listing Based on Program Mapping

### DIFF
--- a/src/ops-console/components/SchoolDetailsComponents/ClassDetailsPageUtils.test.ts
+++ b/src/ops-console/components/SchoolDetailsComponents/ClassDetailsPageUtils.test.ts
@@ -154,8 +154,14 @@ describe('ClassDetailsPageUtils', () => {
     it.each([
       [{ handle_classess: 1 }, ['1']],
       [{ handle_classess: '1' }, ['1']],
+      // Keeps backward compatibility with legacy KG scope encoded as grade "0".
+      [{ handle_classess: '0' }, ['0']],
       [{ handle_classess: '1 and 2' }, ['1', '2']],
       [{ handle_classess: '1,2' }, ['1', '2']],
+      // Ensures KG labels are stored as distinct tokens rather than collapsing both to 0.
+      [{ handle_classess: 'LKG' }, ['LKG']],
+      [{ handle_classess: 'ukg c' }, ['UKG']],
+      [{ handle_classess: 'LKG and UKG' }, ['LKG', 'UKG']],
       [{ handle_classess: [1, 2] }, ['1', '2']],
       [{ handle_classess: '["1","2"]' }, ['1', '2']],
       [{ handle_classess: "['1','2']" }, ['1', '2']],
@@ -199,6 +205,62 @@ describe('ClassDetailsPageUtils', () => {
           section: 'A',
         }),
       ).toBe(true);
+    });
+
+    // Validates LKG-only scope does not leak UKG rows.
+    it('shows only LKG when the program scope is LKG', () => {
+      const lkgOnly = getProgramAllowedGrades({
+        handle_classess: 'LKG',
+      });
+
+      expect(
+        filterByProgramGrades(
+          [{ name: 'LKG A' }, { name: 'UKG A' }, { name: '1A' }],
+          lkgOnly,
+        ),
+      ).toEqual([{ name: 'LKG A' }]);
+    });
+
+    // Validates UKG-only scope does not leak LKG rows.
+    it('shows only UKG when the program scope is UKG', () => {
+      const ukgOnly = getProgramAllowedGrades({
+        handle_classess: 'UKG',
+      });
+
+      expect(
+        filterByProgramGrades(
+          [{ name: 'LKG B' }, { name: 'UKG B' }, { name: '2A' }],
+          ukgOnly,
+        ),
+      ).toEqual([{ name: 'UKG B' }]);
+    });
+
+    // Validates dual KG scope includes both KG branches together.
+    it('shows both LKG and UKG when both are in program scope', () => {
+      const kgBoth = getProgramAllowedGrades({
+        handle_classess: 'LKG and UKG',
+      });
+
+      expect(
+        filterByProgramGrades(
+          [{ name: 'LKG C' }, { name: 'UKG C' }, { name: '3A' }],
+          kgBoth,
+        ),
+      ).toEqual([{ name: 'LKG C' }, { name: 'UKG C' }]);
+    });
+
+    // Guards existing installs where KG scope is configured as numeric 0.
+    it('keeps legacy grade 0 scopes matching both LKG and UKG', () => {
+      const legacyKg = getProgramAllowedGrades({
+        handle_classess: 0,
+      });
+
+      expect(
+        filterByProgramGrades(
+          [{ name: 'LKG A' }, { name: 'UKG A' }, { name: '1A' }],
+          legacyKg,
+        ),
+      ).toEqual([{ name: 'LKG A' }, { name: 'UKG A' }]);
     });
   });
 });

--- a/src/ops-console/components/SchoolDetailsComponents/ClassDetailsPageUtils.ts
+++ b/src/ops-console/components/SchoolDetailsComponents/ClassDetailsPageUtils.ts
@@ -175,6 +175,15 @@ function normalizeGradeToken(value?: number | string): string | null {
   return grade ? grade : null;
 }
 
+// Separates LKG/UKG labels so KG filtering can be scoped precisely.
+function parseKgToken(value?: number | string): string | null {
+  if (value === null || value === undefined) return null;
+  const cleaned = String(value).replace(CLASS_PREFIX_REGEX, '').trim();
+  if (!cleaned) return null;
+  const kgMatch = cleaned.match(KG_REGEX);
+  return kgMatch ? kgMatch[1].toUpperCase() : null;
+}
+
 // Extracts only the grade portion from a configured program class token.
 function parseProgramGradePart(value: string | number): string | null {
   if (typeof value === 'number') {
@@ -184,7 +193,17 @@ function parseProgramGradePart(value: string | number): string | null {
   const cleaned = value.trim().replace(WRAPPING_QUOTES_REGEX, '').trim();
   if (!cleaned) return null;
 
+  const kgToken = parseKgToken(cleaned);
+  if (kgToken) return kgToken;
+  // Keeps legacy numeric scope payloads (including string "0") working as-is.
+  if (/^\d+$/.test(cleaned)) return normalizeGradeToken(cleaned);
+
   const parsed = parseGradeSection(cleaned);
+  // Converts KG-like class names (for example "UKG A") to explicit KG tokens.
+  if (parsed.grade === 0) {
+    const parsedKgToken = parseKgToken(parsed.section);
+    if (parsedKgToken) return parsedKgToken;
+  }
   return normalizeGradeToken(parsed.grade);
 }
 
@@ -251,13 +270,24 @@ export function isProgramGradeAllowed(
 ): boolean {
   if (!allowedGrades) return true;
 
-  const parsedGrade = parseGradeSection(
+  const parsed = parseGradeSection(
     source.name ?? undefined,
     source.grade ?? undefined,
     source.section ?? undefined,
-  ).grade;
-  const grade = normalizeGradeToken(parsedGrade);
-  return grade !== null && allowedGrades.has(grade);
+  );
+  const parsedGrade = normalizeGradeToken(parsed.grade);
+  if (parsedGrade === null) return false;
+  if (parsedGrade !== '0') return allowedGrades.has(parsedGrade);
+
+  // KG classes share grade 0, so we match LKG/UKG tokens to keep scope-specific filtering accurate.
+  const kgToken =
+    parseKgToken(source.name ?? undefined) ??
+    parseKgToken(parsed.section ?? undefined) ??
+    parseKgToken(source.section ?? undefined);
+  if (kgToken && allowedGrades.has(kgToken)) return true;
+
+  // Preserves compatibility with legacy program scopes configured as grade "0".
+  return allowedGrades.has('0');
 }
 
 // Applies the configured program grade scope to any grade-bearing row list.


### PR DESCRIPTION
fix: Filter Classes in OPS School Listing Based on Program Mapping