### PR TITLE
fix: prevent unnecessary homework pathway reloads during final sticker flow completion

### DIFF
--- a/src/components/assignment/HomeworkPathwayStructure.tsx
+++ b/src/components/assignment/HomeworkPathwayStructure.tsx
@@ -51,7 +51,10 @@ import StickerBookPreviewModal, {
 import { AudioUtil } from '../../utility/AudioUtil';
 import { useHomeworkSticker } from '../../hooks/useHomeworkSticker';
 import logger from '../../utility/logger';
-import { hasPendingHomeworkStickerFlow } from '../../utility/homeworkStickerFlow';
+import {
+  hasPendingFinalHomeworkStickerFlow,
+  hasPendingHomeworkStickerFlow,
+} from '../../utility/homeworkStickerFlow';
 
 interface HomeworkPathwayStructureProps {
   selectedSubject?: string | null;
@@ -708,6 +711,7 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
   const {
     closeStickerCompletion,
     closeStickerPreview,
+    finishFinalHomeworkStickerFlow,
     getPersistedStickerCompletionPayload,
     getStickerPreviewPayload,
     handleMascotReplayClick,
@@ -1908,6 +1912,9 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
           sessionStorage.removeItem(PENDING_HOMEWORK_REWARD_TRANSITION_KEY);
           await updateMascotToNormalState(newRewardId as string);
           await Util.updateUserReward();
+          if (hasPendingFinalHomeworkStickerFlow()) {
+            finishFinalHomeworkStickerFlow();
+          }
         }
 
         if (shouldRunRewardAnimation) {
@@ -1960,6 +1967,7 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
     checkAndUpdateReward,
     history,
     fetchSVGGroup,
+    finishFinalHomeworkStickerFlow,
     getPersistedStickerCompletionPayload,
     getStickerPreviewPayload,
     handleStickerPreviewReady,

--- a/src/hooks/useHomeworkSticker.test.ts
+++ b/src/hooks/useHomeworkSticker.test.ts
@@ -94,7 +94,7 @@ describe('useHomeworkSticker', () => {
       },
     );
 
-    const { result, rerender } = renderHook(
+    const { result } = renderHook(
       ({ riveContainer }: { riveContainer: HTMLDivElement | null }) =>
         useHomeworkSticker({
           containerRef: { current: container },
@@ -124,22 +124,88 @@ describe('useHomeworkSticker', () => {
     });
 
     await act(async () => {
-      jest.runOnlyPendingTimers();
-    });
-
-    expect(reloadHomeworkPathway).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      rerender({ riveContainer: document.createElement('div') });
       await Promise.resolve();
     });
 
+    expect(reloadHomeworkPathway).not.toHaveBeenCalled();
     expect(playMascotAudioFromLocalPath).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       jest.advanceTimersByTime(4000);
     });
 
+    expect(onFinalHomeworkStickerComplete).not.toHaveBeenCalled();
+
+    act(() => {
+      capturedPlaybackStop?.();
+    });
+
+    expect(onFinalHomeworkStickerComplete).toHaveBeenCalledTimes(1);
+  });
+
+  test('finishes final homework after collecting the sticker preview without pathway reload', async () => {
+    const container = document.createElement('div');
+    const reloadHomeworkPathway = jest.fn();
+    const onFinalHomeworkStickerComplete = jest.fn();
+    let capturedPlaybackStop: (() => void) | undefined;
+
+    const playMascotAudioFromLocalPath = jest.fn(
+      async (
+        _localAudioPath: string,
+        _stateConfig?: {
+          stateMachine?: string;
+          inputName?: string;
+          stateValue?: number;
+          animationName?: string;
+        },
+        playbackOptions?: {
+          onPlaybackStop?: () => void;
+        },
+      ) => {
+        capturedPlaybackStop = playbackOptions?.onPlaybackStop;
+        return true;
+      },
+    );
+
+    const { result } = renderHook(() =>
+      useHomeworkSticker({
+        containerRef: { current: container },
+        riveContainer: document.createElement('div'),
+        currentMascotStateValue: 1,
+        reloadHomeworkPathway,
+        onFinalHomeworkStickerComplete,
+        playMascotAudioFromLocalPath,
+        playRewardAudio: jest.fn().mockResolvedValue(undefined),
+      }),
+    );
+
+    act(() => {
+      setPendingFinalHomeworkStickerFlow('student-1');
+      result.current.handleStickerPreviewReady(
+        {
+          source: 'homework_pathway',
+          stickerBookId: 'book-1',
+          stickerBookTitle: 'Sticker Book',
+          stickerBookSvgUrl: '',
+          collectedStickerIds: [],
+          nextStickerId: 'sticker-1',
+          nextStickerName: 'Sticker 1',
+          nextStickerImage: 'sticker.png',
+        },
+        'pathway_completion_auto',
+      );
+    });
+
+    act(() => {
+      result.current.closeStickerPreview('acknowledge_button');
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(reloadHomeworkPathway).not.toHaveBeenCalled();
+    expect(playMascotAudioFromLocalPath).toHaveBeenCalledTimes(1);
     expect(onFinalHomeworkStickerComplete).not.toHaveBeenCalled();
 
     act(() => {

--- a/src/hooks/useHomeworkSticker.test.ts
+++ b/src/hooks/useHomeworkSticker.test.ts
@@ -3,7 +3,10 @@ import { useHomeworkSticker } from './useHomeworkSticker';
 import { ServiceConfig } from '../services/ServiceConfig';
 import { Util } from '../utility/util';
 import { AudioUtil } from '../utility/AudioUtil';
-import { setPendingFinalHomeworkStickerFlow } from '../utility/homeworkStickerFlow';
+import {
+  hasPendingFinalHomeworkStickerFlow,
+  setPendingFinalHomeworkStickerFlow,
+} from '../utility/homeworkStickerFlow';
 
 jest.mock('../services/ServiceConfig');
 jest.mock('../utility/util');
@@ -205,6 +208,62 @@ describe('useHomeworkSticker', () => {
     });
 
     expect(reloadHomeworkPathway).not.toHaveBeenCalled();
+    expect(playMascotAudioFromLocalPath).toHaveBeenCalledTimes(1);
+    expect(onFinalHomeworkStickerComplete).not.toHaveBeenCalled();
+
+    act(() => {
+      capturedPlaybackStop?.();
+    });
+
+    expect(onFinalHomeworkStickerComplete).toHaveBeenCalledTimes(1);
+  });
+
+  test('guards final homework sticker finish against duplicate triggers', async () => {
+    const container = document.createElement('div');
+    const onFinalHomeworkStickerComplete = jest.fn();
+    let capturedPlaybackStop: (() => void) | undefined;
+
+    const playMascotAudioFromLocalPath = jest.fn(
+      async (
+        _localAudioPath: string,
+        _stateConfig?: {
+          stateMachine?: string;
+          inputName?: string;
+          stateValue?: number;
+          animationName?: string;
+        },
+        playbackOptions?: {
+          onPlaybackStop?: () => void;
+        },
+      ) => {
+        capturedPlaybackStop = playbackOptions?.onPlaybackStop;
+        return true;
+      },
+    );
+
+    const { result } = renderHook(() =>
+      useHomeworkSticker({
+        containerRef: { current: container },
+        riveContainer: document.createElement('div'),
+        currentMascotStateValue: 1,
+        reloadHomeworkPathway: jest.fn(),
+        onFinalHomeworkStickerComplete,
+        playMascotAudioFromLocalPath,
+        playRewardAudio: jest.fn().mockResolvedValue(undefined),
+      }),
+    );
+
+    act(() => {
+      setPendingFinalHomeworkStickerFlow('student-1');
+      result.current.finishFinalHomeworkStickerFlow();
+      result.current.finishFinalHomeworkStickerFlow();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(hasPendingFinalHomeworkStickerFlow()).toBe(false);
     expect(playMascotAudioFromLocalPath).toHaveBeenCalledTimes(1);
     expect(onFinalHomeworkStickerComplete).not.toHaveBeenCalled();
 

--- a/src/hooks/useHomeworkSticker.ts
+++ b/src/hooks/useHomeworkSticker.ts
@@ -668,10 +668,7 @@ export function useHomeworkSticker({
       }
 
       if (hasPendingFinalHomeworkStickerFlow()) {
-        playStickerAudioAfterReload();
-        window.setTimeout(() => {
-          reloadHomeworkPathway();
-        }, 0);
+        playStickerAudioAndFinishHomework();
         return;
       }
 
@@ -683,6 +680,7 @@ export function useHomeworkSticker({
     [
       getPersistedStickerCompletionPayload,
       playStickerAudioAfterReload,
+      playStickerAudioAndFinishHomework,
       reloadHomeworkPathway,
       stickerPreviewData,
       stickerPreviewTrigger,
@@ -705,10 +703,7 @@ export function useHomeworkSticker({
       setIsStickerCompletionOpen(false);
 
       if (hasPendingFinalHomeworkStickerFlow()) {
-        playStickerAudioAfterReload();
-        window.setTimeout(() => {
-          reloadHomeworkPathway();
-        }, 0);
+        playStickerAudioAndFinishHomework();
         return;
       }
 
@@ -738,6 +733,7 @@ export function useHomeworkSticker({
       hasPendingPathwayStickerReward,
       playStickerAudioAfterReload,
       playStickerAudioAndClearPending,
+      playStickerAudioAndFinishHomework,
       reloadHomeworkPathway,
       stickerCompletionData,
     ],
@@ -1031,6 +1027,7 @@ export function useHomeworkSticker({
     handleMascotReplayClick,
     handleStickerPreviewReady,
     hasPendingPathwayStickerReward,
+    finishFinalHomeworkStickerFlow: playStickerAudioAndFinishHomework,
     isOffline,
     isStickerBookCelebrationPopupOn,
     isStickerBookCompletionPopupOn,

--- a/src/hooks/useHomeworkSticker.ts
+++ b/src/hooks/useHomeworkSticker.ts
@@ -151,6 +151,7 @@ export function useHomeworkSticker({
   const isStickerCollectSpeakingRef = useRef(false);
   const hasCollectedStickerRef = useRef(false);
   const hasCheckedStickerReplayEligibilityRef = useRef(false);
+  const isFinishingFinalHomeworkStickerFlowRef = useRef(false);
   const pendingCelebrationRiveContainerRef = useRef<Element | null>(null);
   const latestRiveContainerRef = useRef<Element | null>(null);
   const rewardStickerTiltRequestIdRef = useRef(0);
@@ -365,6 +366,13 @@ export function useHomeworkSticker({
   );
 
   const playStickerAudioAndFinishHomework = useCallback(() => {
+    if (isFinishingFinalHomeworkStickerFlowRef.current) return;
+
+    isFinishingFinalHomeworkStickerFlowRef.current = true;
+    clearPendingFinalHomeworkStickerFlow();
+    hasCollectedStickerRef.current = true;
+    hasCheckedStickerReplayEligibilityRef.current = true;
+
     void playStickerAudioAndClearPending(() => {
       finishHomeworkAfterStickerFlow();
     });
@@ -744,6 +752,7 @@ export function useHomeworkSticker({
     latestRiveContainerRef.current = null;
     hasCollectedStickerRef.current = false;
     hasCheckedStickerReplayEligibilityRef.current = false;
+    isFinishingFinalHomeworkStickerFlowRef.current = false;
     isStickerCollectSpeakingRef.current = false;
     setShouldCelebrateAfterPathwayReload(false);
     setStickerCollectTiltActive(false);

--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -575,7 +575,9 @@ const LidoPlayer: FC = () => {
       setGameResult(data);
       const isReward: boolean = state?.reward ?? false;
       const shouldGiveDailyReward =
-        isReward || (learning_path && (await Util.shouldGiveDailyReward()));
+        isReward ||
+        ((learning_path || is_homework) &&
+          (await Util.shouldGiveDailyReward()));
       if (shouldGiveDailyReward) {
         sessionStorage.setItem(REWARD_LESSON, 'true');
       }


### PR DESCRIPTION
when the final homework sticker flow is pending, closing the sticker preview/completion now directly plays sticker collect audio and then finishes homework. It no longer waits for pathway reload.