### PR TITLE
fix: Mascot overlaps reward element during speaking animation

### DIFF
--- a/src/components/learningPathway/ChimpleRiveMascot.css
+++ b/src/components/learningPathway/ChimpleRiveMascot.css
@@ -15,14 +15,18 @@
     to bottom,
     transparent 0%,
     transparent 40%,
-    black 45%,
-    black 100%
+    black 43%,
+    black 55%,
+    transparent 57%,
+    transparent 100%
   );
   mask-image: linear-gradient(
     to bottom,
     transparent 0%,
     transparent 40%,
-    black 45%,
-    black 100%
+    black 43%,
+    black 55%,
+    transparent 57%,
+    transparent 100%
   );
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/7ffbfc69-cc6b-4a6e-a347-6a4bf6e8eba2

