### PR TITLE
fix: implement language-specific course preference logic and reset user learning path upon language change

### DIFF
--- a/src/components/LearningPathway.tsx
+++ b/src/components/LearningPathway.tsx
@@ -110,7 +110,7 @@ const LearningPathway: React.FC = () => {
 
         const sortedCourses = await sortCoursesByStudentLanguage(
           courses,
-          student.language_id,
+          student,
         );
         const learningPath = student.learning_path
           ? JSON.parse(student.learning_path)

--- a/src/hooks/useLearningPath.test.ts
+++ b/src/hooks/useLearningPath.test.ts
@@ -3,12 +3,18 @@ import {
   getLastPlayedLesson,
   getNextFromList,
   recommendNextLesson,
+  sortCoursesByStudentLanguage,
   useLearningPath,
 } from './useLearningPath';
 import { ServiceConfig } from '../services/ServiceConfig';
 import { Util } from '../utility/util';
 import { schoolUtil } from '../utility/schoolUtil';
-import { EVENTS, LEARNING_PATHWAY_MODE } from '../common/constants';
+import {
+  EVENTS,
+  LANGUAGE,
+  LEARNING_PATHWAY_MODE,
+  TableTypes,
+} from '../common/constants';
 
 jest.mock('../utility/util');
 jest.mock('../utility/schoolUtil');
@@ -33,6 +39,7 @@ const mockApi = {
   getChaptersForCourse: jest.fn(),
   getLessonsForChapter: jest.fn(),
   updateLearningPath: jest.fn(),
+  getLanguageWithId: jest.fn(),
 };
 
 describe('useLearningPath features used by Home tab', () => {
@@ -60,6 +67,46 @@ describe('useLearningPath features used by Home tab', () => {
     mockApi.getChaptersForCourse.mockResolvedValue([]);
     mockApi.getLessonsForChapter.mockResolvedValue([]);
     mockApi.updateLearningPath.mockResolvedValue(undefined);
+    mockApi.getLanguageWithId.mockResolvedValue(undefined);
+    localStorage.clear();
+  });
+
+  test('prefers the student-language math course when old English math is still attached', async () => {
+    localStorage.setItem(LANGUAGE, 'hi');
+
+    const sorted = await sortCoursesByStudentLanguage(
+      [
+        { id: 'english', code: 'en', subject_id: 'english-subject' },
+        {
+          id: 'math-english',
+          code: 'maths',
+          subject_id: 'math-subject',
+          curriculum_id: 'curriculum-1',
+          grade_id: 'grade-1',
+        },
+        {
+          id: 'digital-skills',
+          code: 'digital',
+          subject_id: 'digital-subject',
+        },
+        {
+          id: 'math-hindi',
+          code: 'maths-hi',
+          subject_id: 'math-subject',
+          curriculum_id: 'curriculum-1',
+          grade_id: 'grade-1',
+        },
+        { id: 'hindi', code: 'hi', subject_id: 'hindi-subject' },
+      ] as TableTypes<'course'>[],
+      'lang-hi',
+    );
+
+    expect(sorted.map((course) => course.id)).toEqual([
+      'hindi',
+      'english',
+      'math-hindi',
+      'digital-skills',
+    ]);
   });
 
   test('pathway rebuild/sync after class-join style course list change preserves current course index', async () => {

--- a/src/hooks/useLearningPath.ts
+++ b/src/hooks/useLearningPath.ts
@@ -9,6 +9,7 @@ import {
   LEARNING_PATHWAY_MODE,
   TableTypes,
   LANGUAGE,
+  COURSES,
 } from '../common/constants';
 import { updateLocalAttributes, useGbContext } from '../growthbook/Growthbook';
 import logger from '../utility/logger';
@@ -251,58 +252,174 @@ export function getNextFromList(
   };
 }
 
-export const sortCoursesByStudentLanguage = async (
-  courses: any[],
-  student: any,
+const LANGUAGE_VARIANT_PATTERN = /^(.+?)-([a-z]{2,3})$/i;
+
+const normalizeCourseToken = (value?: string | null) =>
+  value?.trim().toLowerCase() ?? '';
+
+const getCourseCodeBase = (course?: TableTypes<'course'>) => {
+  const normalizedCode = normalizeCourseToken(course?.code);
+  const matches = normalizedCode.match(LANGUAGE_VARIANT_PATTERN);
+  return matches?.[1] ?? normalizedCode;
+};
+
+const isMathCourse = (course?: TableTypes<'course'>) =>
+  getCourseCodeBase(course) === COURSES.MATHS;
+
+const isLanguageMatchedCourse = (
+  course: TableTypes<'course'>,
+  languageCode: string,
 ) => {
-  // 1. Try Local Storage first
-  const localLanguageCode = localStorage.getItem(LANGUAGE)?.toLowerCase();
-  if (localLanguageCode) {
-    const targetCourses = courses.filter(
-      (c) => c.code?.toLowerCase() === localLanguageCode,
+  const normalizedCode = normalizeCourseToken(course.code);
+  const normalizedName = normalizeCourseToken(course.name);
+  const normalizedLanguageCode = normalizeCourseToken(languageCode);
+
+  if (!normalizedLanguageCode) return false;
+
+  return (
+    normalizedCode === normalizedLanguageCode ||
+    normalizedCode.endsWith(`-${normalizedLanguageCode}`) ||
+    normalizedName === normalizedLanguageCode ||
+    normalizedName.endsWith(`-${normalizedLanguageCode}`)
+  );
+};
+
+const getMathCourseGroupKey = (course: TableTypes<'course'>) =>
+  [
+    course.subject_id ?? '',
+    course.curriculum_id ?? '',
+    course.grade_id ?? '',
+    course.framework_id ?? '',
+    getCourseCodeBase(course),
+  ].join('|');
+
+const getMathCoursePreferenceScore = (
+  course: TableTypes<'course'>,
+  languageCode: string,
+) => {
+  if (isLanguageMatchedCourse(course, languageCode)) return 0;
+  if (
+    isLanguageMatchedCourse(course, COURSES.ENGLISH) ||
+    normalizeCourseToken(course.code) === getCourseCodeBase(course)
+  ) {
+    return 1;
+  }
+  return 2;
+};
+
+const preferStudentLanguageMathCourses = (
+  courses: TableTypes<'course'>[],
+  languageCode: string,
+) => {
+  if (!languageCode) return courses;
+
+  const preferredByGroup = new Map<string, TableTypes<'course'>>();
+
+  courses.forEach((course) => {
+    if (!isMathCourse(course)) return;
+
+    const groupKey = getMathCourseGroupKey(course);
+    const current = preferredByGroup.get(groupKey);
+    if (!current) {
+      preferredByGroup.set(groupKey, course);
+      return;
+    }
+
+    const courseScore = getMathCoursePreferenceScore(course, languageCode);
+    const currentScore = getMathCoursePreferenceScore(current, languageCode);
+    if (courseScore < currentScore) {
+      preferredByGroup.set(groupKey, course);
+    }
+  });
+
+  const emittedMathGroups = new Set<string>();
+  const resolvedCourses: TableTypes<'course'>[] = [];
+
+  courses.forEach((course) => {
+    if (!isMathCourse(course)) {
+      resolvedCourses.push(course);
+      return;
+    }
+
+    const groupKey = getMathCourseGroupKey(course);
+    if (emittedMathGroups.has(groupKey)) return;
+
+    emittedMathGroups.add(groupKey);
+    resolvedCourses.push(preferredByGroup.get(groupKey) ?? course);
+  });
+
+  return resolvedCourses;
+};
+
+const resolveStudentLanguageCode = async (
+  studentOrLanguageId?: TableTypes<'user'> | string | null,
+) => {
+  const localLanguageCode = normalizeCourseToken(
+    localStorage.getItem(LANGUAGE),
+  );
+  if (localLanguageCode) return localLanguageCode;
+
+  const languageId =
+    typeof studentOrLanguageId === 'string'
+      ? studentOrLanguageId
+      : studentOrLanguageId?.language_id;
+  if (!languageId) return '';
+
+  try {
+    const language =
+      await ServiceConfig.getI().apiHandler.getLanguageWithId(languageId);
+    return normalizeCourseToken(language?.code);
+  } catch (e) {
+    logger.error('Error resolving student language', e);
+    return '';
+  }
+};
+
+export const sortCoursesByStudentLanguage = async (
+  courses: TableTypes<'course'>[],
+  studentOrLanguageId?: TableTypes<'user'> | string | null,
+) => {
+  const languageCode = await resolveStudentLanguageCode(studentOrLanguageId);
+  const languagePreferredCourses = preferStudentLanguageMathCourses(
+    courses,
+    languageCode,
+  );
+
+  if (languageCode) {
+    const targetCourses = languagePreferredCourses.filter(
+      (c) => normalizeCourseToken(c.code) === languageCode,
     );
 
     if (targetCourses.length > 0) {
-      const otherCourses = courses.filter(
-        (c) => c.code?.toLowerCase() !== localLanguageCode,
+      const otherCourses = languagePreferredCourses.filter(
+        (c) => normalizeCourseToken(c.code) !== languageCode,
       );
       return [...targetCourses, ...otherCourses];
     }
   }
 
-  // 2. Fallback: API Call
-  if (!student?.language_id) return courses;
+  if (typeof studentOrLanguageId !== 'object' || !studentOrLanguageId) {
+    return languagePreferredCourses;
+  }
+  if (!studentOrLanguageId.language_id) {
+    return languagePreferredCourses;
+  }
 
   try {
     const language = await ServiceConfig.getI().apiHandler.getLanguageWithId(
-      student.language_id,
+      studentOrLanguageId.language_id,
     );
-    if (!language) return courses;
+    if (!language) return languagePreferredCourses;
 
-    const languageCode = language.code?.toLowerCase();
-    const languageName = language.name?.trim().toLowerCase();
+    const languageName = normalizeCourseToken(language.name);
 
-    // Priority 1: Match by Code
-    if (languageCode) {
-      const targetCourses = courses.filter(
-        (c) => c.code?.toLowerCase() === languageCode,
-      );
-      if (targetCourses.length > 0) {
-        const otherCourses = courses.filter(
-          (c) => c.code?.toLowerCase() !== languageCode,
-        );
-        return [...targetCourses, ...otherCourses];
-      }
-    }
-
-    // Priority 2: Match by Name (if code match failed)
     if (languageName) {
-      const targetCourses = courses.filter(
-        (c) => c.name?.trim().toLowerCase() === languageName,
+      const targetCourses = languagePreferredCourses.filter(
+        (c) => normalizeCourseToken(c.name) === languageName,
       );
       if (targetCourses.length > 0) {
-        const otherCourses = courses.filter(
-          (c) => c.name?.trim().toLowerCase() !== languageName,
+        const otherCourses = languagePreferredCourses.filter(
+          (c) => normalizeCourseToken(c.name) !== languageName,
         );
         return [...targetCourses, ...otherCourses];
       }
@@ -311,7 +428,7 @@ export const sortCoursesByStudentLanguage = async (
     logger.error('Error sorting courses by language', e);
   }
 
-  return courses;
+  return languagePreferredCourses;
 };
 
 export function getLastPlayedLesson(

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -49,6 +49,7 @@ import {
   RESULT_STATUS,
   LIDO_ASSESSMENT,
   LATEST_LEARNING_PATH,
+  REWARD_LEARNING_PATH,
 } from '../../common/constants';
 import { StudentLessonResult } from '../../common/courseConstants';
 import { AvatarObj } from '../../components/animation/Avatar';
@@ -2959,6 +2960,7 @@ export class SqliteApi implements ServiceApi {
       language_id = ?,
       locale_id = ?,
       updated_at = ?
+      ${languageChanged ? ', learning_path = ?' : ''}
     WHERE id = ?;
   `;
     const params = [
@@ -2973,6 +2975,9 @@ export class SqliteApi implements ServiceApi {
       localeId,
       now,
     ];
+    if (languageChanged) {
+      params.push(null);
+    }
     params.push(student.id);
     await this.executeQuery(updateUserQuery, params);
 
@@ -2988,6 +2993,7 @@ export class SqliteApi implements ServiceApi {
       language_id: languageDocId,
       locale_id: localeId,
       updated_at: now,
+      ...(languageChanged && { learning_path: null }),
     };
 
     await this.assignCoursesToStudent(
@@ -3009,7 +3015,12 @@ export class SqliteApi implements ServiceApi {
       language_id: languageDocId,
       locale_id: localeId,
       updated_at: now,
+      ...(languageChanged && { learning_path: null }),
     });
+    if (languageChanged) {
+      localStorage.removeItem(`${LATEST_LEARNING_PATH}:${student.id}`);
+      sessionStorage.removeItem(REWARD_LEARNING_PATH);
+    }
     return updatedStudent;
   }
   async getCurrentClassIdForStudent(studentId: string): Promise<string | null> {

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -47,6 +47,8 @@ import {
   RESULT_STATUS,
   LEARNING_PATHWAY_MODE,
   ProgramType,
+  LATEST_LEARNING_PATH,
+  REWARD_LEARNING_PATH,
 } from '../../common/constants';
 import { Constants } from '../database'; // adjust the path as per your project
 import { StudentLessonResult } from '../../common/courseConstants';
@@ -2489,6 +2491,7 @@ export class SupabaseApi implements ServiceApi {
     localeId?: string,
   ): Promise<TableTypes<'user'>> {
     if (!this.supabase) return student;
+    const languageChanged = student.language_id !== languageDocId;
 
     const updatedFields: any = {
       name,
@@ -2501,19 +2504,26 @@ export class SupabaseApi implements ServiceApi {
       language_id: languageDocId,
     };
 
-    if (student.language_id !== languageDocId) {
+    if (languageChanged) {
       const countryCode = await this.getClientCountryCode();
       const locale = await this.getLocaleByIdOrCode(undefined, countryCode);
       updatedFields.locale_id = locale?.id ?? DEFAULT_LOCALE_ID;
+      updatedFields.learning_path = null;
     }
 
     await this.supabase.from('user').update(updatedFields).eq('id', student.id);
     const updatedStudent = { ...student, ...updatedFields };
+    if (languageChanged) {
+      localStorage.removeItem(`${LATEST_LEARNING_PATH}:${student.id}`);
+      sessionStorage.removeItem(REWARD_LEARNING_PATH);
+    }
 
     const courses =
       gradeDocId && boardDocId
         ? await this.getCourseByUserGradeId(gradeDocId, boardDocId)
-        : [];
+        : languageChanged
+          ? await this.getDefaultCoursesForLanguage(languageDocId)
+          : [];
 
     if (courses && courses.length > 0) {
       // Batch fetch existing user_course entries for this student and these courses
@@ -2550,6 +2560,40 @@ export class SupabaseApi implements ServiceApi {
 
     return updatedStudent;
   }
+
+  private async getDefaultCoursesForLanguage(
+    languageDocId?: string | null,
+  ): Promise<TableTypes<'course'>[]> {
+    const [englishCourse, mathsCourse, digitalSkillsCourse] = await Promise.all(
+      [
+        this.getCourse(CHIMPLE_ENGLISH),
+        this.resolveMathCourseByLanguage(languageDocId),
+        this.getCourse(CHIMPLE_DIGITAL_SKILLS),
+      ],
+    );
+
+    const language = languageDocId
+      ? await this.getLanguageWithId(languageDocId)
+      : undefined;
+    let langCourse: TableTypes<'course'> | undefined;
+
+    if (language && language.code !== COURSES.ENGLISH) {
+      const thirdLanguageCourseMap: Record<string, string> = {
+        hi: CHIMPLE_HINDI,
+        kn: GRADE1_KANNADA,
+        mr: GRADE1_MARATHI,
+      };
+      const courseId = thirdLanguageCourseMap[language.code ?? ''];
+      if (courseId) {
+        langCourse = await this.getCourse(courseId);
+      }
+    }
+
+    return [englishCourse, mathsCourse, langCourse, digitalSkillsCourse].filter(
+      Boolean,
+    ) as TableTypes<'course'>[];
+  }
+
   async updateStudentFromSchoolMode(
     student: TableTypes<'user'>,
     name: string,


### PR DESCRIPTION
when a student’s profile language changes, we now clear the old learning_path. That matters because the old pathway already contains selected lesson IDs. If the profile was created in English, those lesson IDs can still point to English math assessment content even after changing the profile to Hindi/Kannada.