### PR TITLE
fix: Mascot overlaps reward element during speaking animation

### DIFF
--- a/src/components/learningPathway/ChimpleRiveMascot.css
+++ b/src/components/learningPathway/ChimpleRiveMascot.css
@@ -9,3 +9,20 @@
   position: absolute;
   inset: 0;
 }
+
+#chimple-mascot-active-layer {
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    transparent 0%,
+    transparent 40%,
+    black 45%,
+    black 100%
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0%,
+    transparent 40%,
+    black 45%,
+    black 100%
+  );
+}


### PR DESCRIPTION

https://github.com/user-attachments/assets/b111db84-513f-4967-b296-23476a2f32a6

