### PR TITLE
fix: Unable to copy content from Ops Console

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -234,8 +234,6 @@ const App: React.FC = () => {
   useEffect(() => {
     // this event listener is to remove the highlighted text(if exists) on a click
     const handleClick = () => {
-      if (document.body.classList.contains('ops-console')) return;
-
       const sel = window.getSelection();
       if (sel && !sel.isCollapsed) {
         sel.removeAllRanges();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -234,6 +234,8 @@ const App: React.FC = () => {
   useEffect(() => {
     // this event listener is to remove the highlighted text(if exists) on a click
     const handleClick = () => {
+      if (document.body.classList.contains('ops-console')) return;
+
       const sel = window.getSelection();
       if (sel && !sel.isCollapsed) {
         sel.removeAllRanges();

--- a/src/ops-console/pages/SidebarPage.tsx
+++ b/src/ops-console/pages/SidebarPage.tsx
@@ -105,9 +105,16 @@ const SidebarPage: React.FC = () => {
     }
   };
 
+  const preserveSelectedText = (event: React.MouseEvent<HTMLDivElement>) => {
+    const selection = window.getSelection();
+    if (selection && !selection.isCollapsed) {
+      event.stopPropagation();
+    }
+  };
+
   return (
     <IonPage>
-      <div className="sidebarpage-rightSide">
+      <div className="sidebarpage-rightSide" onClick={preserveSelectedText}>
         <Sidebar
           name={currentUser?.name || ''}
           email={currentUser?.email || ''}


### PR DESCRIPTION
Add an early return in the click handler inside App.tsx so that if document.body contains the 'ops-console' class, the handler does not remove the user's text selection. 
 This preserves highlighted text when the app is running in the ops-console context.