### PR TITLE
refactor(ops-console): polish school listing labels, export styling, and mobile controls

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -163,6 +163,7 @@
   "Average Score": "Average Score",
   "Average time spent by active students in the last 7 days.": "Average time spent by active students in the last 7 days.",
   "Average Time Spent": "Average Time Spent",
+  "Avg Time Spent": "Avg Time Spent",
   "Avg Activities Completed": "Avg Activities Completed",
   "Avg Assignments Completed": "Avg Assignments Completed",
   "Avg week time in mins": "Avg week time in mins",

--- a/src/ops-console/components/DataTableBody.tsx
+++ b/src/ops-console/components/DataTableBody.tsx
@@ -33,7 +33,7 @@ const getHeaderLabelSx = (
     return {
       display: 'block',
       overflow: 'visible',
-      whiteSpace: 'normal',
+      whiteSpace: 'pre-line',
       lineHeight: 1.15,
       fontWeight: 700,
     } as const;

--- a/src/ops-console/components/DataTableBody.tsx
+++ b/src/ops-console/components/DataTableBody.tsx
@@ -19,6 +19,7 @@ export interface Column<T extends object> {
   key: keyof T | string;
   label: string;
   align?: 'left' | 'right' | 'center' | 'justify' | 'inherit';
+  headerAlign?: 'left' | 'center' | 'right';
   render?: (row: T) => React.ReactNode;
   width?: string | number;
   [key: string]: unknown;
@@ -260,65 +261,79 @@ function DataTableBodyInner<T extends object>(
                 />
               </TableCell>
             )}
-            {columns.map((col) => (
-              <TableCell
-                key={String(col.key)}
-                align={col.align || 'left'}
-                className="data-tablebody-head-cell"
-                sx={{
-                  width: col.width ?? 'auto',
-                  textAlign: headerAlign,
-                  transform: 'none',
-                  height: 'auto',
-                  paddingTop: {
-                    xs: '4px !important',
-                    sm: '6px !important',
-                    md: '8px !important',
-                  },
-                  paddingBottom: {
-                    xs: '4px !important',
-                    sm: '6px !important',
-                    md: '8px !important',
-                  },
-                  fontWeight: 700,
-                }}
-              >
-                {/* Sortable and non-sortable headers share the same wrapping rules. */}
-                {col.sortable === false ? (
-                  <span
-                    className="data-tablebody-head-label"
-                    style={getHeaderLabelSx(headerClampLines, headerNoEllipsis)}
-                  >
-                    {col.label}
-                  </span>
-                ) : (
-                  <TableSortLabel
-                    active={orderBy === String(col.key)}
-                    direction={orderBy === String(col.key) ? order : 'asc'}
-                    onClick={() => onSort(String(col.key))}
-                    sx={{
-                      fontWeight: 700,
-                      width: '100%',
-                      justifyContent:
-                        headerAlign === 'center'
-                          ? 'center'
-                          : headerAlign === 'right'
-                            ? 'flex-end'
-                            : 'flex-start',
-                      '& .MuiTableSortLabel-label': getHeaderLabelSx(
+            {columns.map((col) => {
+              const resolvedHeaderAlign = col.headerAlign ?? headerAlign;
+              return (
+                <TableCell
+                  key={String(col.key)}
+                  align={col.align || 'left'}
+                  className="data-tablebody-head-cell"
+                  sx={{
+                    width: col.width ?? 'auto',
+                    textAlign: resolvedHeaderAlign,
+                    transform: 'none',
+                    height: 'auto',
+                    paddingTop: {
+                      xs: '4px !important',
+                      sm: '6px !important',
+                      md: '8px !important',
+                    },
+                    paddingBottom: {
+                      xs: '4px !important',
+                      sm: '6px !important',
+                      md: '8px !important',
+                    },
+                    fontWeight: 700,
+                  }}
+                >
+                  {/* Sortable and non-sortable headers share the same wrapping rules. */}
+                  {col.sortable === false ? (
+                    <span
+                      className="data-tablebody-head-label"
+                      style={getHeaderLabelSx(
                         headerClampLines,
                         headerNoEllipsis,
-                      ),
-                      '& .MuiTableSortLabel-icon': {
-                        opacity: 1,
-                      },
-                    }}
-                  >
-                    {col.label}
-                  </TableSortLabel>
-                )}
-              </TableCell>
-            ))}
+                      )}
+                    >
+                      {col.label}
+                    </span>
+                  ) : (
+                    <TableSortLabel
+                      active={orderBy === String(col.key)}
+                      direction={orderBy === String(col.key) ? order : 'asc'}
+                      onClick={() => onSort(String(col.key))}
+                      sx={{
+                        color: '#121619 !important',
+                        fontWeight: 700,
+                        width: '100%',
+                        justifyContent:
+                          resolvedHeaderAlign === 'center'
+                            ? 'center'
+                            : resolvedHeaderAlign === 'right'
+                              ? 'flex-end'
+                              : 'flex-start',
+                        '&:hover': {
+                          color: '#121619 !important',
+                        },
+                        '& .MuiTableSortLabel-label': getHeaderLabelSx(
+                          headerClampLines,
+                          headerNoEllipsis,
+                        ),
+                        '& .MuiTableSortLabel-label, & .MuiTableSortLabel-icon':
+                          {
+                            color: '#121619 !important',
+                          },
+                        '& .MuiTableSortLabel-icon': {
+                          opacity: 1,
+                        },
+                      }}
+                    >
+                      {col.label}
+                    </TableSortLabel>
+                  )}
+                </TableCell>
+              );
+            })}
           </TableRow>
         </TableHead>
         {/* Show skeleton or actual rows */}

--- a/src/ops-console/components/SchoolListDateRangeDropdown.tsx
+++ b/src/ops-console/components/SchoolListDateRangeDropdown.tsx
@@ -24,8 +24,12 @@ const SchoolListDateRangeDropdown: React.FC<
 > = ({ value, onChange }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [isCloseShine, setIsCloseShine] = useState(false);
-  const closeShineTimeoutRef = useRef<number | null>(null);
-  const closeShineRafRef = useRef<number | null>(null);
+  const closeShineTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const closeShineRafRef = useRef<ReturnType<
+    typeof requestAnimationFrame
+  > | null>(null);
   const open = Boolean(anchorEl);
 
   const selectedLabel = useMemo(
@@ -37,16 +41,16 @@ const SchoolListDateRangeDropdown: React.FC<
     setIsCloseShine(false);
 
     if (closeShineRafRef.current !== null) {
-      window.cancelAnimationFrame(closeShineRafRef.current);
+      cancelAnimationFrame(closeShineRafRef.current);
     }
-    closeShineRafRef.current = window.requestAnimationFrame(() => {
+    closeShineRafRef.current = requestAnimationFrame(() => {
       setIsCloseShine(true);
     });
 
     if (closeShineTimeoutRef.current !== null) {
-      window.clearTimeout(closeShineTimeoutRef.current);
+      clearTimeout(closeShineTimeoutRef.current);
     }
-    closeShineTimeoutRef.current = window.setTimeout(() => {
+    closeShineTimeoutRef.current = setTimeout(() => {
       setIsCloseShine(false);
       closeShineTimeoutRef.current = null;
     }, 700);
@@ -64,10 +68,10 @@ const SchoolListDateRangeDropdown: React.FC<
   useEffect(() => {
     return () => {
       if (closeShineTimeoutRef.current !== null) {
-        window.clearTimeout(closeShineTimeoutRef.current);
+        clearTimeout(closeShineTimeoutRef.current);
       }
       if (closeShineRafRef.current !== null) {
-        window.cancelAnimationFrame(closeShineRafRef.current);
+        cancelAnimationFrame(closeShineRafRef.current);
       }
     };
   }, []);

--- a/src/ops-console/components/SchoolListDateRangeDropdown.tsx
+++ b/src/ops-console/components/SchoolListDateRangeDropdown.tsx
@@ -1,4 +1,10 @@
-import React, { useMemo, useState } from 'react';
+import React, {
+  useEffect,
+  useRef,
+  useState,
+  useMemo,
+  useCallback,
+} from 'react';
 import { Button, Divider, ListItemText, Menu, MenuItem } from '@mui/material';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { t } from 'i18next';
@@ -17,6 +23,9 @@ const SchoolListDateRangeDropdown: React.FC<
   SchoolListDateRangeDropdownProps
 > = ({ value, onChange }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [isCloseShine, setIsCloseShine] = useState(false);
+  const closeShineTimeoutRef = useRef<number | null>(null);
+  const closeShineRafRef = useRef<number | null>(null);
   const open = Boolean(anchorEl);
 
   const selectedLabel = useMemo(
@@ -24,7 +33,44 @@ const SchoolListDateRangeDropdown: React.FC<
     [value],
   );
 
-  const handleClose = () => setAnchorEl(null);
+  const triggerCloseShine = useCallback(() => {
+    setIsCloseShine(false);
+
+    if (closeShineRafRef.current !== null) {
+      window.cancelAnimationFrame(closeShineRafRef.current);
+    }
+    closeShineRafRef.current = window.requestAnimationFrame(() => {
+      setIsCloseShine(true);
+    });
+
+    if (closeShineTimeoutRef.current !== null) {
+      window.clearTimeout(closeShineTimeoutRef.current);
+    }
+    closeShineTimeoutRef.current = window.setTimeout(() => {
+      setIsCloseShine(false);
+      closeShineTimeoutRef.current = null;
+    }, 700);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setAnchorEl((currentAnchor) => {
+      if (currentAnchor) {
+        triggerCloseShine();
+      }
+      return null;
+    });
+  }, [triggerCloseShine]);
+
+  useEffect(() => {
+    return () => {
+      if (closeShineTimeoutRef.current !== null) {
+        window.clearTimeout(closeShineTimeoutRef.current);
+      }
+      if (closeShineRafRef.current !== null) {
+        window.cancelAnimationFrame(closeShineRafRef.current);
+      }
+    };
+  }, []);
 
   const handleSelect = (nextValue: DateRangeValue) => {
     handleClose();
@@ -36,8 +82,16 @@ const SchoolListDateRangeDropdown: React.FC<
       <Button
         variant="outlined"
         id="school-list-date-range-button"
-        className="school-list-actions-button school-list-date-range-button"
-        onClick={(event) => setAnchorEl(event.currentTarget)}
+        className={`school-list-actions-button school-list-date-range-button${
+          isCloseShine ? ' school-list-actions-button-close-shine' : ''
+        }`}
+        onClick={(event) => {
+          if (open) {
+            handleClose();
+            return;
+          }
+          setAnchorEl(event.currentTarget);
+        }}
         aria-controls={open ? 'school-list-date-range-menu' : undefined}
         aria-expanded={open ? 'true' : undefined}
         aria-haspopup="menu"
@@ -59,6 +113,7 @@ const SchoolListDateRangeDropdown: React.FC<
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
         PaperProps={{ className: 'school-list-actions-menu' }}
+        slotProps={{ list: { disablePadding: true } }}
       >
         {DATE_RANGE_OPTIONS.flatMap((option, index) => {
           const nodes = [

--- a/src/ops-console/pages/SchoolList.css
+++ b/src/ops-console/pages/SchoolList.css
@@ -374,19 +374,24 @@
 
   .school-list-date-range-button.MuiButton-root {
     white-space: nowrap;
+    padding-left: 4px !important;
+    padding-right: 4px !important;
   }
 
   .school-list-export-button.MuiButton-root {
     max-width: 102px;
-    padding: 4px 6px !important;
+    padding: 4px 4px !important;
   }
 
   .school-list-date-range-button.MuiButton-root .MuiButton-endIcon,
+  .school-list-date-range-button.MuiButton-root .MuiButton-startIcon,
+  .school-list-export-button.MuiButton-root .MuiButton-endIcon,
+  .school-list-export-button.MuiButton-root .MuiButton-startIcon,
   .school-list-actions-group
     .school-list-actions-button.MuiButton-root
     .MuiButton-endIcon,
   .school-list-export-button.MuiButton-root .MuiButton-startIcon {
-    margin-left: 4px;
+    margin-left: 2px;
     margin-right: 0;
   }
 

--- a/src/ops-console/pages/SchoolList.css
+++ b/src/ops-console/pages/SchoolList.css
@@ -260,10 +260,6 @@
   box-sizing: border-box;
 }
 
-.school-list-table-container .data-tablebody-cell:first-child {
-  box-shadow: 8px 0 12px -12px rgba(18, 22, 25, 0.35);
-}
-
 @media (max-width: 768px) {
   /* Mobile keeps a fixed name column while every metric column remains individually scrollable. */
   .school-list-table-container .data-tablebody-head-cell:not(:first-child),

--- a/src/ops-console/pages/SchoolList.export.test.ts
+++ b/src/ops-console/pages/SchoolList.export.test.ts
@@ -33,7 +33,7 @@ describe('buildSchoolListExportSheetRows', () => {
         'Activated Students',
         'Active Students',
         'Active Students',
-        'Average Time Spent',
+        'Avg Time Spent',
         'Active Teachers',
         'Active Teachers',
         'Activities Assigned',

--- a/src/ops-console/pages/SchoolList.helpers.tsx
+++ b/src/ops-console/pages/SchoolList.helpers.tsx
@@ -98,6 +98,7 @@ export const getSchoolListColumns = (): Column<SchoolListRow>[] => [
     key: 'name',
     label: t('School Name'),
     width: '20%',
+    headerAlign: 'left',
     sortable: true,
     orderBy: 'name',
   },

--- a/src/ops-console/pages/SchoolList.helpers.tsx
+++ b/src/ops-console/pages/SchoolList.helpers.tsx
@@ -134,7 +134,7 @@ export const getSchoolListColumns = (): Column<SchoolListRow>[] => [
   },
   {
     key: 'avgTimeSpent',
-    label: t('Average Time Spent'),
+    label: t('Avg Time Spent'),
     width: '7.78%',
     align: 'center',
     sortable: false,
@@ -191,7 +191,7 @@ export const getSchoolListExportColumns = (): SchoolListExportColumn[] => [
   },
   { key: 'activeStudents', label: t('Active Students'), part: 'value' },
   { key: 'activeStudents', label: t('Active Students'), part: 'percent' },
-  { key: 'avgTimeSpent', label: t('Average Time Spent'), part: 'value' },
+  { key: 'avgTimeSpent', label: t('Avg Time Spent'), part: 'value' },
   { key: 'activeTeachers', label: t('Active Teachers'), part: 'value' },
   { key: 'activeTeachers', label: t('Active Teachers'), part: 'percent' },
   {

--- a/src/ops-console/pages/SchoolList.test.tsx
+++ b/src/ops-console/pages/SchoolList.test.tsx
@@ -385,7 +385,7 @@ describe('SchoolList export', () => {
               'Activated Students',
               'Active Students',
               'Active Students',
-              'Average Time Spent',
+              'Avg Time Spent',
               'Active Teachers',
               'Active Teachers',
               'Activities Assigned',

--- a/src/ops-console/pages/SchoolListRowRenderer.tsx
+++ b/src/ops-console/pages/SchoolListRowRenderer.tsx
@@ -57,7 +57,9 @@ export const mapSchoolRowsToRenderRows = (
         exportPercentText: '',
         render: (
           <Box display="flex" flexDirection="column" alignItems="flex-start">
-            <Typography variant="subtitle2">{school.school_name}</Typography>
+            <Typography variant="subtitle2" fontWeight={700}>
+              {school.school_name}
+            </Typography>
             {udiseLocation && (
               <Typography
                 variant="subtitle2"

--- a/src/ops-console/pages/SchoolListRowRenderer.tsx
+++ b/src/ops-console/pages/SchoolListRowRenderer.tsx
@@ -57,7 +57,7 @@ export const mapSchoolRowsToRenderRows = (
         exportPercentText: '',
         render: (
           <Box display="flex" flexDirection="column" alignItems="flex-start">
-            <Typography variant="subtitle2" fontWeight={700}>
+            <Typography variant="subtitle2" fontWeight={700} color="#121619">
               {school.school_name}
             </Typography>
             {udiseLocation && (

--- a/src/ops-console/pages/useSchoolListExport.ts
+++ b/src/ops-console/pages/useSchoolListExport.ts
@@ -164,8 +164,8 @@ const applyHeaderRowFormatting = (
       },
       fill: {
         patternType: 'solid',
-        fgColor: { rgb: '1976D2' },
-        bgColor: { rgb: '1976D2' },
+        fgColor: { rgb: '1A71F6' },
+        bgColor: { rgb: '1A71F6' },
       },
       alignment: {
         ...(cell.s?.alignment ?? {}),

--- a/src/workers/background.worker.ts
+++ b/src/workers/background.worker.ts
@@ -657,8 +657,8 @@ const buildXlsxFile = async (
           },
           fill: {
             patternType: 'solid',
-            fgColor: { rgb: '1976D2' },
-            bgColor: { rgb: '1976D2' },
+            fgColor: { rgb: '1A71F6' },
+            bgColor: { rgb: '1A71F6' },
           },
           alignment: {
             ...(cell.s?.alignment ?? {}),


### PR DESCRIPTION
- Renamed Average Time Spent to Avg Time Spent in the school listing and aligned the English translation and tests.
- Improved school export formatting by updating header colors, tightening header layout, and keeping export generation consistent across main-thread and worker paths.
- Adjusted School Listing UI polish with bold school-name cells, mobile button spacing fixes for export/date-range controls, removed dropdown menu list padding, and added the close-shine effect to the date-range dropdown button.