### PR TITLE
fix: Enforce 11-digit UDISE validation 

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1056,6 +1056,7 @@
   "Please enter a valid email address.": "Please enter a valid email address.",
   "Please enter a valid WhatsApp invite link": "Please enter a valid WhatsApp invite link",
   "Please Enter Valid Code": "Please Enter Valid Code",
+  "Please enter a valid 11-digit UDISE code (use leading zeros if required).": "Please enter a valid 11-digit UDISE code (use leading zeros if required).",
   "Please fill in all fields.": "Please fill in all fields.",
   "please install the Chimple Kids app": " please install the Chimple Kids app",
   "Please provide a phone number.": "Please provide a phone number.",

--- a/src/ops-console/pages/AddSchoolPage.tsx
+++ b/src/ops-console/pages/AddSchoolPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Breadcrumb from '../components/Breadcrumb';
 import { Box, Grid, Typography, FormLabel, TextField } from '@mui/material';
 import ContactFormSection from '../components/SchoolRequestComponents/ContactFormSection';
@@ -21,9 +21,6 @@ const AddSchoolPage: React.FC = () => {
   const location = useLocation();
   const editData: any = location.state;
   const api = ServiceConfig.getI().apiHandler;
-  const udiseValidationTimer = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
   const [loading, setLoading] = useState(true);
   const [schoolName, setSchoolName] = useState('');
   const [udise, setUdise] = useState('');
@@ -243,17 +240,13 @@ const AddSchoolPage: React.FC = () => {
   const handleUdiseChange = async (value: string) => {
     value = value.replace(/\D/g, '').slice(0, UDISE_LENGTH);
     setUdise(value);
-    if (udiseValidationTimer.current) {
-      clearTimeout(udiseValidationTimer.current);
-    }
-    setErrorMessage('');
 
     if (value && value.length < UDISE_LENGTH) {
-      udiseValidationTimer.current = setTimeout(() => {
-        setErrorMessage(INVALID_UDISE_MESSAGE);
-      }, 1000);
+      setErrorMessage(INVALID_UDISE_MESSAGE);
       return;
     }
+
+    setErrorMessage('');
 
     if (value.length === UDISE_LENGTH) {
       try {
@@ -279,14 +272,6 @@ const AddSchoolPage: React.FC = () => {
       }
     }
   };
-
-  useEffect(() => {
-    return () => {
-      if (udiseValidationTimer.current) {
-        clearTimeout(udiseValidationTimer.current);
-      }
-    };
-  }, []);
 
   useEffect(() => {
     async function init() {

--- a/src/ops-console/pages/AddSchoolPage.tsx
+++ b/src/ops-console/pages/AddSchoolPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Breadcrumb from '../components/Breadcrumb';
 import { Box, Grid, Typography, FormLabel, TextField } from '@mui/material';
 import ContactFormSection from '../components/SchoolRequestComponents/ContactFormSection';
@@ -13,14 +13,16 @@ import logger from '../../utility/logger';
 
 const DEFAULT_COUNTRY = 'INDIA';
 const UDISE_LENGTH = 11;
-const INVALID_UDISE_MESSAGE =
-  'Please enter a valid 11-digit UDISE code (use leading zeros if required).';
+const INVALID_UDISE_MESSAGE = t(
+  'Please enter a valid 11-digit UDISE code (use leading zeros if required).',
+);
 
 const AddSchoolPage: React.FC = () => {
   const history = useHistory();
   const location = useLocation();
   const editData: any = location.state;
   const api = ServiceConfig.getI().apiHandler;
+  const latestUdiseValue = useRef('');
   const [loading, setLoading] = useState(true);
   const [schoolName, setSchoolName] = useState('');
   const [udise, setUdise] = useState('');
@@ -239,6 +241,7 @@ const AddSchoolPage: React.FC = () => {
 
   const handleUdiseChange = async (value: string) => {
     value = value.replace(/\D/g, '').slice(0, UDISE_LENGTH);
+    latestUdiseValue.current = value;
     setUdise(value);
 
     if (value && value.length < UDISE_LENGTH) {
@@ -251,11 +254,15 @@ const AddSchoolPage: React.FC = () => {
     if (value.length === UDISE_LENGTH) {
       try {
         const exist = await api.getSchoolDetailsByUdise(value);
+        if (latestUdiseValue.current !== value) return;
+
         if (exist && (!editData || editData.schoolData.udise !== value)) {
           setErrorMessage('A school with this UDISE code already exists.');
           return;
         }
         const res = await api.getSchoolDataByUdise(value);
+        if (latestUdiseValue.current !== value) return;
+
         if (res) {
           if (res.school_name) setSchoolName(res.school_name);
 

--- a/src/ops-console/pages/AddSchoolPage.tsx
+++ b/src/ops-console/pages/AddSchoolPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Breadcrumb from '../components/Breadcrumb';
 import { Box, Grid, Typography, FormLabel, TextField } from '@mui/material';
 import ContactFormSection from '../components/SchoolRequestComponents/ContactFormSection';
@@ -12,12 +12,18 @@ import DropdownField from '../components/DropdownField';
 import logger from '../../utility/logger';
 
 const DEFAULT_COUNTRY = 'INDIA';
+const UDISE_LENGTH = 11;
+const INVALID_UDISE_MESSAGE =
+  'Please enter a valid 11-digit UDISE code (use leading zeros if required).';
 
 const AddSchoolPage: React.FC = () => {
   const history = useHistory();
   const location = useLocation();
   const editData: any = location.state;
   const api = ServiceConfig.getI().apiHandler;
+  const udiseValidationTimer = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const [loading, setLoading] = useState(true);
   const [schoolName, setSchoolName] = useState('');
   const [udise, setUdise] = useState('');
@@ -218,7 +224,7 @@ const AddSchoolPage: React.FC = () => {
   const isSaveDisabled = () => {
     const isFormValid =
       !!schoolName &&
-      !!udise &&
+      udise.length === UDISE_LENGTH &&
       !!schoolModel &&
       !!address.state &&
       !!address.district &&
@@ -235,11 +241,21 @@ const AddSchoolPage: React.FC = () => {
   };
 
   const handleUdiseChange = async (value: string) => {
-    value = value.replace(/\D/g, '').slice(0, 11);
+    value = value.replace(/\D/g, '').slice(0, UDISE_LENGTH);
     setUdise(value);
+    if (udiseValidationTimer.current) {
+      clearTimeout(udiseValidationTimer.current);
+    }
     setErrorMessage('');
 
-    if (value.length === 11) {
+    if (value && value.length < UDISE_LENGTH) {
+      udiseValidationTimer.current = setTimeout(() => {
+        setErrorMessage(INVALID_UDISE_MESSAGE);
+      }, 1000);
+      return;
+    }
+
+    if (value.length === UDISE_LENGTH) {
       try {
         const exist = await api.getSchoolDetailsByUdise(value);
         if (exist && (!editData || editData.schoolData.udise !== value)) {
@@ -263,6 +279,14 @@ const AddSchoolPage: React.FC = () => {
       }
     }
   };
+
+  useEffect(() => {
+    return () => {
+      if (udiseValidationTimer.current) {
+        clearTimeout(udiseValidationTimer.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     async function init() {
@@ -361,6 +385,11 @@ const AddSchoolPage: React.FC = () => {
   }, [program]);
 
   async function handleApprove() {
+    if (udise.length !== UDISE_LENGTH) {
+      setErrorMessage(INVALID_UDISE_MESSAGE);
+      return;
+    }
+
     let keyContacts = contacts
       .map((c) => {
         const obj: any = {};


### PR DESCRIPTION
…rror

Add UDISE_LENGTH and INVALID_UDISE_MESSAGE constants and enforce exact 11-digit UDISE validation across the form. Sanitize UDISE input to digits only and limit to the defined length, show an error if shorter (including guidance about leading zeros), and defer the API lookup until the UDISE is valid. Also prevent saving or approving when the UDISE is not the required length.