### PR TITLE
feat: show merged parent contacts in edit/interact/card list with fetch-only API updates

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1190,6 +1190,8 @@ export interface StudentInfo {
   grade: number;
   classSection: string;
   parent: TableTypes<'user'> | null;
+  // Optional full parent list used when merged profiles carry multiple contacts.
+  parents?: TableTypes<'user'>[];
   classWithidname?: {
     id: string;
     class_name: string;

--- a/src/ops-console/components/SchoolDetailsComponents/CardListModal.test.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/CardListModal.test.tsx
@@ -145,10 +145,10 @@ describe('CardListModal', () => {
 
   /* ================= PHONE FALLBACK ================= */
 
-  it('uses parent phone first', async () => {
+  it('shows parent phone first in the contact list', async () => {
     render(<CardListModal {...baseProps} />);
 
-    await screen.findByText('6666666666');
+    await screen.findByText('6666666666 / 7777777777');
   });
 
   it('falls back to email if no phone', async () => {

--- a/src/ops-console/components/SchoolDetailsComponents/CardListModal.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/CardListModal.tsx
@@ -6,6 +6,10 @@ import { CircularProgress } from '@mui/material';
 import './CardListModal.css';
 import { t } from 'i18next';
 import logger from '../../../utility/logger';
+import {
+  formatStudentContactList,
+  getStudentPrimaryContact,
+} from '../../utils/studentContactNumbers';
 
 interface StudentItem {
   user?: {
@@ -17,8 +21,18 @@ interface StudentItem {
     phone?: string | null;
   };
   phone?: string | null;
-  parent?: { phone?: string | null } | null;
+  parent?: { phone?: string | null; email?: string | null } | null;
+  parents?: { phone?: string | null; email?: string | null }[] | null;
 }
+
+type StudentSearchResponse = {
+  data?: StudentItem[];
+  total?: number;
+};
+
+type ProcessedStudentItem = Omit<StudentItem, 'user'> & {
+  user: NonNullable<StudentItem['user']>;
+};
 
 interface CardListModalProps {
   open: boolean;
@@ -56,7 +70,7 @@ const CardListModal: React.FC<CardListModalProps> = ({
     const currentRequest = ++requestIdRef.current;
     setLoading(true);
     try {
-      let res;
+      let res: StudentSearchResponse;
       if (searchText.trim()) {
         res = await api.searchStudentsInSchool(
           schoolId,
@@ -77,7 +91,7 @@ const CardListModal: React.FC<CardListModalProps> = ({
       if (currentRequest !== requestIdRef.current) return;
       if (!primaryStudentData && res.data) {
         const found = res.data.find(
-          (s: any) => s.user?.id === primaryStudentId,
+          (student) => student.user?.id === primaryStudentId,
         );
         if (found) setPrimaryStudentData(found);
       }
@@ -110,34 +124,42 @@ const CardListModal: React.FC<CardListModalProps> = ({
     }
   }, [open]);
 
-  const processedStudents = students
-    .map((s: any) => {
-      const user = s.user ?? s;
-      const phone = s.parent?.phone ?? s.phone ?? user?.phone ?? '';
-      return {
-        ...s,
+  const processedStudents = students.reduce<ProcessedStudentItem[]>(
+    (list, student) => {
+      if (!student.user || student.user.id === primaryStudentId) return list;
+
+      const user = student.user;
+      // Build display contact from merged parent/user sources.
+      const phone = getStudentPrimaryContact({
+        user,
+        parent: student.parent,
+        parents: student.parents,
+      });
+      list.push({
+        ...student,
         user: {
           ...user,
-          phone: String(phone).replace(/\D/g, ''),
+          phone: String(phone).replace(/\D/g, '') || user?.phone || '',
         },
         parent: {
-          phone: String(phone).replace(/\D/g, ''),
+          ...student.parent,
+          phone:
+            String(phone).replace(/\D/g, '') || student.parent?.phone || '',
         },
-      };
-    })
-    .filter((s) => s.user?.id !== primaryStudentId);
+      });
+
+      return list;
+    },
+    [],
+  );
   const selectedStudent = processedStudents.find(
-    (s) => s.user?.id === selectedId,
+    (s) => s.user.id === selectedId,
   );
   const pageCount = Math.ceil(total / ROWS_PER_PAGE);
   if (!open) return null;
 
   const primaryName = primaryStudentData?.user?.name || '';
-  const primaryContact =
-    primaryStudentData?.parent?.phone ||
-    primaryStudentData?.user?.phone ||
-    primaryStudentData?.user?.email ||
-    '';
+  const primaryContact = getStudentPrimaryContact(primaryStudentData);
   return (
     <div id="cardlist-backdrop" className="cardlist-modal-backdrop">
       <div id="cardlist-modal" className="cardlist-modal">
@@ -194,11 +216,11 @@ const CardListModal: React.FC<CardListModalProps> = ({
             </div>
           ) : (
             processedStudents.map((s) => {
-              const selected = selectedId === s.user?.id;
+              const selected = selectedId === s.user.id;
               return (
                 <label
                   id="cardlist-label"
-                  key={s.user?.id}
+                  key={s.user.id}
                   className={`cardlist-card ${
                     selected ? 'cardlist-card-selected' : ''
                   }`}
@@ -207,23 +229,23 @@ const CardListModal: React.FC<CardListModalProps> = ({
                     id="cardlist-input"
                     type="radio"
                     checked={selected}
-                    onChange={() => setSelectedId(s.user?.id!)}
+                    onChange={() => setSelectedId(s.user.id)}
                   />
 
                   <div id="cardlist-row" className="cardlist-row">
                     <span id="cardlist-col-id" className="cardlist-col-id">
-                      {s.user?.student_id || 'N/A'}
+                      {s.user.student_id || 'N/A'}
                     </span>
 
                     <span id="cardlist-col-name" className="cardlist-col-name">
-                      {s.user?.name || 'N/A'}
+                      {s.user.name || 'N/A'}
                     </span>
 
                     <span
                       id="cardlist-col-gender"
                       className="cardlist-col-gender"
                     >
-                      {s.user?.gender
+                      {s.user.gender
                         ? s.user.gender.toLowerCase() === 'male'
                           ? 'Male'
                           : s.user.gender.toLowerCase() === 'female'
@@ -235,10 +257,7 @@ const CardListModal: React.FC<CardListModalProps> = ({
                       id="cardlist-col-phone"
                       className="cardlist-col-phone"
                     >
-                      {s.parent?.phone ||
-                        s.user?.phone ||
-                        s.user?.email ||
-                        'N/A'}
+                      {formatStudentContactList(s, 'N/A')}
                     </span>
                   </div>
                 </label>

--- a/src/ops-console/components/SchoolDetailsComponents/CardListModal.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/CardListModal.tsx
@@ -128,24 +128,9 @@ const CardListModal: React.FC<CardListModalProps> = ({
     (list, student) => {
       if (!student.user || student.user.id === primaryStudentId) return list;
 
-      const user = student.user;
-      // Build display contact from merged parent/user sources.
-      const phone = getStudentPrimaryContact({
-        user,
-        parent: student.parent,
-        parents: student.parents,
-      });
       list.push({
         ...student,
-        user: {
-          ...user,
-          phone: String(phone).replace(/\D/g, '') || user?.phone || '',
-        },
-        parent: {
-          ...student.parent,
-          phone:
-            String(phone).replace(/\D/g, '') || student.parent?.phone || '',
-        },
+        user: student.user as NonNullable<StudentItem['user']>,
       });
 
       return list;

--- a/src/ops-console/components/SchoolDetailsComponents/FormCard.css
+++ b/src/ops-console/components/SchoolDetailsComponents/FormCard.css
@@ -113,6 +113,40 @@
   box-shadow: 0 0 0 1px rgba(26, 115, 232, 0.15);
 }
 
+.formcard-chip-list {
+  min-height: 38px;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  background: #f9fafb;
+  padding: 6px 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  box-sizing: border-box;
+}
+
+.formcard-value-chip {
+  max-width: 100%;
+  min-height: 24px;
+  border-radius: 9999px;
+  background: #f3f4f6;
+  color: #374151;
+  border: 1px solid #d1d5db;
+  padding: 3px 9px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.formcard-value-chip-empty {
+  color: #6b7280;
+  font-weight: 500;
+}
+
 .formcard-select-wrapper {
   position: relative;
 }

--- a/src/ops-console/components/SchoolDetailsComponents/FormCard.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/FormCard.tsx
@@ -5,7 +5,7 @@ import 'react-international-phone/style.css';
 import { t } from 'i18next';
 import CheckIcon from '@mui/icons-material/Check';
 
-export type FieldKind = 'text' | 'email' | 'phone' | 'select';
+export type FieldKind = 'text' | 'email' | 'phone' | 'select' | 'chips';
 export type FieldColumn = 0 | 1 | 2; // 0 = left, 1 = right, 2 = full row
 
 export interface FieldConfig {
@@ -374,6 +374,28 @@ const FormCard: React.FC<EntityModalProps> = ({
             onChange={(e) => handleChange(field.name, e.target.value)}
           />
         );
+
+      case 'chips': {
+        // Chips are supplied as a "/" joined string from read-only form values.
+        const chips = (values[field.name] ?? '')
+          .split('/')
+          .map((value) => value.trim())
+          .filter(Boolean);
+
+        return (
+          <div className="formcard-chip-list" id={field.name}>
+            {chips.map((chip, index) => (
+              <span
+                key={`${chip}-${index}`}
+                className="formcard-value-chip"
+                title={chip}
+              >
+                {chip}
+              </span>
+            ))}
+          </div>
+        );
+      }
 
       case 'text':
       default:

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolStudents.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolStudents.tsx
@@ -68,6 +68,7 @@ import { RoleType } from '../../../interface/modelInterfaces';
 import { useAppSelector } from '../../../redux/hooks';
 import { RootState } from '../../../redux/store';
 import { AuthState } from '../../../redux/slices/auth/authSlice';
+import { getStudentContactValues } from '../../utils/studentContactNumbers';
 
 type ApiStudentData = StudentInfo;
 type StudentPerformanceBand =
@@ -445,6 +446,16 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
     [schoolId, optionalClassId, programScopedClassIds],
   );
 
+  const invalidateStudentListCache = useCallback(() => {
+    // Merge updates can change contacts, so clear school-scoped cache entries.
+    const schoolCachePrefix = `${schoolId}|`;
+    Array.from(studentListCache.keys()).forEach((cacheKey) => {
+      if (cacheKey.startsWith(schoolCachePrefix)) {
+        studentListCache.delete(cacheKey);
+      }
+    });
+  }, [schoolId]);
+
   const issTotal = isTotal ?? true;
   const issFilter = isFilter ?? true;
   const custoomTitle = customTitle ?? 'Students';
@@ -461,14 +472,18 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
 
     // Reuses prefetched school students only when no program scope is active.
     if (isInitial && !allowedGrades && !optionalClassId) {
-      const prefetchedStudents = data.students || [];
-      const prefetchedTotal =
-        data.totalStudentCount ?? prefetchedStudents.length;
       const cacheKey = getStudentListCacheKey(
         schoolId,
         optionalClassId,
         programScopedClassIds,
       );
+      // Prefer cached post-merge data over initial props on remount/tab switch.
+      const cachedStudents = studentListCache.get(cacheKey);
+      const prefetchedStudents = cachedStudents?.data ?? data.students ?? [];
+      const prefetchedTotal =
+        cachedStudents?.total ??
+        data.totalStudentCount ??
+        prefetchedStudents.length;
 
       setStudents(prefetchedStudents);
       setTotalCount(prefetchedTotal);
@@ -984,7 +999,7 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
         gender: s_api.user.gender ?? 'N/A',
         grade: s_api.grade ?? 0,
         classSection: s_api.classSection ?? 'N/A',
-        phoneNumber: s_api.parent?.phone || s_api.parent?.email || 'N/A', //here
+        phoneNumber: s_api.parent?.phone || s_api.parent?.email || 'N/A',
         class: getClassDisplayLabel(
           s_api.grade,
           s_api.classSection,
@@ -1552,8 +1567,8 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
     // 6️⃣ Phone – full width
     {
       name: 'phone',
-      label: 'Phone Number',
-      kind: 'text',
+      label: 'Phone / Email',
+      kind: 'chips',
       column: 2,
       disabled: true,
     },
@@ -1777,6 +1792,8 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
           text: mergeMessage, // dynamic
           autoCloseSeconds: 5,
         });
+        invalidateStudentListCache();
+        await fetchStudents(page, debouncedSearchTerm);
       } else {
         setPopup({
           open: true,
@@ -1785,20 +1802,6 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
           text: mergeResult.message || t('Failed to merge student profile.'),
           autoCloseSeconds: 5,
         });
-      }
-      // Keep UI in sync with backend after merge attempts.
-      let removed = false;
-      setStudents((prev) => {
-        const next = prev.filter((row: any) => {
-          const rowId = row?.user?.id ?? row?.id;
-          const keep = rowId !== oldId;
-          if (!keep) removed = true;
-          return keep;
-        });
-        return next;
-      });
-      if (removed) {
-        setTotalCount((prev) => Math.max(0, prev - 1));
       }
       setShowSuccessPopup(true);
       setIsMergeStudentModalOpen(false);
@@ -1861,7 +1864,8 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
           classAndSection: `${editStudentData?.grade ?? ''}${
             editStudentData?.classSection ?? ''
           }`,
-          phone: editStudentData?.parent?.phone ?? '',
+          // Show all merged contacts in edit details as chips.
+          phone: getStudentContactValues(editStudentData).join(' / '),
         }}
         onClose={() => {
           setIsEditStudentModalOpen(false);

--- a/src/ops-console/components/fcInteractComponents/FcInteractPopUp.css
+++ b/src/ops-console/components/fcInteractComponents/FcInteractPopUp.css
@@ -82,6 +82,11 @@
   cursor: pointer;
   font-size: 14px;
 }
+.fc-interact-popup-contact {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
 .fc-interact-popup-divider {
   height: 1px;
   background: #eef2f7;

--- a/src/ops-console/components/fcInteractComponents/FcInteractPopUp.tsx
+++ b/src/ops-console/components/fcInteractComponents/FcInteractPopUp.tsx
@@ -17,6 +17,7 @@ import { ServiceConfig } from '../../../services/ServiceConfig';
 import { useMediaActions } from '../../common/mediaactions';
 import AttachMedia from '../../common/AttachMedia';
 import logger from '../../../utility/logger';
+import { getStudentContactEntries } from '../../utils/studentContactNumbers';
 
 type Q = { id: string; question: string };
 
@@ -98,6 +99,20 @@ const FcInteractPopUp: React.FC<FcInteractPopUpProps> = ({
   } else if (principalData) {
     userData = principalData;
   }
+
+  const contactEntries = studentData
+    ? getStudentContactEntries(studentData)
+    : getStudentContactEntries({ user: userData, parent: parentData });
+  const formatPhoneDisplay = (phone: string) => {
+    const digits = phone.replace(/\D/g, '');
+    return digits.length === 10 ? `+91 ${phone}` : phone;
+  };
+  const getContactDisplayValue = (type: 'phone' | 'email', value: string) =>
+    type === 'phone' ? formatPhoneDisplay(value) : value;
+  const handleContactClick = (type: 'phone' | 'email', value: string) => {
+    window.location.href =
+      type === 'phone' ? `tel:${value}` : `mailto:${value}`;
+  };
 
   useEffect(() => {
     let mounted = true;
@@ -283,43 +298,31 @@ const FcInteractPopUp: React.FC<FcInteractPopUpProps> = ({
                 className="fc-interact-popup-contact"
                 id="fc-contact-section"
               >
-                {userData?.phone || parentData?.phone ? (
-                  <div
-                    className="fc-interact-popup-contact-line"
-                    id="fc-phone-line"
-                    onClick={() =>
-                      (window.location.href = `tel:${
-                        userData?.phone ?? parentData?.phone
-                      }`)
-                    }
-                  >
-                    <span
-                      className="fc-interact-popup-contact-text"
-                      id="fc-phone-text"
-                    >
-                      +91 {userData?.phone || parentData?.phone}
-                    </span>
-                    <LaunchRounded style={{ fontSize: 16 }} />
-                  </div>
-                ) : (
-                  <div
-                    className="fc-interact-popup-contact-line"
-                    id="fc-email-line"
-                    onClick={() =>
-                      (window.location.href = `mailto:${
-                        userData?.email ?? parentData?.email
-                      }`)
-                    }
-                  >
-                    <span
-                      className="fc-interact-popup-contact-text"
-                      id="fc-email-text"
-                    >
-                      {userData?.email ?? parentData?.email}
-                    </span>
-                    <EmailRounded style={{ fontSize: 16 }} />
-                  </div>
-                )}
+                {/* Show each available phone/email contact as its own action row. */}
+                {contactEntries.length > 0
+                  ? contactEntries.map((contact, index) => (
+                      <div
+                        key={`${contact.type}-${contact.value}-${index}`}
+                        className="fc-interact-popup-contact-line"
+                        id={`fc-contact-line-${index}`}
+                        onClick={() =>
+                          handleContactClick(contact.type, contact.value)
+                        }
+                      >
+                        <span
+                          className="fc-interact-popup-contact-text"
+                          id={`fc-contact-text-${index}`}
+                        >
+                          {getContactDisplayValue(contact.type, contact.value)}
+                        </span>
+                        {contact.type === 'phone' ? (
+                          <LaunchRounded style={{ fontSize: 16 }} />
+                        ) : (
+                          <EmailRounded style={{ fontSize: 16 }} />
+                        )}
+                      </div>
+                    ))
+                  : null}
               </div>
 
               <div className="fc-interact-popup-divider" id="fc-divider" />

--- a/src/ops-console/pages/SchoolList.helpers.tsx
+++ b/src/ops-console/pages/SchoolList.helpers.tsx
@@ -354,8 +354,9 @@ export const formatPercent = (value: unknown) => {
 
 // Percentage chip palette used by the listing metrics.
 export const getPercentMeta = (percent: number) => {
-  if (percent >= 80) return { bg: '#DFF7EB', color: '#2BA980' };
-  if (percent >= 60) return { bg: '#FEF3C7', color: '#E7A54E' };
+  const roundedPercent = Math.round(percent);
+  if (roundedPercent >= 70) return { bg: '#DFF7EB', color: '#2BA980' };
+  if (roundedPercent >= 31) return { bg: '#FEF3C7', color: '#E7A54E' };
   return { bg: '#FCE8E6', color: '#D35451' };
 };
 

--- a/src/ops-console/pages/StudentPendingRequest.tsx
+++ b/src/ops-console/pages/StudentPendingRequest.tsx
@@ -177,9 +177,10 @@ const StudentPendingRequestDetails = () => {
           return;
         }
         // MERGE & APPROVE logic
+        // Keep requested profile as source and selected student as destination.
         const mergeResult = await api.mergeStudentRequest(
-          currentSelectedStudent,
           newStudentUserId,
+          currentSelectedStudent,
           currentRequest_Id,
           respondedBy,
         );

--- a/src/ops-console/utils/studentContactNumbers.test.ts
+++ b/src/ops-console/utils/studentContactNumbers.test.ts
@@ -1,0 +1,60 @@
+import {
+  formatStudentContactList,
+  formatStudentPhoneList,
+  getStudentContactValues,
+  getStudentEmailAddresses,
+  getStudentPhoneNumbers,
+  getStudentPrimaryContact,
+} from './studentContactNumbers';
+
+describe('studentContactNumbers', () => {
+  it('returns all unique parent and student phone numbers in display order', () => {
+    expect(
+      getStudentPhoneNumbers({
+        user: { phone: '09176543210' },
+        parent: { phone: '9876543210' },
+        parents: [
+          { phone: '9876543210' },
+          { phone: '+91 87654 32109' },
+          { phone: '' },
+        ],
+      }),
+    ).toEqual(['9876543210', '+91 87654 32109', '09176543210']);
+  });
+
+  it('formats phone lists and falls back to email when no phone exists', () => {
+    const student = {
+      user: { email: 'student@example.com' },
+      parent: { email: 'parent@example.com' },
+      parents: [{ email: 'guardian@example.com' }],
+    };
+
+    expect(formatStudentPhoneList(student)).toBe('N/A');
+    expect(getStudentPrimaryContact(student)).toBe('guardian@example.com');
+  });
+
+  it('keeps phone and email contacts from multiple parents', () => {
+    const student = {
+      user: { email: 'student@example.com' },
+      parents: [
+        { phone: '9876543210', email: 'parent@example.com' },
+        { email: 'guardian@example.com' },
+      ],
+    };
+
+    expect(getStudentEmailAddresses(student)).toEqual([
+      'parent@example.com',
+      'guardian@example.com',
+      'student@example.com',
+    ]);
+    expect(getStudentContactValues(student)).toEqual([
+      '9876543210',
+      'parent@example.com',
+      'guardian@example.com',
+      'student@example.com',
+    ]);
+    expect(formatStudentContactList(student)).toBe(
+      '9876543210 / parent@example.com / guardian@example.com / student@example.com',
+    );
+  });
+});

--- a/src/ops-console/utils/studentContactNumbers.ts
+++ b/src/ops-console/utils/studentContactNumbers.ts
@@ -1,0 +1,125 @@
+type ContactLike = {
+  id?: string | null;
+  phone?: string | number | null;
+  email?: string | null;
+};
+
+type StudentContactLike = {
+  user?: ContactLike | null;
+  parent?: ContactLike | null;
+  parents?: ContactLike[] | null;
+};
+
+export type StudentContactEntry = {
+  type: 'phone' | 'email';
+  value: string;
+};
+
+const normalizePhoneKey = (value: string): string => {
+  const digits = value.replace(/\D/g, '');
+  if (digits.length === 12 && digits.startsWith('91')) return digits.slice(2);
+  if (digits.length === 11 && digits.startsWith('0')) return digits.slice(1);
+  return digits || value.trim().toLowerCase();
+};
+
+const addUniquePhone = (
+  phones: string[],
+  seen: Set<string>,
+  phone: string | number | null | undefined,
+) => {
+  const value = String(phone ?? '').trim();
+  if (!value) return;
+
+  const key = normalizePhoneKey(value);
+  if (!key || seen.has(key)) return;
+
+  seen.add(key);
+  phones.push(value);
+};
+
+const addUniqueEmail = (
+  emails: string[],
+  seen: Set<string>,
+  email: string | null | undefined,
+) => {
+  const value = String(email ?? '').trim();
+  if (!value) return;
+
+  const key = value.toLowerCase();
+  if (seen.has(key)) return;
+
+  seen.add(key);
+  emails.push(value);
+};
+
+export const getStudentPhoneNumbers = (
+  student: StudentContactLike | null | undefined,
+): string[] => {
+  if (!student) return [];
+
+  const phones: string[] = [];
+  const seen = new Set<string>();
+  const parents = Array.isArray(student.parents) ? student.parents : [];
+
+  parents.forEach((parent) => addUniquePhone(phones, seen, parent?.phone));
+  addUniquePhone(phones, seen, student.parent?.phone);
+  addUniquePhone(phones, seen, student.user?.phone);
+
+  return phones;
+};
+
+export const getStudentEmailAddresses = (
+  student: StudentContactLike | null | undefined,
+): string[] => {
+  if (!student) return [];
+
+  const emails: string[] = [];
+  const seen = new Set<string>();
+  const parents = Array.isArray(student.parents) ? student.parents : [];
+
+  parents.forEach((parent) => addUniqueEmail(emails, seen, parent?.email));
+  addUniqueEmail(emails, seen, student.parent?.email);
+  addUniqueEmail(emails, seen, student.user?.email);
+
+  return emails;
+};
+
+export const getStudentContactValues = (
+  student: StudentContactLike | null | undefined,
+): string[] =>
+  getStudentContactEntries(student).map((contact) => contact.value);
+
+export const getStudentContactEntries = (
+  student: StudentContactLike | null | undefined,
+): StudentContactEntry[] => [
+  ...getStudentPhoneNumbers(student).map((value) => ({
+    type: 'phone' as const,
+    value,
+  })),
+  ...getStudentEmailAddresses(student).map((value) => ({
+    type: 'email' as const,
+    value,
+  })),
+];
+
+export const getStudentPrimaryContact = (
+  student: StudentContactLike | null | undefined,
+): string => {
+  return getStudentContactValues(student)[0] ?? '';
+};
+
+export const formatStudentPhoneList = (
+  student: StudentContactLike | null | undefined,
+  fallback = 'N/A',
+): string => {
+  const phones = getStudentPhoneNumbers(student);
+  return phones.length > 0 ? phones.join(' / ') : fallback;
+};
+
+export const formatStudentContactList = (
+  student: StudentContactLike | null | undefined,
+  fallback = 'N/A',
+): string => {
+  const contacts = getStudentContactValues(student);
+  return contacts.length > 0 ? contacts.join(' / ') : fallback;
+};

--- a/src/services/api/ApiHandler.ts
+++ b/src/services/api/ApiHandler.ts
@@ -1658,8 +1658,12 @@ export class ApiHandler implements ServiceApi {
   }
   public async getParentsByStudentId(
     studentId: string,
+    options?: {
+      studentIds?: string[];
+      activeOnly?: boolean;
+    },
   ): Promise<TableTypes<'user'>[]> {
-    return await this.s.getParentsByStudentId(studentId);
+    return await this.s.getParentsByStudentId(studentId, options);
   }
   public async mergeStudentRequest(
     existingStudentId: string,

--- a/src/services/api/ServiceApi.ts
+++ b/src/services/api/ServiceApi.ts
@@ -2266,9 +2266,18 @@ export interface ServiceApi {
   /**
    * Fetch  parent information even if the student is deleted.
    * @param {string} studentId - The ID of the student to fetch.
+   * @param {Object} [options] - Optional query controls for bulk lookup and filtering.
+   * @param {string[]} [options.studentIds] - When provided, fetches parents for all listed students.
+   * @param {boolean} [options.activeOnly] - When true, excludes deleted parent links.
    * @returns Promise resolving to an array of parents.
    */
-  getParentsByStudentId(studentId: string): Promise<TableTypes<'user'>[]>;
+  getParentsByStudentId(
+    studentId: string,
+    options?: {
+      studentIds?: string[];
+      activeOnly?: boolean;
+    },
+  ): Promise<TableTypes<'user'>[]>;
 
   /**
    * Merge a new student into an existing student record in SQLite.

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -7135,6 +7135,44 @@ order by
     return { grade: 0, section: cleanedName };
   }
 
+  private async getParentsByStudentIds(
+    studentIds: string[],
+  ): Promise<Map<string, TableTypes<'user'>[]>> {
+    // Shared helper: fetch all active parent links for a student batch in one query.
+    const parentsByStudentId = new Map<string, TableTypes<'user'>[]>();
+    if (!this._db || studentIds.length === 0) return parentsByStudentId;
+
+    const parentPlaceholders = studentIds.map(() => '?').join(', ');
+    const parentRowsRes = await this._db.query(
+      `
+      SELECT pu.student_id as linked_student_id, p.*
+      FROM ${TABLES.ParentUser} pu
+      JOIN ${TABLES.User} p ON pu.parent_id = p.id
+      WHERE pu.student_id IN (${parentPlaceholders})
+        AND pu.is_deleted = false
+        AND p.is_deleted = false
+      `,
+      studentIds,
+    );
+
+    (parentRowsRes?.values ?? []).forEach((parentRow) => {
+      const row = parentRow as TableTypes<'user'> & {
+        linked_student_id?: string | null;
+      };
+      const linkedStudentId = String(row.linked_student_id ?? '').trim();
+      if (!linkedStudentId) return;
+
+      const { linked_student_id, ...parentUser } = row;
+      const currentParents = parentsByStudentId.get(linkedStudentId) ?? [];
+      parentsByStudentId.set(linkedStudentId, [
+        ...currentParents,
+        parentUser as TableTypes<'user'>,
+      ]);
+    });
+
+    return parentsByStudentId;
+  }
+
   async getStudentInfoBySchoolId(
     schoolId: string,
     page: number = 1,
@@ -7220,8 +7258,13 @@ order by
   `;
     const res = await this._db.query(query, [...baseParams, limit, offset]);
     const rows = res?.values ?? [];
+    const studentIds = rows
+      .map((row) => String((row as { id?: string | null })?.id ?? '').trim())
+      .filter((id): id is string => id.length > 0);
+    // Hydrate full parent contact list so UI can show merged phone/email entries.
+    const parentsByStudentId = await this.getParentsByStudentIds(studentIds);
 
-    const studentInfoList: StudentInfo[] = rows.map((row: any) => {
+    const studentInfoList: StudentInfo[] = rows.map((row) => {
       const {
         class_id,
         class_name,
@@ -7233,6 +7276,8 @@ order by
       } = row;
 
       const { grade, section } = this.parseClassName(class_name || '');
+      const parents =
+        parentsByStudentId.get(String(studentUser.id ?? '')) ?? [];
       const parentObject: TableTypes<'user'> | null = parent_id
         ? {
             id: parent_id,
@@ -7270,6 +7315,8 @@ order by
         grade,
         classSection: section,
         parent: parentObject,
+        parents:
+          parents.length > 0 ? parents : parentObject ? [parentObject] : [],
         classWithidname: {
           id: class_id,
           class_name: class_name || '',
@@ -7339,8 +7386,13 @@ order by
   `;
     const res = await this._db.query(query, [classId, limit, offset]);
     const rows = res?.values ?? [];
+    const studentIds = rows
+      .map((row) => String((row as { id?: string | null })?.id ?? '').trim())
+      .filter((id): id is string => id.length > 0);
+    // Hydrate full parent contact list so UI can show merged phone/email entries.
+    const parentsByStudentId = await this.getParentsByStudentIds(studentIds);
 
-    const studentInfoList: StudentInfo[] = rows.map((row: any) => {
+    const studentInfoList: StudentInfo[] = rows.map((row) => {
       const {
         class_name,
         parent_id,
@@ -7351,6 +7403,8 @@ order by
       } = row;
 
       const { grade, section } = this.parseClassName(class_name || '');
+      const parents =
+        parentsByStudentId.get(String(studentUser.id ?? '')) ?? [];
       const parentObject: TableTypes<'user'> | null = parent_id
         ? {
             id: parent_id,
@@ -7388,6 +7442,8 @@ order by
         grade,
         classSection: section,
         parent: parentObject,
+        parents:
+          parents.length > 0 ? parents : parentObject ? [parentObject] : [],
       };
     });
 

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -7135,44 +7135,6 @@ order by
     return { grade: 0, section: cleanedName };
   }
 
-  private async getParentsByStudentIds(
-    studentIds: string[],
-  ): Promise<Map<string, TableTypes<'user'>[]>> {
-    // Shared helper: fetch all active parent links for a student batch in one query.
-    const parentsByStudentId = new Map<string, TableTypes<'user'>[]>();
-    if (!this._db || studentIds.length === 0) return parentsByStudentId;
-
-    const parentPlaceholders = studentIds.map(() => '?').join(', ');
-    const parentRowsRes = await this._db.query(
-      `
-      SELECT pu.student_id as linked_student_id, p.*
-      FROM ${TABLES.ParentUser} pu
-      JOIN ${TABLES.User} p ON pu.parent_id = p.id
-      WHERE pu.student_id IN (${parentPlaceholders})
-        AND pu.is_deleted = false
-        AND p.is_deleted = false
-      `,
-      studentIds,
-    );
-
-    (parentRowsRes?.values ?? []).forEach((parentRow) => {
-      const row = parentRow as TableTypes<'user'> & {
-        linked_student_id?: string | null;
-      };
-      const linkedStudentId = String(row.linked_student_id ?? '').trim();
-      if (!linkedStudentId) return;
-
-      const { linked_student_id, ...parentUser } = row;
-      const currentParents = parentsByStudentId.get(linkedStudentId) ?? [];
-      parentsByStudentId.set(linkedStudentId, [
-        ...currentParents,
-        parentUser as TableTypes<'user'>,
-      ]);
-    });
-
-    return parentsByStudentId;
-  }
-
   async getStudentInfoBySchoolId(
     schoolId: string,
     page: number = 1,
@@ -7262,7 +7224,10 @@ order by
       .map((row) => String((row as { id?: string | null })?.id ?? '').trim())
       .filter((id): id is string => id.length > 0);
     // Hydrate full parent contact list so UI can show merged phone/email entries.
-    const parentsByStudentId = await this.getParentsByStudentIds(studentIds);
+    const parentRows = (await this.getParentsByStudentId('', {
+      studentIds,
+      activeOnly: true,
+    })) as Array<TableTypes<'user'> & { linked_student_id?: string | null }>;
 
     const studentInfoList: StudentInfo[] = rows.map((row) => {
       const {
@@ -7276,8 +7241,16 @@ order by
       } = row;
 
       const { grade, section } = this.parseClassName(class_name || '');
-      const parents =
-        parentsByStudentId.get(String(studentUser.id ?? '')) ?? [];
+      const parents = parentRows
+        .filter(
+          (parent) =>
+            String(parent.linked_student_id ?? '').trim() ===
+            String(studentUser.id ?? '').trim(),
+        )
+        .map(({ linked_student_id, ...parentUser }) => {
+          void linked_student_id;
+          return parentUser as TableTypes<'user'>;
+        });
       const parentObject: TableTypes<'user'> | null = parent_id
         ? {
             id: parent_id,
@@ -7390,7 +7363,10 @@ order by
       .map((row) => String((row as { id?: string | null })?.id ?? '').trim())
       .filter((id): id is string => id.length > 0);
     // Hydrate full parent contact list so UI can show merged phone/email entries.
-    const parentsByStudentId = await this.getParentsByStudentIds(studentIds);
+    const parentRows = (await this.getParentsByStudentId('', {
+      studentIds,
+      activeOnly: true,
+    })) as Array<TableTypes<'user'> & { linked_student_id?: string | null }>;
 
     const studentInfoList: StudentInfo[] = rows.map((row) => {
       const {
@@ -7403,8 +7379,16 @@ order by
       } = row;
 
       const { grade, section } = this.parseClassName(class_name || '');
-      const parents =
-        parentsByStudentId.get(String(studentUser.id ?? '')) ?? [];
+      const parents = parentRows
+        .filter(
+          (parent) =>
+            String(parent.linked_student_id ?? '').trim() ===
+            String(studentUser.id ?? '').trim(),
+        )
+        .map(({ linked_student_id, ...parentUser }) => {
+          void linked_student_id;
+          return parentUser as TableTypes<'user'>;
+        });
       const parentObject: TableTypes<'user'> | null = parent_id
         ? {
             id: parent_id,
@@ -7499,6 +7483,10 @@ order by
   }
   async getParentsByStudentId(
     studentId: string,
+    options?: {
+      studentIds?: string[];
+      activeOnly?: boolean;
+    },
   ): Promise<TableTypes<'user'>[]> {
     await this.ensureInitialized();
     if (!this._db) {
@@ -7507,19 +7495,33 @@ order by
     }
 
     try {
+      const requestedStudentIds =
+        options?.studentIds?.filter((id) => id.trim() !== '') ??
+        (studentId.trim() !== '' ? [studentId] : []);
+      if (requestedStudentIds.length === 0) {
+        return [];
+      }
+
+      const parentPlaceholders = requestedStudentIds.map(() => '?').join(', ');
+      const activeOnlyClause =
+        options?.activeOnly === true
+          ? `
+          AND pu.is_deleted = false
+          AND p.is_deleted = false
+        `
+          : '';
       const parentRes = await this._db.query(
         `
-          SELECT p.*
+          SELECT pu.student_id as linked_student_id, p.*
           FROM parent_user pu
           JOIN user p ON pu.parent_id = p.id
-          WHERE pu.student_id = ?
+          WHERE pu.student_id IN (${parentPlaceholders})
+          ${activeOnlyClause}
         `,
-        // no is_deleted filter
-        [studentId],
+        requestedStudentIds,
       );
 
-      const parentRows = parentRes?.values ?? [];
-      return parentRows;
+      return (parentRes?.values ?? []) as TableTypes<'user'>[];
     } catch (error) {
       logger.error('Error fetching parents by student ID', error);
       return [];

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -3727,15 +3727,14 @@ export class SupabaseApi implements ServiceApi {
       };
     }
 
-    const parentByStudentId = new Map<
+    const parentsByStudentId = new Map<
       string,
-      {
+      Array<{
         id?: string;
-        parent_name?: string;
         phone?: string;
         email?: string;
         is_wa_contact?: string | boolean | null;
-      } | null
+      }>
     >();
     if (pagedStudentIds.length > 0) {
       const { data: parentLinks, error: parentError } = await this.supabase
@@ -3759,7 +3758,6 @@ export class SupabaseApi implements ServiceApi {
           string,
           {
             id?: string;
-            parent_name?: string;
             phone?: string;
             email?: string;
             is_wa_contact?: string | boolean | null;
@@ -3795,10 +3793,6 @@ export class SupabaseApi implements ServiceApi {
 
               parentById.set(parentId, {
                 id: parentId,
-                parent_name:
-                  typeof parentUser?.name === 'string'
-                    ? parentUser.name
-                    : undefined,
                 phone:
                   typeof parentUser?.phone === 'string'
                     ? parentUser.phone
@@ -3820,8 +3814,24 @@ export class SupabaseApi implements ServiceApi {
         (parentLinks || []).forEach((link) => {
           const sid = String(link?.student_id || '').trim();
           const parentId = String(link?.parent_id || '').trim();
-          if (!sid || parentByStudentId.has(sid)) return;
-          parentByStudentId.set(sid, parentById.get(parentId) || null);
+          const parent = parentById.get(parentId);
+          if (!sid || !parent) return;
+
+          const currentParents = parentsByStudentId.get(sid) ?? [];
+          // Deduplicate by contact values to keep merged contacts clean.
+          const alreadyAdded = currentParents.some(
+            (existingParent) =>
+              (existingParent.id && existingParent.id === parent.id) ||
+              (existingParent.phone &&
+                parent.phone &&
+                existingParent.phone === parent.phone) ||
+              (existingParent.email &&
+                parent.email &&
+                existingParent.email === parent.email),
+          );
+          if (alreadyAdded) return;
+
+          parentsByStudentId.set(sid, [...currentParents, parent]);
         });
       }
     }
@@ -3835,7 +3845,9 @@ export class SupabaseApi implements ServiceApi {
         const classIdValue = row.classIdValue;
         const className = classMap.get(classIdValue) || '';
         const { grade, section } = this.parseClassName(className);
-        const parent = parentByStudentId.get(studentId) || null;
+        const parents =
+          (parentsByStudentId.get(studentId) as TableTypes<'user'>[]) ?? [];
+        const parent = parents[0] || null;
         const updatedUser = {
           ...user,
           phone: user?.phone || parent?.phone || '',
@@ -3847,6 +3859,8 @@ export class SupabaseApi implements ServiceApi {
           grade,
           classSection: section,
           parent,
+          parents,
+          // Needed by student detail flows that rely on class id/name shape.
           classWithidname: {
             id: classIdValue,
             class_name: className,
@@ -3904,29 +3918,50 @@ export class SupabaseApi implements ServiceApi {
       return { data: [], total: 0 };
     }
 
-    const studentInfoList: StudentInfo[] = (data || []).map((row: any) => {
+    type StudentParentLinkRow = {
+      user?:
+        | (TableTypes<'user'> & {
+            parent_links?: Array<{ parent?: TableTypes<'user'> | null }>;
+          })
+        | null;
+      class?: { id?: string | null; name?: string | null } | null;
+    };
+    const studentRows = (data ?? []) as object[] as StudentParentLinkRow[];
+    const studentInfoList = studentRows.reduce<StudentInfo[]>((list, row) => {
       const { user, class: cls } = row;
+      if (!user) return list;
 
       const className = cls?.name || '';
       const { grade, section } = this.parseClassName(className);
 
-      const parent = user?.parent_links?.[0]?.parent || null;
+      const parents = (user.parent_links || [])
+        .map((link) => link?.parent)
+        .filter((parent): parent is TableTypes<'user'> => Boolean(parent));
+      const parent = parents[0] || null;
 
-      return {
+      list.push({
         user,
         grade,
         classSection: section,
         parent,
-      };
-    });
+        parents,
+        classWithidname: cls?.id
+          ? {
+              id: cls.id,
+              class_name: className,
+            }
+          : undefined,
+      });
+      return list;
+    }, []);
     return {
       data: studentInfoList,
       total: count ?? 0,
     };
   }
   async getStudentAndParentByStudentId(studentId: string): Promise<{
-    user: any;
-    parents: any[];
+    user: TableTypes<'user'> | null;
+    parents: TableTypes<'user'>[];
   }> {
     if (!this.supabase) {
       logger.warn('Supabase not initialized.');
@@ -3953,7 +3988,12 @@ export class SupabaseApi implements ServiceApi {
       logger.error('Error fetching student and parent by student ID:', error);
       return { user: null, parents: [] };
     }
-    const parents = (data.parent_links || []).map((link: any) => link.parent);
+    const parentLinks = (data.parent_links ?? []) as object[] as Array<{
+      parent?: TableTypes<'user'> | null;
+    }>;
+    const parents = parentLinks
+      .map((link) => link.parent)
+      .filter((parent): parent is TableTypes<'user'> => Boolean(parent));
 
     return {
       user: data,
@@ -10570,12 +10610,56 @@ export class SupabaseApi implements ServiceApi {
             .map((row) => String(row?.user?.id ?? '').trim())
             .filter((id) => id.length > 0);
 
-          let parentLinkedStudents: any[] = [];
+          type StudentSearchRow = {
+            class_id: string;
+            user: {
+              id: string;
+              name?: string | null;
+              email?: string | null;
+              phone?: string | null;
+              gender?: string | null;
+              student_id?: string | null;
+            };
+          };
+          let parentLinkedStudents: StudentSearchRow[] = [];
+          type ParentSearchContact = {
+            phone?: string | null;
+            email?: string | null;
+            is_wa_contact?: string | boolean | null;
+          };
+          const parentContactsByStudentId = new Map<
+            string,
+            ParentSearchContact[]
+          >();
+          const addParentContact = (
+            studentId: string | null | undefined,
+            parent: ParentSearchContact | null | undefined,
+          ) => {
+            const normalizedStudentId = String(studentId ?? '').trim();
+            if (!normalizedStudentId || !parent) return;
 
-          const parentContactMap = new Map<string, any>();
+            const currentParents =
+              parentContactsByStudentId.get(normalizedStudentId) ?? [];
+            // For search results we only need unique phone/email contact entries.
+            const alreadyAdded = currentParents.some(
+              (existingParent) =>
+                (existingParent.phone &&
+                  parent.phone &&
+                  existingParent.phone === parent.phone) ||
+                (existingParent.email &&
+                  parent.email &&
+                  existingParent.email === parent.email),
+            );
+            if (alreadyAdded) return;
+
+            parentContactsByStudentId.set(normalizedStudentId, [
+              ...currentParents,
+              parent,
+            ]);
+          };
 
           if (parentIds.length > 0) {
-            const { data: parentLinksRaw } = await (supabase
+            const { data: parentLinksRaw } = await supabase
               .from('parent_user')
               .select(
                 `
@@ -10588,7 +10672,7 @@ export class SupabaseApi implements ServiceApi {
               `,
               )
               .in('parent_id', parentIds)
-              .eq('is_deleted', false) as any);
+              .eq('is_deleted', false);
             const parentLinks = (parentLinksRaw ?? []) as Array<{
               student_id?: string | null;
               parent?: {
@@ -10602,8 +10686,8 @@ export class SupabaseApi implements ServiceApi {
               .map((link) => String(link?.student_id ?? '').trim())
               .filter((id) => id.length > 0);
 
-            (parentLinks ?? []).forEach((link: any) => {
-              parentContactMap.set(link.student_id, {
+            parentLinks.forEach((link) => {
+              addParentContact(link.student_id, {
                 phone: link.parent?.phone ?? null,
                 email: link.parent?.email ?? null,
                 is_wa_contact: link.parent?.is_wa_contact ?? null,
@@ -10631,13 +10715,17 @@ export class SupabaseApi implements ServiceApi {
                 .in('user_id', studentIds)
                 .eq('is_deleted', false);
 
-              parentLinkedStudents = data ?? [];
+              parentLinkedStudents = (data ??
+                []) as object[] as StudentSearchRow[];
             }
           }
 
-          const allRows = [...(studentRows ?? []), ...parentLinkedStudents];
+          const allRows = [
+            ...((studentRows ?? []) as object[] as StudentSearchRow[]),
+            ...parentLinkedStudents,
+          ];
 
-          const uniqueMap = new Map<string, any>();
+          const uniqueMap = new Map<string, StudentSearchRow>();
 
           allRows.forEach((row) => {
             uniqueMap.set(row.user.id, row);
@@ -10645,14 +10733,11 @@ export class SupabaseApi implements ServiceApi {
 
           const mergedRows = Array.from(uniqueMap.values());
           // ✅ GET ALL STUDENT IDS
-          const allStudentIds = mergedRows.map((r: any) => r.user.id);
+          const allStudentIds = mergedRows.map((r) => r.user.id);
 
-          // Fetch parent contact only for students not already mapped.
-          const missingParentStudentIds = allStudentIds.filter(
-            (id: string) => !parentContactMap.has(id),
-          );
-          if (missingParentStudentIds.length > 0) {
-            const { data: allParentLinksRaw } = await (supabase
+          // Fetch every linked parent contact for matched students.
+          if (allStudentIds.length > 0) {
+            const { data: allParentLinksRaw } = await supabase
               .from('parent_user')
               .select(
                 `
@@ -10664,8 +10749,8 @@ export class SupabaseApi implements ServiceApi {
         )
       `,
               )
-              .in('student_id', missingParentStudentIds)
-              .eq('is_deleted', false) as any);
+              .in('student_id', allStudentIds)
+              .eq('is_deleted', false);
             const allParentLinks = (allParentLinksRaw ?? []) as Array<{
               student_id?: string | null;
               parent?: {
@@ -10676,9 +10761,7 @@ export class SupabaseApi implements ServiceApi {
             }>;
 
             allParentLinks.forEach((link) => {
-              const studentId = String(link?.student_id ?? '').trim();
-              if (!studentId) return;
-              parentContactMap.set(studentId, {
+              addParentContact(link.student_id, {
                 phone: link.parent?.phone ?? null,
                 email: link.parent?.email ?? null,
                 is_wa_contact: link.parent?.is_wa_contact ?? null,
@@ -10688,16 +10771,16 @@ export class SupabaseApi implements ServiceApi {
           const offset = (page - 1) * limit;
 
           const pagedRows = mergedRows.slice(offset, offset + limit);
-          const result = pagedRows.map((row: any) => {
-            const classInfo = classData?.find(
-              (c: any) => c.id === row.class_id,
-            );
+          const result = pagedRows.map((row) => {
+            const classInfo = classData?.find((c) => c.id === row.class_id);
 
             const className = classInfo?.name ?? '';
 
             const { grade, section } = this.parseClassName(className);
 
-            const parentContact = parentContactMap.get(row.user.id) ?? {};
+            const parentContacts =
+              parentContactsByStudentId.get(row.user.id) ?? [];
+            const parentContact = parentContacts[0] ?? {};
 
             // ✅ FALLBACK FLATTEN LOGIC (ONLY ADDITION)
             const phone = row.user.phone || parentContact.phone || '';
@@ -10718,9 +10801,14 @@ export class SupabaseApi implements ServiceApi {
                 email: parentContact.email ?? null,
                 is_wa_contact: parentContact.is_wa_contact ?? null,
               },
+              parents: parentContacts,
 
               class_id: row.class_id,
               class_name: className,
+              classWithidname: {
+                id: row.class_id,
+                class_name: className,
+              },
               grade,
               classSection: section,
             };

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -4002,23 +4002,42 @@ export class SupabaseApi implements ServiceApi {
   }
   async getParentsByStudentId(
     studentId: string,
+    options?: {
+      studentIds?: string[];
+      activeOnly?: boolean;
+    },
   ): Promise<TableTypes<'user'>[]> {
     if (!this.supabase) {
       logger.warn('Supabase not initialized.');
       return [];
     }
 
-    const { data, error } = await this.supabase
-      .from('parent_user')
-      .select(
-        `
+    const requestedStudentIds =
+      options?.studentIds?.filter((id) => id.trim() !== '') ??
+      (studentId.trim() !== '' ? [studentId] : []);
+    if (requestedStudentIds.length === 0) {
+      return [];
+    }
+
+    let query = this.supabase.from('parent_user').select(
+      `
           parent:parent_id (
             *
           )
         `,
-      )
-      .eq('student_id', studentId);
-    // no is_deleted filter
+    );
+
+    if (requestedStudentIds.length === 1) {
+      query = query.eq('student_id', requestedStudentIds[0]);
+    } else {
+      query = query.in('student_id', requestedStudentIds);
+    }
+
+    if (options?.activeOnly) {
+      query = query.eq('is_deleted', false);
+    }
+
+    const { data, error } = await query;
 
     if (error || !data) {
       logger.error('Error fetching parents by student ID:', error);


### PR DESCRIPTION
Expose all merged parent phone/email contacts in Edit Student Details, FC Interact popup, and Merge Card List using shared contact helpers. Keep backend scope fetch-only by hydrating parent contact lists in student fetch/search responses, remove unnecessary parent metadata in search aggregation, and preserve existing class metadata shape required by student flows. Also fix post-merge stale UI by invalidating/reloading cached student data and preferring refreshed cache on remount.