### PR TITLE
feat(growthbook): add offline payload restore from local cache

### DIFF
--- a/src/growthbook/growthbookCacheRestore.ts
+++ b/src/growthbook/growthbookCacheRestore.ts
@@ -1,0 +1,60 @@
+import logger from '../utility/logger';
+import type { GrowthBookPayload } from '@growthbook/growthbook';
+
+const GB_CACHE_KEY = 'gbFeaturesCache';
+
+type GrowthBookLike = {
+  setPayload: (payload: GrowthBookPayload) => Promise<void>;
+};
+
+type GrowthBookCacheEntry = {
+  data?: GrowthBookPayload;
+};
+
+type GrowthBookCacheRow = [string, GrowthBookCacheEntry];
+
+export const tryRestoreGrowthbookPayloadFromCache = async (
+  gbInstance: GrowthBookLike,
+  clientKey?: string,
+): Promise<boolean> => {
+  try {
+    // GrowthBook stores a cache map in localStorage under gbFeaturesCache.
+    // We read that raw cache directly for offline recovery.
+    const raw = localStorage.getItem(GB_CACHE_KEY);
+    if (!raw) return false;
+
+    const parsed = JSON.parse(raw) as GrowthBookCacheRow[];
+    if (!Array.isArray(parsed) || parsed.length === 0) return false;
+    const cacheRows = parsed.filter((entry) => {
+      return (
+        Array.isArray(entry) &&
+        entry.length >= 2 &&
+        typeof entry[0] === 'string' &&
+        typeof entry[1] === 'object' &&
+        entry[1] !== null
+      );
+    });
+    if (cacheRows.length === 0) return false;
+
+    const targetClientKey = clientKey ?? '';
+    const cacheKey = `https://cdn.growthbook.io||${targetClientKey}`;
+    // Prefer exact key match; keep a contains fallback for legacy key shapes.
+    const matched =
+      cacheRows.find((entry) => entry[0] === cacheKey) ??
+      cacheRows.find(
+        (entry) =>
+          targetClientKey.length > 0 && entry[0].includes(targetClientKey),
+      ) ??
+      null;
+
+    const payload = matched?.[1].data;
+    if (!payload) return false;
+
+    // Rehydrate GrowthBook instance with the cached payload.
+    await gbInstance.setPayload(payload);
+    return true;
+  } catch (error) {
+    logger.error('Failed to restore GrowthBook payload from cache', error);
+    return false;
+  }
+};

--- a/src/growthbook/growthbookCacheRestore.ts
+++ b/src/growthbook/growthbookCacheRestore.ts
@@ -16,7 +16,10 @@ type GrowthBookCacheRow = [string, GrowthBookCacheEntry];
 export const tryRestoreGrowthbookPayloadFromCache = async (
   gbInstance: GrowthBookLike,
   clientKey?: string,
+  apiHost: string = 'https://cdn.growthbook.io',
 ): Promise<boolean> => {
+  if (!clientKey) return false;
+
   try {
     // GrowthBook stores a cache map in localStorage under gbFeaturesCache.
     // We read that raw cache directly for offline recovery.
@@ -36,15 +39,11 @@ export const tryRestoreGrowthbookPayloadFromCache = async (
     });
     if (cacheRows.length === 0) return false;
 
-    const targetClientKey = clientKey ?? '';
-    const cacheKey = `https://cdn.growthbook.io||${targetClientKey}`;
+    const cacheKey = `${apiHost}||${clientKey}`;
     // Prefer exact key match; keep a contains fallback for legacy key shapes.
     const matched =
       cacheRows.find((entry) => entry[0] === cacheKey) ??
-      cacheRows.find(
-        (entry) =>
-          targetClientKey.length > 0 && entry[0].includes(targetClientKey),
-      ) ??
+      cacheRows.find((entry) => entry[0].includes(clientKey)) ??
       null;
 
     const payload = matched?.[1].data;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -87,6 +87,7 @@ persistor.subscribe(() => {
 });
 
 const isNativePlatform = Capacitor.isNativePlatform();
+const GB_API_HOST = 'https://cdn.growthbook.io';
 // GrowthBook cache tuning:
 // - staleTTL controls how quickly we revalidate when online.
 // - maxAge keeps last-known payload available for long offline windows.
@@ -162,7 +163,7 @@ const root = createRoot(container!, {
 });
 
 const gb = new GrowthBook({
-  apiHost: 'https://cdn.growthbook.io',
+  apiHost: GB_API_HOST,
   clientKey: process.env.REACT_APP_GROWTHBOOK_ID,
   enableDevMode: true,
   trackingCallback: async (experiment, result) => {
@@ -205,6 +206,7 @@ void (async () => {
     await tryRestoreGrowthbookPayloadFromCache(
       gb,
       process.env.REACT_APP_GROWTHBOOK_ID,
+      GB_API_HOST,
     );
   }
 })();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,6 +36,7 @@ import {
   SpeechSynthesisUtterance,
 } from './utility/WindowsSpeech';
 import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react';
+import { configureCache } from '@growthbook/growthbook';
 import { Util } from './utility/util';
 import {
   CAN_HOT_UPDATE,
@@ -44,6 +45,7 @@ import {
   VERSION_KEY,
 } from './common/constants';
 import { GbProvider } from './growthbook/Growthbook';
+import { tryRestoreGrowthbookPayloadFromCache } from './growthbook/growthbookCacheRestore';
 import { initializeFireBase } from './services/Firebase';
 import * as Sentry from '@sentry/capacitor';
 import * as SentryReact from '@sentry/react';
@@ -85,6 +87,11 @@ persistor.subscribe(() => {
 });
 
 const isNativePlatform = Capacitor.isNativePlatform();
+// GrowthBook cache tuning:
+// - staleTTL controls how quickly we revalidate when online.
+// - maxAge keeps last-known payload available for long offline windows.
+const GB_STALE_TTL_MS = 1000 * 60 * 5; // 5 minutes
+const GB_MAX_AGE_MS = 1000 * 60 * 60 * 24 * 365; // 365 days
 // This function checks if the native version has changed, sets new version in preferences and resets the hot update bundle.
 async function checkNativeVersionAndReset() {
   const { versionName } = await LiveUpdate.getVersionName();
@@ -181,9 +188,26 @@ const gb = new GrowthBook({
     }
   },
 });
-gb.init({
-  streaming: true,
+// Keep cached feature payloads available for extended offline periods.
+// This improves startup resiliency when fetch fails on cold launch.
+configureCache({
+  staleTTL: GB_STALE_TTL_MS,
+  maxAge: GB_MAX_AGE_MS,
 });
+
+void (async () => {
+  const initResult = await gb.init({
+    streaming: true,
+  });
+  // Fallback path: if init cannot fetch from network, restore the most recent
+  // payload from local cache so feature evaluation can still work offline.
+  if (!initResult?.success) {
+    await tryRestoreGrowthbookPayloadFromCache(
+      gb,
+      process.env.REACT_APP_GROWTHBOOK_ID,
+    );
+  }
+})();
 const serviceInstance = ServiceConfig.getInstance(APIMode.SQLITE);
 const renderApp = () => {
   root.render(


### PR DESCRIPTION
- configure GrowthBook cache for resilient offline behavior (staleTTL: 5m, maxAge: 365d)
- add fallback restore path after gb.init() failure to rehydrate payload from gbFeaturesCache
- extract cache-restore logic into src/growthbook/growthbookCacheRestore.ts
- keep implementation strictly typed (no any/unknown in helper)
- add inline comments documenting cache strategy and offline fallback flow