### PR TITLE
feat(CHIM-888): Implement Local Persistence for Sticker Book Painting State

### DIFF
--- a/src/components/coloring/ColoringBoard.test.tsx
+++ b/src/components/coloring/ColoringBoard.test.tsx
@@ -51,6 +51,10 @@ jest.mock('@capacitor/app', () => ({
   },
 }));
 
+jest.mock('@growthbook/growthbook-react', () => ({
+  useFeatureIsOn: jest.fn(() => true),
+}));
+
 /* -------------------- MOCK UTIL -------------------- */
 
 jest.mock('../../utility/util', () => ({
@@ -96,6 +100,33 @@ jest.mock('./SVGScene', () => ({
 jest.mock('./ColorPalette', () => (props: any) => (
   <div data-testid="color-palette">ColorPalette</div>
 ));
+
+type StickerBookActionsMockProps = {
+  showPaint: boolean;
+  onSave: () => void;
+  onPaint: () => void;
+};
+
+jest.mock(
+  '../stickerBook/StickerBookActions',
+  () => (props: StickerBookActionsMockProps) => (
+    <div
+      data-testid="sticker-book-actions"
+      id="sticker-book-actions-root"
+      className="StickerBookActions-root"
+    >
+      <button type="button" onClick={props.onSave}>
+        <img src="camera.svg" alt="Save" />
+        Save
+      </button>
+      {props.showPaint ? (
+        <button type="button" onClick={props.onPaint}>
+          Paint
+        </button>
+      ) : null}
+    </div>
+  ),
+);
 
 jest.mock('./PaintTopBar', () => (props: any) => (
   <button data-testid="exit-btn" onClick={props.onExit}>

--- a/src/components/coloring/ColoringBoard.test.tsx
+++ b/src/components/coloring/ColoringBoard.test.tsx
@@ -260,6 +260,16 @@ const getLastToastProps = () => {
   return calls[calls.length - 1][0];
 };
 
+const createDeferred = () => {
+  let resolve!: () => void;
+
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
+};
+
 /* ===================================================== */
 /* ======================= TESTS ======================= */
 /* ===================================================== */
@@ -449,6 +459,89 @@ describe('ColoringBoard', () => {
         'student1',
         'book-1',
         expect.stringContaining('<svg'),
+      );
+    });
+  });
+
+  test('keeps queued saves tied to the sticker book that queued them', async () => {
+    jest.useFakeTimers();
+
+    mockParseSvg.mockImplementation((markup: string) => ({
+      attrs: {},
+      inner: markup.replace(/^<svg[^>]*>/, '').replace(/<\/svg>$/, ''),
+    }));
+
+    const firstSave = createDeferred();
+    (savePaintedStickerBook as jest.Mock)
+      .mockImplementationOnce(() => firstSave.promise)
+      .mockResolvedValueOnce(undefined);
+
+    const view = renderBoard({
+      stickerBookId: 'book-1',
+      svgRaw: '<svg><rect id="book-1" /></svg>',
+    });
+
+    await screen.findByTestId('svg-scene');
+
+    mockColoringState = {
+      ...mockColoringState,
+      coloredRegions: { region1: '#ff0000' },
+    };
+
+    view.rerender(<ColoringBoard />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(savePaintedStickerBook).toHaveBeenNthCalledWith(
+        1,
+        'student1',
+        'book-1',
+        expect.stringContaining('book-1'),
+      );
+    });
+
+    mockColoringState = {
+      ...mockColoringState,
+      coloredRegions: {},
+    };
+    mockLocation.state = {
+      stickerBookId: 'book-2',
+      svgRaw: '<svg><circle id="book-2" /></svg>',
+    };
+
+    view.rerender(<ColoringBoard />);
+
+    await waitFor(() => {
+      expect(loadPaintedStickerBook).toHaveBeenCalledWith('student1', 'book-2');
+    });
+
+    mockColoringState = {
+      ...mockColoringState,
+      coloredRegions: { region2: '#00ff00' },
+    };
+
+    view.rerender(<ColoringBoard />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(savePaintedStickerBook).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      firstSave.resolve();
+      await firstSave.promise;
+    });
+
+    await waitFor(() => {
+      expect(savePaintedStickerBook).toHaveBeenNthCalledWith(
+        2,
+        'student1',
+        'book-2',
+        expect.stringContaining('book-2'),
       );
     });
   });

--- a/src/components/coloring/ColoringBoard.test.tsx
+++ b/src/components/coloring/ColoringBoard.test.tsx
@@ -10,6 +10,11 @@ import {
 import '@testing-library/jest-dom';
 import ColoringBoard from './ColoringBoard';
 import { Util } from '../../utility/util';
+import { App } from '@capacitor/app';
+import {
+  loadPaintedStickerBook,
+  savePaintedStickerBook,
+} from '../../utility/stickerBookPaintStorage';
 
 /* -------------------- MOCK SVG -------------------- */
 
@@ -36,6 +41,14 @@ jest.mock('react-router-dom', () => ({
     goBack: mockGoBack,
   }),
   useLocation: () => mockLocation,
+}));
+
+jest.mock('@capacitor/app', () => ({
+  App: {
+    addListener: jest.fn(() => ({
+      remove: jest.fn(),
+    })),
+  },
 }));
 
 /* -------------------- MOCK UTIL -------------------- */
@@ -102,11 +115,20 @@ jest.mock(
     ) : null,
 );
 
+let mockColoringState = {
+  selectedColor: '#000',
+  setSelectedColor: jest.fn(),
+  coloredRegions: {} as Record<string, string>,
+};
+
 jest.mock('./useSvgColoring', () => ({
-  useSvgColoring: () => ({
-    selectedColor: '#000',
-    setSelectedColor: jest.fn(),
-  }),
+  useSvgColoring: () => mockColoringState,
+}));
+
+jest.mock('../../utility/stickerBookPaintStorage', () => ({
+  loadPaintedStickerBook: jest.fn(),
+  savePaintedStickerBook: jest.fn(),
+  deletePaintedStickerBook: jest.fn(),
 }));
 
 const mockSaveModal = jest.fn();
@@ -214,6 +236,7 @@ const getLastToastProps = () => {
 describe('ColoringBoard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useRealTimers();
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       text: () => Promise.resolve('<svg></svg>'),
@@ -253,6 +276,13 @@ describe('ColoringBoard', () => {
       handleSaveAndShare: mockHandleSaveAndShare,
     };
     lastUseStickerBookSaveOptions = null;
+    mockColoringState = {
+      selectedColor: '#000',
+      setSelectedColor: jest.fn(),
+      coloredRegions: {},
+    };
+    (loadPaintedStickerBook as jest.Mock).mockResolvedValue(null);
+    (savePaintedStickerBook as jest.Mock).mockResolvedValue(undefined);
 
     mockParseSvg.mockReturnValue({
       attrs: {},
@@ -290,6 +320,28 @@ describe('ColoringBoard', () => {
     });
   });
 
+  test('restores persisted svg before route state svg', async () => {
+    (loadPaintedStickerBook as jest.Mock).mockResolvedValueOnce(
+      '<svg><rect width="12" height="12" /></svg>',
+    );
+
+    renderBoard({
+      stickerBookId: 'book-1',
+      svgRaw: '<svg><circle /></svg>',
+      svgUrl: '/test.svg',
+    });
+
+    await waitFor(() => {
+      expect(loadPaintedStickerBook).toHaveBeenCalledWith('student1', 'book-1');
+    });
+
+    expect(fetch).not.toHaveBeenCalledWith('/test.svg');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('svg-scene')).toBeInTheDocument();
+    });
+  });
+
   /* ---------------- SVG URL FETCH ---------------- */
 
   test('fetches svg when svgUrl provided', async () => {
@@ -304,6 +356,94 @@ describe('ColoringBoard', () => {
     await waitFor(() => {
       expect(screen.getByTestId('svg-scene')).toBeInTheDocument();
     });
+  });
+
+  test('debounced autosave persists painted svg for a sticker book', async () => {
+    jest.useFakeTimers();
+
+    const view = renderBoard({
+      stickerBookId: 'book-1',
+      svgRaw: '<svg></svg>',
+    });
+
+    await screen.findByTestId('svg-scene');
+
+    mockColoringState = {
+      ...mockColoringState,
+      coloredRegions: { region1: '#ff0000' },
+    };
+
+    view.rerender(<ColoringBoard />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(savePaintedStickerBook).toHaveBeenCalledWith(
+        'student1',
+        'book-1',
+        expect.stringContaining('<svg'),
+      );
+    });
+  });
+
+  test('flushes painted svg when the app backgrounds', async () => {
+    const view = renderBoard({
+      stickerBookId: 'book-1',
+      svgRaw: '<svg></svg>',
+    });
+
+    await screen.findByTestId('svg-scene');
+
+    mockColoringState = {
+      ...mockColoringState,
+      coloredRegions: { region1: '#00ff00' },
+    };
+
+    view.rerender(<ColoringBoard />);
+
+    const appStateChangeHandler = (
+      App.addListener as jest.Mock
+    ).mock.calls.find(([eventName]) => eventName === 'appStateChange')?.[1];
+
+    expect(appStateChangeHandler).toEqual(expect.any(Function));
+
+    await act(async () => {
+      await appStateChangeHandler?.({ isActive: false });
+    });
+
+    await waitFor(() => {
+      expect(savePaintedStickerBook).toHaveBeenCalledWith(
+        'student1',
+        'book-1',
+        expect.stringContaining('<svg'),
+      );
+    });
+  });
+
+  test('does not persist when stickerBookId is missing', async () => {
+    jest.useFakeTimers();
+
+    const view = renderBoard({
+      svgRaw: '<svg></svg>',
+    });
+
+    await screen.findByTestId('svg-scene');
+
+    mockColoringState = {
+      ...mockColoringState,
+      coloredRegions: { region1: '#123456' },
+    };
+
+    view.rerender(<ColoringBoard />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(savePaintedStickerBook).not.toHaveBeenCalled();
+    expect(loadPaintedStickerBook).not.toHaveBeenCalled();
   });
 
   /* ---------------- EMPTY STATE ---------------- */
@@ -354,7 +494,7 @@ describe('ColoringBoard', () => {
 
   /* ---------------- EXIT CONFIRM WITH RETURN ---------------- */
 
-  test('exit confirm navigates using replace when returnTo exists', () => {
+  test('exit confirm navigates using replace when returnTo exists', async () => {
     renderBoard({
       returnTo: '/home',
     });
@@ -363,19 +503,23 @@ describe('ColoringBoard', () => {
 
     fireEvent.click(screen.getByText('confirm-exit'));
 
-    expect(mockReplace).toHaveBeenCalledWith('/home');
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/home');
+    });
   });
 
   /* ---------------- EXIT CONFIRM WITHOUT RETURN ---------------- */
 
-  test('exit confirm uses goBack when returnTo missing', () => {
+  test('exit confirm uses goBack when returnTo missing', async () => {
     renderBoard();
 
     fireEvent.click(screen.getByTestId('exit-btn'));
 
     fireEvent.click(screen.getByText('confirm-exit'));
 
-    expect(mockGoBack).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockGoBack).toHaveBeenCalled();
+    });
   });
   /* ---------------- COLOR TRAY ---------------- */
 
@@ -567,18 +711,20 @@ describe('ColoringBoard', () => {
 
   /* ---------------- EXIT WITHOUT STATE ---------------- */
 
-  test('exit works without location state', () => {
+  test('exit works without location state', async () => {
     renderBoard();
 
     fireEvent.click(screen.getByTestId('exit-btn'));
     fireEvent.click(screen.getByText('confirm-exit'));
 
-    expect(mockGoBack).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockGoBack).toHaveBeenCalled();
+    });
   });
 
   /* ---------------- EXIT WITH RETURN PATH ---------------- */
 
-  test('exit replaces path when returnTo provided', () => {
+  test('exit replaces path when returnTo provided', async () => {
     renderBoard({
       returnTo: '/dashboard',
     });
@@ -586,7 +732,9 @@ describe('ColoringBoard', () => {
     fireEvent.click(screen.getByTestId('exit-btn'));
     fireEvent.click(screen.getByText('confirm-exit'));
 
-    expect(mockReplace).toHaveBeenCalledWith('/dashboard');
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/dashboard');
+    });
   });
 
   /* ---------------- CAMERA ICON ALT TEXT ---------------- */

--- a/src/components/coloring/ColoringBoard.tsx
+++ b/src/components/coloring/ColoringBoard.tsx
@@ -1,6 +1,13 @@
 import './ColoringBoard.css';
 // Changes: added unique ids, prefixed svg frame class, localized UI strings.
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { App } from '@capacitor/app';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useSvgColoring } from './useSvgColoring';
 import { SVGScene } from './SVGScene';
@@ -10,15 +17,27 @@ import PaintTopBar from './PaintTopBar';
 import logger from '../../utility/logger';
 import { parseSvg, ParsedSvg, sanitizeSvg } from '../common/SvgHelpers';
 import { Util } from '../../utility/util';
-import { EVENTS, PAGES } from '../../common/constants';
+import {
+  ENABLE_SAVE_AND_SHARE_STICKER_BOOK,
+  EVENTS,
+  PAGES,
+} from '../../common/constants';
 import PaintExitPopup from './PaintExitPopup';
 import { t } from 'i18next';
 import StickerBookActions from '../stickerBook/StickerBookActions';
 import StickerBookSaveModal from '../stickerBook/StickerBookSaveModal';
 import StickerBookToast from '../stickerBook/StickerBookToast';
 import { useStickerBookSave } from '../../hooks/useStickerBookSave';
+import {
+  loadPaintedStickerBook,
+  savePaintedStickerBook,
+} from '../../utility/stickerBookPaintStorage';
+import { useFeatureIsOn } from '@growthbook/growthbook-react';
+
+const AUTOSAVE_DEBOUNCE_MS = 1000;
 
 type ColoringBoardRouteState = {
+  stickerBookId?: string;
   svgUrl?: string;
   svgRaw?: string;
   artworkTitle?: string;
@@ -70,8 +89,21 @@ const ColoringBoard: React.FC = () => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [showExitConfirm, setShowExitConfirm] = useState<boolean>(false);
   const [hasSavedArtwork, setHasSavedArtwork] = useState<boolean>(false);
+  const autosaveTimeoutRef = useRef<number | null>(null);
+  const isSaveInFlightRef = useRef(false);
+  const pendingSerializedSvgRef = useRef<string | null>(null);
+  const saveQueuePromiseRef = useRef<Promise<void> | null>(null);
+  const hasPaintChangesRef = useRef(false);
+  const hasHydratedPersistenceRef = useRef(false);
+  const lastPersistedSvgRef = useRef<string | null>(null);
+  const isStickerBookSaveEnabled: boolean = useFeatureIsOn(
+    ENABLE_SAVE_AND_SHARE_STICKER_BOOK,
+  );
 
   const parsedSvg = useMemo(() => parseSvg(svgMarkup), [svgMarkup]);
+  const currentStudentId = Util.getCurrentStudent()?.id ?? null;
+  const stickerBookId = location.state?.stickerBookId ?? null;
+  const canPersistPaintState = !!currentStudentId && !!stickerBookId;
   const toastText = t(
     'Yay! Your creation is saved, share it with your family & friends!',
   );
@@ -108,6 +140,88 @@ const ColoringBoard: React.FC = () => {
     },
   });
 
+  const serializeLiveSvg = useCallback(() => {
+    const svgEl = svgRef.current;
+    if (!svgEl) return null;
+
+    const coloringSvg = svgEl.cloneNode(true) as SVGSVGElement;
+    return new XMLSerializer().serializeToString(coloringSvg);
+  }, []);
+
+  const drainPaintSaveQueue = useCallback(async () => {
+    if (!canPersistPaintState || !currentStudentId || !stickerBookId) return;
+    if (isSaveInFlightRef.current)
+      return saveQueuePromiseRef.current ?? undefined;
+
+    const processQueue = async () => {
+      while (pendingSerializedSvgRef.current) {
+        const nextSerializedSvg = pendingSerializedSvgRef.current;
+        pendingSerializedSvgRef.current = null;
+
+        if (
+          !nextSerializedSvg ||
+          nextSerializedSvg === lastPersistedSvgRef.current
+        ) {
+          continue;
+        }
+
+        isSaveInFlightRef.current = true;
+
+        try {
+          await savePaintedStickerBook(
+            currentStudentId,
+            stickerBookId,
+            nextSerializedSvg,
+          );
+          lastPersistedSvgRef.current = nextSerializedSvg;
+          hasPaintChangesRef.current = false;
+        } catch (error) {
+          logger.warn(
+            '[StickerBookPaint] Failed to persist painted sticker book.',
+            {
+              error,
+              userId: currentStudentId,
+              stickerBookId,
+            },
+          );
+        } finally {
+          isSaveInFlightRef.current = false;
+        }
+      }
+    };
+
+    const savePromise = processQueue().finally(() => {
+      saveQueuePromiseRef.current = null;
+    });
+
+    saveQueuePromiseRef.current = savePromise;
+    return savePromise;
+  }, [canPersistPaintState, currentStudentId, stickerBookId]);
+
+  const queuePaintSave = useCallback(
+    async (serializedSvg: string | null) => {
+      if (!serializedSvg || !canPersistPaintState) return;
+
+      pendingSerializedSvgRef.current = serializedSvg;
+      await drainPaintSaveQueue();
+    },
+    [canPersistPaintState, drainPaintSaveQueue],
+  );
+
+  const flushPaintSave = useCallback(async () => {
+    if (!canPersistPaintState || !hasPaintChangesRef.current) return;
+
+    const serializedSvg = serializeLiveSvg();
+    if (!serializedSvg) return;
+
+    if (autosaveTimeoutRef.current !== null) {
+      window.clearTimeout(autosaveTimeoutRef.current);
+      autosaveTimeoutRef.current = null;
+    }
+
+    await queuePaintSave(serializedSvg);
+  }, [canPersistPaintState, queuePaintSave, serializeLiveSvg]);
+
   useEffect(() => {
     let mounted = true;
     const state = location.state;
@@ -115,7 +229,26 @@ const ColoringBoard: React.FC = () => {
     const loadSvg = async () => {
       setIsLoading(true);
       try {
+        if (canPersistPaintState && currentStudentId && stickerBookId) {
+          const persistedSvg = await loadPaintedStickerBook(
+            currentStudentId,
+            stickerBookId,
+          );
+
+          if (persistedSvg) {
+            lastPersistedSvgRef.current = persistedSvg;
+            hasHydratedPersistenceRef.current = true;
+            hasPaintChangesRef.current = false;
+
+            if (mounted) setSvgMarkup(persistedSvg);
+            return;
+          }
+        }
+
         if (state?.svgRaw) {
+          lastPersistedSvgRef.current = state.svgRaw;
+          hasHydratedPersistenceRef.current = true;
+          hasPaintChangesRef.current = false;
           if (mounted) setSvgMarkup(state.svgRaw);
           return;
         }
@@ -126,6 +259,9 @@ const ColoringBoard: React.FC = () => {
             throw new Error(`Failed to fetch svg: ${res.status}`);
           }
           const text = await res.text();
+          lastPersistedSvgRef.current = text;
+          hasHydratedPersistenceRef.current = true;
+          hasPaintChangesRef.current = false;
           if (mounted) setSvgMarkup(text);
           return;
         }
@@ -141,7 +277,7 @@ const ColoringBoard: React.FC = () => {
     return () => {
       mounted = false;
     };
-  }, [location.state]);
+  }, [canPersistPaintState, currentStudentId, location.state, stickerBookId]);
 
   useEffect(() => {
     Util.logEvent(EVENTS.PAINT_MODE_PAGE_VIEW, {
@@ -151,7 +287,69 @@ const ColoringBoard: React.FC = () => {
     });
   }, [location.state]);
 
-  const handleExit = () => {
+  useEffect(() => {
+    if (!canPersistPaintState || !hasHydratedPersistenceRef.current) return;
+    if (!Object.keys(coloring.coloredRegions).length) return;
+
+    hasPaintChangesRef.current = true;
+
+    if (autosaveTimeoutRef.current !== null) {
+      window.clearTimeout(autosaveTimeoutRef.current);
+    }
+
+    autosaveTimeoutRef.current = window.setTimeout(() => {
+      autosaveTimeoutRef.current = null;
+      void flushPaintSave();
+    }, AUTOSAVE_DEBOUNCE_MS);
+  }, [canPersistPaintState, coloring.coloredRegions, flushPaintSave]);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        void flushPaintSave();
+      }
+    };
+
+    const handlePageHide = () => {
+      void flushPaintSave();
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('pagehide', handlePageHide);
+
+    const appStateListener = App.addListener(
+      'appStateChange',
+      ({ isActive }) => {
+        if (!isActive) {
+          void flushPaintSave();
+        }
+      },
+    );
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('pagehide', handlePageHide);
+
+      void Promise.resolve(appStateListener).then((listener) =>
+        listener?.remove?.(),
+      );
+    };
+  }, [flushPaintSave]);
+
+  useEffect(() => {
+    return () => {
+      if (autosaveTimeoutRef.current !== null) {
+        window.clearTimeout(autosaveTimeoutRef.current);
+        autosaveTimeoutRef.current = null;
+      }
+
+      void flushPaintSave();
+    };
+  }, [flushPaintSave]);
+
+  const handleExit = async () => {
+    await flushPaintSave();
+
     const returnTo = location.state?.returnTo;
     if (returnTo) {
       history.replace(returnTo);
@@ -178,11 +376,10 @@ const ColoringBoard: React.FC = () => {
     });
     logger.info('save');
 
-    const svgEl = svgRef.current;
-    if (!svgEl) return;
+    const serializedSvg = serializeLiveSvg();
+    if (!serializedSvg) return;
 
-    const coloringSvg = svgEl.cloneNode(true);
-    openSaveModal(new XMLSerializer().serializeToString(coloringSvg));
+    openSaveModal(serializedSvg);
   };
 
   return (
@@ -251,7 +448,7 @@ const ColoringBoard: React.FC = () => {
           onSave={handleSave}
           onPaint={() => {}}
           paintDisabled={true}
-          canSave={true}
+          canSave={isStickerBookSaveEnabled}
         />
 
         <div id="coloring-board-tray" className="coloring-board-tray">
@@ -284,7 +481,7 @@ const ColoringBoard: React.FC = () => {
             user_id: Util.getCurrentStudent()?.id ?? null,
             page_path: window.location.pathname,
           });
-          handleExit();
+          void handleExit();
         }}
       />
       <StickerBookSaveModal

--- a/src/components/coloring/ColoringBoard.tsx
+++ b/src/components/coloring/ColoringBoard.tsx
@@ -45,6 +45,12 @@ type ColoringBoardRouteState = {
   returnTo?: string;
 };
 
+type PaintSavePayload = {
+  serializedSvg: string;
+  studentId: string;
+  stickerBookId: string;
+};
+
 const InlineSvg = React.forwardRef<
   SVGSVGElement,
   { svg: ParsedSvg; className?: string }
@@ -91,11 +97,11 @@ const ColoringBoard: React.FC = () => {
   const [hasSavedArtwork, setHasSavedArtwork] = useState<boolean>(false);
   const autosaveTimeoutRef = useRef<number | null>(null);
   const isSaveInFlightRef = useRef(false);
-  const pendingSerializedSvgRef = useRef<string | null>(null);
+  const pendingPaintSaveRef = useRef<PaintSavePayload | null>(null);
   const saveQueuePromiseRef = useRef<Promise<void> | null>(null);
   const hasPaintChangesRef = useRef(false);
   const hasHydratedPersistenceRef = useRef(false);
-  const lastPersistedSvgRef = useRef<string | null>(null);
+  const lastPersistedPaintSaveRef = useRef<PaintSavePayload | null>(null);
   const isStickerBookSaveEnabled: boolean = useFeatureIsOn(
     ENABLE_SAVE_AND_SHARE_STICKER_BOOK,
   );
@@ -149,19 +155,25 @@ const ColoringBoard: React.FC = () => {
   }, []);
 
   const drainPaintSaveQueue = useCallback(async () => {
-    if (!canPersistPaintState || !currentStudentId || !stickerBookId) return;
     if (isSaveInFlightRef.current)
       return saveQueuePromiseRef.current ?? undefined;
+    if (!pendingPaintSaveRef.current) return;
 
     const processQueue = async () => {
-      while (pendingSerializedSvgRef.current) {
-        const nextSerializedSvg = pendingSerializedSvgRef.current;
-        pendingSerializedSvgRef.current = null;
+      while (pendingPaintSaveRef.current) {
+        const nextPaintSave = pendingPaintSaveRef.current;
+        pendingPaintSaveRef.current = null;
 
-        if (
-          !nextSerializedSvg ||
-          nextSerializedSvg === lastPersistedSvgRef.current
-        ) {
+        const isDuplicateSave =
+          !!lastPersistedPaintSaveRef.current &&
+          nextPaintSave.studentId ===
+            lastPersistedPaintSaveRef.current.studentId &&
+          nextPaintSave.stickerBookId ===
+            lastPersistedPaintSaveRef.current.stickerBookId &&
+          nextPaintSave.serializedSvg ===
+            lastPersistedPaintSaveRef.current.serializedSvg;
+
+        if (isDuplicateSave) {
           continue;
         }
 
@@ -169,19 +181,19 @@ const ColoringBoard: React.FC = () => {
 
         try {
           await savePaintedStickerBook(
-            currentStudentId,
-            stickerBookId,
-            nextSerializedSvg,
+            nextPaintSave.studentId,
+            nextPaintSave.stickerBookId,
+            nextPaintSave.serializedSvg,
           );
-          lastPersistedSvgRef.current = nextSerializedSvg;
+          lastPersistedPaintSaveRef.current = nextPaintSave;
           hasPaintChangesRef.current = false;
         } catch (error) {
           logger.warn(
             '[StickerBookPaint] Failed to persist painted sticker book.',
             {
               error,
-              userId: currentStudentId,
-              stickerBookId,
+              userId: nextPaintSave.studentId,
+              stickerBookId: nextPaintSave.stickerBookId,
             },
           );
         } finally {
@@ -196,16 +208,20 @@ const ColoringBoard: React.FC = () => {
 
     saveQueuePromiseRef.current = savePromise;
     return savePromise;
-  }, [canPersistPaintState, currentStudentId, stickerBookId]);
+  }, []);
 
   const queuePaintSave = useCallback(
     async (serializedSvg: string | null) => {
-      if (!serializedSvg || !canPersistPaintState) return;
+      if (!serializedSvg || !currentStudentId || !stickerBookId) return;
 
-      pendingSerializedSvgRef.current = serializedSvg;
+      pendingPaintSaveRef.current = {
+        serializedSvg,
+        studentId: currentStudentId,
+        stickerBookId,
+      };
       await drainPaintSaveQueue();
     },
-    [canPersistPaintState, drainPaintSaveQueue],
+    [currentStudentId, drainPaintSaveQueue, stickerBookId],
   );
 
   const flushPaintSave = useCallback(async () => {
@@ -236,7 +252,11 @@ const ColoringBoard: React.FC = () => {
           );
 
           if (persistedSvg) {
-            lastPersistedSvgRef.current = persistedSvg;
+            lastPersistedPaintSaveRef.current = {
+              serializedSvg: persistedSvg,
+              studentId: currentStudentId,
+              stickerBookId,
+            };
             hasHydratedPersistenceRef.current = true;
             hasPaintChangesRef.current = false;
 
@@ -246,7 +266,14 @@ const ColoringBoard: React.FC = () => {
         }
 
         if (state?.svgRaw) {
-          lastPersistedSvgRef.current = state.svgRaw;
+          lastPersistedPaintSaveRef.current =
+            currentStudentId && stickerBookId
+              ? {
+                  serializedSvg: state.svgRaw,
+                  studentId: currentStudentId,
+                  stickerBookId,
+                }
+              : null;
           hasHydratedPersistenceRef.current = true;
           hasPaintChangesRef.current = false;
           if (mounted) setSvgMarkup(state.svgRaw);
@@ -259,7 +286,14 @@ const ColoringBoard: React.FC = () => {
             throw new Error(`Failed to fetch svg: ${res.status}`);
           }
           const text = await res.text();
-          lastPersistedSvgRef.current = text;
+          lastPersistedPaintSaveRef.current =
+            currentStudentId && stickerBookId
+              ? {
+                  serializedSvg: text,
+                  studentId: currentStudentId,
+                  stickerBookId,
+                }
+              : null;
           hasHydratedPersistenceRef.current = true;
           hasPaintChangesRef.current = false;
           if (mounted) setSvgMarkup(text);

--- a/src/components/learningPathway/StickerBookPreviewModal.logic.test.tsx
+++ b/src/components/learningPathway/StickerBookPreviewModal.logic.test.tsx
@@ -417,6 +417,7 @@ describe('useStickerBookPreviewModalLogic', () => {
       }),
     );
     expect(mockPush).toHaveBeenCalledWith(PAGES.COLORING_BOARD, {
+      stickerBookId: 'book-1',
       svgRaw: expect.stringContaining('<svg'),
       svgUrl: '/sticker-book.svg',
       artworkTitle: 'My Book!!',

--- a/src/components/learningPathway/StickerBookPreviewModal.logic.ts
+++ b/src/components/learningPathway/StickerBookPreviewModal.logic.ts
@@ -770,6 +770,7 @@ export const useStickerBookPreviewModalLogic = ({
       : svgMarkup || undefined;
 
     history.push(PAGES.COLORING_BOARD, {
+      stickerBookId: data.stickerBookId,
       svgRaw,
       svgUrl: resolveStickerBookSvgUrl(data.stickerBookSvgUrl),
       artworkTitle: data.stickerBookTitle || t('Sticker Book'),

--- a/src/components/learningPathway/StickerBookPreviewModal.test.tsx
+++ b/src/components/learningPathway/StickerBookPreviewModal.test.tsx
@@ -1061,6 +1061,7 @@ describe('StickerBookPreviewModal', () => {
       }),
     );
     expect(mockPush).toHaveBeenCalledWith(PAGES.COLORING_BOARD, {
+      stickerBookId: 'book-complete',
       svgRaw: expect.stringContaining('<svg'),
       svgUrl: 'https://example.com/completed.svg',
       artworkTitle: 'Completed Book',

--- a/src/pages/StickerBook.test.tsx
+++ b/src/pages/StickerBook.test.tsx
@@ -440,6 +440,47 @@ describe('StickerBook page', () => {
     );
   });
 
+  test('onPaint pushes stickerBookId into coloring board route state', async () => {
+    const book = makeBook({
+      id: 'book-7',
+      stickers_metadata: [{ id: 's1', sequence: 1 }],
+    });
+
+    (ServiceConfig.getI as jest.Mock).mockReturnValue({
+      apiHandler: {
+        getAllStickerBooks: jest.fn().mockResolvedValue([book]),
+        getCurrentStickerBookWithProgress: jest.fn().mockResolvedValue({
+          book,
+          progress: { stickers_collected: ['s1'] },
+        }),
+        getUserWonStickerBooks: jest.fn().mockResolvedValue([]),
+        getUserStickerBook: jest.fn().mockResolvedValue([]),
+        markStciekercolledasTrue: jest.fn().mockResolvedValue(undefined),
+        updateRewardAsSeen: jest.fn(),
+      },
+    });
+
+    render(<StickerBook />);
+
+    await waitFor(() => {
+      const props = expectProps();
+      expect(props.canPaint).toBe(true);
+    });
+
+    const props = expectProps();
+    act(() => {
+      props.onPaint();
+    });
+
+    expect(pushMock).toHaveBeenCalledWith(PAGES.COLORING_BOARD, {
+      stickerBookId: 'book-7',
+      svgRaw: '<svg></svg>',
+      svgUrl: '/assets/books/book-1.svg',
+      artworkTitle: 'Animals',
+      returnTo: PAGES.STICKER_BOOK,
+    });
+  });
+
   test('does not render board while loading', () => {
     const slowPromise = new Promise(() => {});
 

--- a/src/pages/StickerBook.tsx
+++ b/src/pages/StickerBook.tsx
@@ -251,6 +251,7 @@ const StickerBook: React.FC = () => {
     if (!selectedBook) return;
     const svgUrl = resolveStickerBookSvgUrl(selectedBook.svg_url ?? '');
     history.push(PAGES.COLORING_BOARD, {
+      stickerBookId: selectedBook.id,
       svgRaw: svgRaw ?? undefined,
       svgUrl,
       artworkTitle: selectedBook.title ?? t('Sticker Book'),

--- a/src/tests/__mocks__/@capacitor/filesystem.ts
+++ b/src/tests/__mocks__/@capacitor/filesystem.ts
@@ -4,6 +4,7 @@ export const Filesystem = {
   stat: jest.fn().mockResolvedValue({}),
   readFile: jest.fn().mockResolvedValue({ data: '' }),
   writeFile: jest.fn().mockResolvedValue({}),
+  deleteFile: jest.fn().mockResolvedValue({}),
 };
 
 export const Directory = {

--- a/src/utility/stickerBookPaintStorage.test.ts
+++ b/src/utility/stickerBookPaintStorage.test.ts
@@ -1,0 +1,211 @@
+import {
+  deletePaintedStickerBook,
+  loadPaintedStickerBook,
+  savePaintedStickerBook,
+  stickerBookPaintStorageInternals,
+} from './stickerBookPaintStorage';
+import { Capacitor } from '@capacitor/core';
+import { Directory, Filesystem } from '@capacitor/filesystem';
+
+jest.mock('@capacitor/core');
+jest.mock('@capacitor/filesystem');
+jest.mock('./logger', () => ({
+  __esModule: true,
+  default: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+type MockIndexedDbStore = Map<string, { key: string; data: string }>;
+
+function createIndexedDbRequest<T>() {
+  return {
+    result: null as T | null,
+    error: null as Error | null,
+    onsuccess: null as ((event: Event) => void) | null,
+    onerror: null as ((event: Event) => void) | null,
+    onupgradeneeded: null as ((event: Event) => void) | null,
+  };
+}
+
+function createMockIndexedDb() {
+  const stores = new Map<string, MockIndexedDbStore>();
+
+  return {
+    open: jest.fn((_name: string, _version: number) => {
+      const request = createIndexedDbRequest<unknown>();
+
+      queueMicrotask(() => {
+        const objectStoreNames = {
+          contains: (storeName: string) => stores.has(storeName),
+        };
+
+        const db = {
+          objectStoreNames,
+          createObjectStore: (storeName: string) => {
+            if (!stores.has(storeName)) {
+              stores.set(storeName, new Map());
+            }
+            return {};
+          },
+          transaction: (storeName: string, _mode: IDBTransactionMode) => {
+            const store = stores.get(storeName) ?? new Map();
+            stores.set(storeName, store);
+
+            const transaction = {
+              error: null as Error | null,
+              oncomplete: null as (() => void) | null,
+              onerror: null as (() => void) | null,
+              onabort: null as (() => void) | null,
+              objectStore: () => ({
+                put: (value: { key: string; data: string }) => {
+                  const putRequest = createIndexedDbRequest<{
+                    key: string;
+                    data: string;
+                  }>();
+                  queueMicrotask(() => {
+                    store.set(value.key, value);
+                    putRequest.result = value;
+                    putRequest.onsuccess?.({} as Event);
+                    transaction.oncomplete?.();
+                  });
+                  return putRequest;
+                },
+                get: (key: string) => {
+                  const getRequest = createIndexedDbRequest<
+                    { key: string; data: string } | undefined
+                  >();
+                  queueMicrotask(() => {
+                    getRequest.result = store.get(key) ?? null;
+                    getRequest.onsuccess?.({} as Event);
+                    transaction.oncomplete?.();
+                  });
+                  return getRequest;
+                },
+                delete: (key: string) => {
+                  const deleteRequest = createIndexedDbRequest<undefined>();
+                  queueMicrotask(() => {
+                    store.delete(key);
+                    deleteRequest.result = null;
+                    deleteRequest.onsuccess?.({} as Event);
+                    transaction.oncomplete?.();
+                  });
+                  return deleteRequest;
+                },
+              }),
+            };
+
+            return transaction;
+          },
+          close: jest.fn(),
+        };
+
+        request.result = db;
+        request.onupgradeneeded?.({} as Event);
+        request.onsuccess?.({} as Event);
+      });
+
+      return request;
+    }),
+  };
+}
+
+describe('stickerBookPaintStorage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(window, 'indexedDB', {
+      configurable: true,
+      value: createMockIndexedDb(),
+    });
+    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(false);
+    (Filesystem.readFile as jest.Mock).mockResolvedValue({ data: '' });
+    (Filesystem.writeFile as jest.Mock).mockResolvedValue({});
+    (Filesystem.deleteFile as jest.Mock).mockResolvedValue({});
+    (Filesystem.mkdir as jest.Mock).mockResolvedValue({});
+  });
+
+  test('saves and loads painted svg through IndexedDB on web', async () => {
+    await savePaintedStickerBook(
+      'student-1',
+      'book-1',
+      '<svg><rect width="12" height="12" /></svg>',
+    );
+
+    const stored = await loadPaintedStickerBook('student-1', 'book-1');
+
+    expect(stored).toBe('<svg><rect width="12" height="12" /></svg>');
+  });
+
+  test('returns null for missing IndexedDB entries', async () => {
+    await expect(
+      loadPaintedStickerBook('student-1', 'missing-book'),
+    ).resolves.toBeNull();
+  });
+
+  test('deletes corrupted IndexedDB svg entries during load', async () => {
+    await savePaintedStickerBook('student-1', 'book-1', 'not-an-svg');
+
+    await expect(
+      loadPaintedStickerBook('student-1', 'book-1'),
+    ).resolves.toBeNull();
+    await expect(
+      loadPaintedStickerBook('student-1', 'book-1'),
+    ).resolves.toBeNull();
+  });
+
+  test('writes and reads painted svg through the native filesystem', async () => {
+    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
+    (Filesystem.readFile as jest.Mock).mockResolvedValue({
+      data: '<svg><circle cx="5" cy="5" r="5" /></svg>',
+    });
+
+    await savePaintedStickerBook(
+      'student-1',
+      'book-1',
+      '<svg><circle cx="5" cy="5" r="5" /></svg>',
+    );
+
+    expect(Filesystem.writeFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: `${stickerBookPaintStorageInternals.PAINT_STORAGE_DIR}/painted_student-1_book-1.svg`,
+        directory: Directory.Data,
+      }),
+    );
+
+    const stored = await loadPaintedStickerBook('student-1', 'book-1');
+
+    expect(stored).toBe('<svg><circle cx="5" cy="5" r="5" /></svg>');
+  });
+
+  test('deletes corrupted native svg files during load', async () => {
+    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
+    (Filesystem.readFile as jest.Mock).mockResolvedValue({
+      data: 'broken-svg',
+    });
+
+    await expect(
+      loadPaintedStickerBook('student-1', 'book-1'),
+    ).resolves.toBeNull();
+
+    expect(Filesystem.deleteFile).toHaveBeenCalledWith({
+      path: `${stickerBookPaintStorageInternals.PAINT_STORAGE_DIR}/painted_student-1_book-1.svg`,
+      directory: Directory.Data,
+    });
+  });
+
+  test('deletePaintedStickerBook removes the persisted entry', async () => {
+    await savePaintedStickerBook(
+      'student-1',
+      'book-1',
+      '<svg><rect width="8" height="8" /></svg>',
+    );
+
+    await deletePaintedStickerBook('student-1', 'book-1');
+
+    await expect(
+      loadPaintedStickerBook('student-1', 'book-1'),
+    ).resolves.toBeNull();
+  });
+});

--- a/src/utility/stickerBookPaintStorage.ts
+++ b/src/utility/stickerBookPaintStorage.ts
@@ -1,0 +1,255 @@
+import { Capacitor } from '@capacitor/core';
+import { Directory, Encoding, Filesystem } from '@capacitor/filesystem';
+import logger from './logger';
+
+const PAINT_STORAGE_DIR = 'stickerBookPaintState';
+const INDEXED_DB_NAME = 'stickerBookPaintProgress';
+const INDEXED_DB_STORE = 'paintedStickerBooks';
+
+type PaintedStickerBookRecord = {
+  key: string;
+  data: string;
+};
+
+function getPaintedStickerBookKey(
+  userId: string,
+  stickerBookId: string,
+): string {
+  return `painted_${userId}_${stickerBookId}.svg`;
+}
+
+function getPaintedStickerBookPath(
+  userId: string,
+  stickerBookId: string,
+): string {
+  return `${PAINT_STORAGE_DIR}/${getPaintedStickerBookKey(
+    userId,
+    stickerBookId,
+  )}`;
+}
+
+function isValidSvgMarkup(data: string): boolean {
+  if (!data) return false;
+
+  try {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(data, 'image/svg+xml');
+    return !!doc.querySelector('svg');
+  } catch {
+    return false;
+  }
+}
+
+function openPaintedStickerBookDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('IndexedDB is not available.'));
+      return;
+    }
+
+    const request = indexedDB.open(INDEXED_DB_NAME, 1);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(INDEXED_DB_STORE)) {
+        db.createObjectStore(INDEXED_DB_STORE, {
+          keyPath: 'key',
+        });
+      }
+    };
+
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+
+    request.onerror = () => {
+      reject(request.error ?? new Error('Failed to open IndexedDB.'));
+    };
+  });
+}
+
+function runIndexedDbRequest<T>(
+  mode: IDBTransactionMode,
+  handler: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T | null> {
+  return openPaintedStickerBookDb().then(
+    (db) =>
+      new Promise<T | null>((resolve, reject) => {
+        const transaction = db.transaction(INDEXED_DB_STORE, mode);
+        const store = transaction.objectStore(INDEXED_DB_STORE);
+        const request = handler(store);
+
+        request.onsuccess = () => {
+          resolve((request.result as T | undefined) ?? null);
+        };
+
+        request.onerror = () => {
+          reject(request.error ?? new Error('IndexedDB request failed.'));
+        };
+
+        transaction.oncomplete = () => {
+          db.close();
+        };
+
+        transaction.onerror = () => {
+          db.close();
+          reject(
+            transaction.error ?? new Error('IndexedDB transaction failed.'),
+          );
+        };
+
+        transaction.onabort = () => {
+          db.close();
+          reject(
+            transaction.error ?? new Error('IndexedDB transaction aborted.'),
+          );
+        };
+      }),
+  );
+}
+
+async function saveToIndexedDb(key: string, data: string): Promise<void> {
+  await runIndexedDbRequest('readwrite', (store) =>
+    store.put({
+      key,
+      data,
+    } as PaintedStickerBookRecord),
+  );
+}
+
+async function loadFromIndexedDb(key: string): Promise<string | null> {
+  const record = await runIndexedDbRequest<
+    PaintedStickerBookRecord | undefined
+  >('readonly', (store) => store.get(key));
+
+  return record?.data ?? null;
+}
+
+async function deleteFromIndexedDb(key: string): Promise<void> {
+  await runIndexedDbRequest('readwrite', (store) => store.delete(key));
+}
+
+async function ensureNativePaintDirectory(): Promise<void> {
+  if (!Capacitor.isNativePlatform()) return;
+
+  try {
+    await Filesystem.mkdir({
+      path: PAINT_STORAGE_DIR,
+      directory: Directory.Data,
+      recursive: true,
+    });
+  } catch {
+    // Ignore directory creation failures if the directory already exists.
+  }
+}
+
+async function deleteCorruptedEntry(
+  userId: string,
+  stickerBookId: string,
+): Promise<void> {
+  try {
+    await deletePaintedStickerBook(userId, stickerBookId);
+  } catch (error) {
+    logger.warn('[StickerBookPaint] Failed to delete corrupted paint state.', {
+      error,
+      userId,
+      stickerBookId,
+    });
+  }
+}
+
+export async function savePaintedStickerBook(
+  userId: string,
+  stickerBookId: string,
+  data: string,
+): Promise<void> {
+  if (!userId || !stickerBookId || !data) return;
+
+  const key = getPaintedStickerBookKey(userId, stickerBookId);
+
+  if (Capacitor.isNativePlatform()) {
+    await ensureNativePaintDirectory();
+    await Filesystem.writeFile({
+      path: getPaintedStickerBookPath(userId, stickerBookId),
+      data,
+      directory: Directory.Data,
+      encoding: Encoding.UTF8,
+      recursive: true,
+    });
+    return;
+  }
+
+  await saveToIndexedDb(key, data);
+}
+
+export async function loadPaintedStickerBook(
+  userId: string,
+  stickerBookId: string,
+): Promise<string | null> {
+  if (!userId || !stickerBookId) return null;
+
+  const key = getPaintedStickerBookKey(userId, stickerBookId);
+
+  try {
+    const data = Capacitor.isNativePlatform()
+      ? await Filesystem.readFile({
+          path: getPaintedStickerBookPath(userId, stickerBookId),
+          directory: Directory.Data,
+          encoding: Encoding.UTF8,
+        }).then((result) =>
+          typeof result.data === 'string' ? result.data : '',
+        )
+      : await loadFromIndexedDb(key);
+
+    if (!data) return null;
+
+    if (!isValidSvgMarkup(data)) {
+      logger.warn('[StickerBookPaint] Invalid persisted SVG. Falling back.', {
+        userId,
+        stickerBookId,
+      });
+      await deleteCorruptedEntry(userId, stickerBookId);
+      return null;
+    }
+
+    return data;
+  } catch (error) {
+    return null;
+  }
+}
+
+export async function deletePaintedStickerBook(
+  userId: string,
+  stickerBookId: string,
+): Promise<void> {
+  if (!userId || !stickerBookId) return;
+
+  const key = getPaintedStickerBookKey(userId, stickerBookId);
+
+  if (Capacitor.isNativePlatform()) {
+    try {
+      await Filesystem.deleteFile({
+        path: getPaintedStickerBookPath(userId, stickerBookId),
+        directory: Directory.Data,
+      });
+    } catch {
+      // Ignore missing files.
+    }
+    return;
+  }
+
+  try {
+    await deleteFromIndexedDb(key);
+  } catch {
+    // Ignore missing records.
+  }
+}
+
+export const stickerBookPaintStorageInternals = {
+  getPaintedStickerBookKey,
+  getPaintedStickerBookPath,
+  isValidSvgMarkup,
+  INDEXED_DB_NAME,
+  INDEXED_DB_STORE,
+  PAINT_STORAGE_DIR,
+};


### PR DESCRIPTION
## Summary

This PR adds local persistence for Sticker Book painting progress so learners can leave the painting flow and return without losing their work.

## What Changed

- Added a new `stickerBookPaintStorage` utility to persist painted Sticker Book SVG state per `userId + stickerBookId`.
- Uses platform-specific storage:
  - Native: Capacitor Filesystem in app data storage
  - Web: IndexedDB
- Restores persisted painted SVG before falling back to route-provided `svgRaw` or fetching the source `svgUrl`.
- Added debounced autosave in `ColoringBoard` when painted regions change.
- Flushes pending paint state when:
  - the app backgrounds
  - the page is hidden
  - the page unloads
  - the user exits paint mode
- Passed `stickerBookId` into the Coloring Board route state from:
  - `StickerBook`
  - `StickerBookPreviewModal`
- Validates persisted SVG before use and deletes corrupted entries automatically.
- Updated tests and Capacitor filesystem mocks to cover restore, autosave, cleanup, and route state propagation.

## Why

Previously, Sticker Book painting progress existed only in memory during the current session. If the learner navigated away, backgrounded the app, or reopened the page, painted progress could be lost. This change makes painting progress resumable and more resilient across navigation and app lifecycle events.

## Testing

- Added coverage for:
  - saving/loading painted SVG via IndexedDB
  - saving/loading painted SVG via native filesystem
  - corrupted persisted SVG cleanup
  - restoring persisted paint state in `ColoringBoard`
  - debounced autosave and background flush behavior
  - `stickerBookId` propagation from Sticker Book entry points

## Notes

- Persistence only applies when both `currentStudentId` and `stickerBookId` are available.
- Save/share availability in `ColoringBoard` now respects the existing `ENABLE_SAVE_AND_SHARE_STICKER_BOOK` feature flag.
