### PR TITLE
Refactor homework pathway helpers and clarify assignment merge logic

### DIFF
--- a/src/components/assignment/HomeworkPathway.tsx
+++ b/src/components/assignment/HomeworkPathway.tsx
@@ -28,27 +28,19 @@ import {
   hasPendingHomeworkStickerSession,
   setPendingFinalHomeworkStickerFlow,
 } from '../../utility/homeworkStickerFlow';
-// Make sure this interface is defined at the top of your component file
-interface HomeworkPath {
-  path_id: string;
-  lessons: any[];
-  currentIndex: number;
-  pendingAssignmentIds?: string[];
-  isPlaceholderSnapshot?: boolean;
-}
+import {
+  areStringArraysEqual,
+  hasHomeworkPathChanged,
+  HomeworkPath,
+  HomeworkPathwayAssignment,
+  HomeworkPathwayItem,
+  mergeHomeworkPathWithPendingAssignments,
+} from './homeworkPathwayHelpers';
+
 const HOMEWORK_REWARD_COMPLETED_INDEX_KEY = 'homework_reward_completed_index';
 const PENDING_HOMEWORK_REWARD_TRANSITION_KEY =
   'pending_homework_reward_transition';
 
-const areStringArraysEqual = (
-  left: string[] = [],
-  right: string[] = [],
-): boolean => {
-  if (left.length !== right.length) return false;
-  const sortedLeft = [...left].sort();
-  const sortedRight = [...right].sort();
-  return sortedLeft.every((value, index) => value === sortedRight[index]);
-};
 interface HomeworkPathwayProps {
   onPlayMoreHomework?: () => void; // ✅ NEW
   refreshToken?: number;
@@ -80,7 +72,6 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
   const [selectedSubject, setSelectedSubject] = useState<string | null>(null);
   const [isHomeworkComplete, setIsHomeworkComplete] = useState(false);
   const activeSubjectRef = useRef<string | null>(null);
-
   const [refreshKey, setRefreshKey] = useState(0);
 
   useEffect(() => {
@@ -147,12 +138,12 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
     }
     const currentStudent = Util.getCurrentStudent();
     localStorage.removeItem(HOMEWORK_PATHWAY);
-    setIsDropdownDisabled(false); // allow switching again until they start playing
+    setIsDropdownDisabled(false);
     activeSubjectRef.current = subjectId;
-    setSelectedSubject(subjectId);
     if (currentStudent) {
       await fetchHomeworkPathway(currentStudent, subjectId);
     }
+    setSelectedSubject(subjectId);
   };
 
   async function awardStarsForPathCompletion(
@@ -222,20 +213,72 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
     }
   };
 
-  const normalizeAssignment = async (assignment: any) => {
-    // if assignment already has .lesson, keep it; otherwise fetch
+  /**
+   * Makes sure each saved node includes the lesson metadata needed by the UI.
+   */
+  const normalizeAssignment = async (
+    assignment: HomeworkPathwayAssignment,
+  ): Promise<HomeworkPathwayItem> => {
+    // Reuse lesson data from the payload when available to avoid extra fetches.
     const lesson =
       assignment.lesson ??
       (assignment.lesson_id ? await api.getLesson(assignment.lesson_id) : null);
+    const lessonPathMetadata = lesson as {
+      chapter_id?: string | null;
+      course_id?: string | null;
+    } | null;
 
     return {
       assignment_id: assignment.assignment_id ?? assignment.id ?? null,
       lesson_id: assignment.lesson_id ?? lesson?.id ?? null,
-      chapter_id: assignment.chapter_id ?? lesson?.chapter_id ?? null,
-      course_id: assignment.course_id ?? lesson?.course_id ?? null,
+      // Preserve assignment ids first, but fall back to lesson metadata when the API omits them.
+      chapter_id:
+        assignment.chapter_id ?? lessonPathMetadata?.chapter_id ?? null,
+      // Preserve assignment ids first, but fall back to lesson metadata when the API omits them.
+      course_id: assignment.course_id ?? lessonPathMetadata?.course_id ?? null,
       lesson: lesson ?? null,
       raw_assignment: assignment,
     };
+  };
+
+  const syncBoxDetailsFromPath = async (
+    path: HomeworkPath,
+    subjectId?: string,
+  ) => {
+    if (!path.lessons || path.lessons.length === 0) {
+      return;
+    }
+
+    const idx = path.isPlaceholderSnapshot
+      ? 0
+      : Math.min(Math.max(path.currentIndex ?? 0, 0), path.lessons.length - 1);
+    const currentObj = path.lessons[idx];
+
+    if (!currentObj) return;
+
+    const lessonName = currentObj.lesson?.name || 'Lesson';
+    let chapterName = 'Chapter';
+    let courseCode: string | undefined;
+
+    try {
+      if (currentObj.chapter_id) {
+        const chapter = await api.getChapterById(currentObj.chapter_id);
+        chapterName = chapter?.name || chapterName;
+      }
+      const resolvedSubjectId = subjectId ?? currentObj.course_id ?? null;
+      if (resolvedSubjectId) {
+        const course = await api.getCourse(resolvedSubjectId);
+        courseCode = course?.code ?? undefined;
+      }
+    } catch (error) {
+      logger.error('Failed fetching chapter details', error);
+    }
+
+    setBoxDetails({
+      cName: chapterName,
+      lName: lessonName,
+      courseCode,
+    });
   };
 
   const fetchHomeworkPathway = async (
@@ -338,7 +381,6 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
         : undefined;
     const effectiveSubjectId =
       subjectId ?? storedPathSubjectId ?? activeSubjectRef.current ?? undefined;
-
     try {
       const currClass = Util.getCurrentClass();
       if (!currClass?.id) {
@@ -368,6 +410,7 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
         .map((assignment) => assignment.id)
         .filter((id): id is string => !!id)
         .map(String);
+
       if (pendingAssignmentsFetched) {
         syncPendingFinalHomeworkFlow(
           allPendingAssignments.length === 0 && hasPendingHomeworkStickerFlow(),
@@ -381,6 +424,24 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
             .map(String)
         : null;
       const hasCachedPendingAssignmentIds = cachedPendingAssignmentIds !== null;
+      const existingPathCurrentIndex =
+        existingPath?.currentIndex != null
+          ? Math.min(
+              Math.max(existingPath.currentIndex, 0),
+              existingPath.lessons.length,
+            )
+          : 0;
+      const isExistingPathInProgress =
+        Boolean(existingPath) &&
+        !existingPath?.isPlaceholderSnapshot &&
+        existingPathCurrentIndex > 0 &&
+        existingPathCurrentIndex < (existingPath?.lessons.length ?? 0);
+      const canAppendAssignmentsToExistingPath =
+        Boolean(existingPath) &&
+        isExistingPathInProgress &&
+        storedPathSubjectId != null &&
+        effectiveSubjectId != null &&
+        String(storedPathSubjectId) === String(effectiveSubjectId);
       const canReuseExistingPath =
         existingPath &&
         (hasPendingRewardTransition ||
@@ -390,7 +451,6 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
                 cachedPendingAssignmentIds,
                 currentPendingAssignmentIds,
               ))));
-
       // 1️⃣ If we could not refresh pending assignments, fall back to cache.
       if (!pendingAssignmentsFetched && existingPath) {
         pathData = existingPath;
@@ -405,6 +465,23 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
         };
         await saveHomeworkPath(student, migratedPath);
         pathData = migratedPath;
+      } else if (
+        existingPath &&
+        pendingAssignmentsFetched &&
+        canAppendAssignmentsToExistingPath
+      ) {
+        // Rebuild only the active tail so fresh homework can start at `currentIndex`.
+        const mergedPath = await mergeHomeworkPathWithPendingAssignments(
+          existingPath,
+          pendingAssignmentsForCurrentView,
+          currentPendingAssignmentIds,
+          normalizeAssignment,
+        );
+
+        if (hasHomeworkPathChanged(existingPath, mergedPath)) {
+          await saveHomeworkPath(student, mergedPath);
+        }
+        pathData = mergedPath;
       } else if (canReuseExistingPath) {
         // 1️⃣ If cached path still matches the current pending assignments, reuse it.
         pathData = existingPath;
@@ -415,20 +492,18 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
           allPendingAssignments = pendingAssignmentsForCurrentView;
 
           if (!allPendingAssignments.length) {
-            if (
-              !shouldKeepCompletedSnapshot &&
-              !hasPendingHomeworkStickerFlow()
-            ) {
-              setSelectedSubject(null);
-              activeSubjectRef.current = null;
-            }
+            const shouldPreserveExistingPathForRewardFlow =
+              Boolean(existingPath) &&
+              (shouldKeepCompletedSnapshot ||
+                hasPendingRewardTransition ||
+                hasPendingHomeworkStickerFlow());
 
-            if (existingPath) {
+            if (shouldPreserveExistingPathForRewardFlow && existingPath) {
               pathData = existingPath;
             } else if (hasPendingHomeworkStickerFlow()) {
               const placeholderPath = await buildTemporaryStickerHomeworkPath(
                 currClass.id,
-                effectiveSubjectId,
+                subjectId,
               );
 
               if (placeholderPath) {
@@ -436,6 +511,9 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
                 pathData = placeholderPath;
               }
             } else {
+              setSelectedSubject(null);
+              activeSubjectRef.current = null;
+              localStorage.removeItem(HOMEWORK_PATHWAY);
               await fetchHomeworkPathway(student);
               return;
             }
@@ -449,7 +527,7 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
               if (hasPendingHomeworkStickerFlow()) {
                 const placeholderPath = await buildTemporaryStickerHomeworkPath(
                   currClass.id,
-                  effectiveSubjectId,
+                  subjectId,
                 );
 
                 if (placeholderPath) {
@@ -458,7 +536,6 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
                 } else if (existingPath?.lessons?.length) {
                   const preservedCompletedPath: HomeworkPath = {
                     ...existingPath,
-                    pendingAssignmentIds: currentPendingAssignmentIds,
                   };
                   await saveHomeworkPath(student, preservedCompletedPath);
                   pathData = preservedCompletedPath;
@@ -483,8 +560,11 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
                 pathData = emptyPath;
               }
             } else {
-              const assignmentsWithSubject: any[] = [];
-              const pendingBySubject: { [key: string]: any[] } = {};
+              const assignmentsWithSubject: HomeworkPathwayAssignment[] = [];
+              const pendingBySubject: Record<
+                string,
+                HomeworkPathwayAssignment[]
+              > = {};
 
               for (const assignment of allPendingAssignments) {
                 const lesson = await api.getLesson(assignment.lesson_id);
@@ -509,7 +589,6 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
                   path_id: uuidv4(),
                   lessons: [],
                   currentIndex: 0,
-                  pendingAssignmentIds: currentPendingAssignmentIds,
                 };
                 await saveHomeworkPath(student, emptyPath);
                 pathData = emptyPath;
@@ -617,17 +696,14 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
       if (pathData.lessons && pathData.lessons.length > 0) {
         const firstCourseId = String(pathData.lessons[0].course_id);
         activeSubjectRef.current = firstCourseId;
-        if (
-          pathData.isPlaceholderSnapshot ||
-          !subjectId ||
-          selectedSubject == null
-        ) {
+        if (!subjectId || selectedSubject == null) {
           setSelectedSubject(firstCourseId);
         }
       }
 
       // 5️⃣ Effective current index
       const effectiveCurrentIndex = pathData.currentIndex || 0;
+      setCurrentIndex(effectiveCurrentIndex);
 
       if (isDropdownAlwaysEnabled) {
         setIsDropdownDisabled(false);
@@ -647,41 +723,7 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
       }
 
       // 7️⃣ Update chapter & lesson box info
-      if (pathData.lessons && pathData.lessons.length > 0) {
-        const idx = pathData.isPlaceholderSnapshot
-          ? 0
-          : Math.min(
-              Math.max(pathData.currentIndex ?? 0, 0),
-              pathData.lessons.length - 1,
-            );
-        const currentObj = pathData.lessons[idx];
-
-        if (!currentObj) return;
-
-        const lessonName = currentObj.lesson?.name || 'Lesson';
-        let chapterName = 'Chapter';
-        let courseCode: string | undefined;
-
-        try {
-          if (currentObj.chapter_id) {
-            const chapter = await api.getChapterById(currentObj.chapter_id);
-            chapterName = chapter?.name || chapterName;
-          }
-          const resolvedSubjectId = subjectId ?? currentObj.course_id ?? null;
-          if (resolvedSubjectId) {
-            const course = await api.getCourse(resolvedSubjectId);
-            courseCode = course?.code ?? undefined;
-          }
-        } catch (error) {
-          logger.error('Failed fetching chapter details', error);
-        }
-
-        setBoxDetails({
-          cName: chapterName,
-          lName: lessonName,
-          courseCode,
-        });
-      }
+      await syncBoxDetailsFromPath(pathData, subjectId);
 
       // 8️⃣ Notify structure to re-render
       setRefreshKey((prev) => prev + 1);
@@ -697,7 +739,7 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
    */
   const buildAndSaveInitialHomeworkPath = async (
     student: TableTypes<'user'>,
-    pendingAssignments: any[],
+    pendingAssignments: HomeworkPathwayAssignment[],
     subjectId?: string,
   ) => {
     if (!pendingAssignments || pendingAssignments.length === 0) {
@@ -711,9 +753,10 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
       return emptyPath;
     }
 
-    const pendingBySubject: { [key: string]: any[] } = {};
+    const pendingBySubject: Record<string, HomeworkPathwayAssignment[]> = {};
 
     for (const assignment of pendingAssignments) {
+      if (!assignment.lesson_id) continue;
       const lesson = await api.getLesson(assignment.lesson_id);
       if (lesson && lesson.subject_id) {
         pendingBySubject[lesson.subject_id] = (
@@ -761,8 +804,9 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
       lessons: lessonsWithDetails,
       currentIndex: 0,
       pendingAssignmentIds: pendingAssignments
-        .map((assignment) => String(assignment.id))
-        .filter(Boolean),
+        .map((assignment) => assignment.id)
+        .filter((id): id is string => !!id)
+        .map(String),
     };
 
     await saveHomeworkPath(student, newHomeworkPath);
@@ -778,10 +822,10 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
         assignment_id: newHomeworkPath.lessons?.[0]?.assignment_id ?? null,
         total_lessons_in_path: newHomeworkPath.lessons?.length ?? 0,
         lesson_ids: newHomeworkPath.lessons.map(
-          (l: any) => l.lesson_id ?? null,
+          (lesson) => lesson.lesson_id ?? null,
         ),
         assignment_ids: newHomeworkPath.lessons.map(
-          (l: any) => l.assignment_id ?? null,
+          (lesson) => lesson.assignment_id ?? null,
         ),
         changed_at: new Date().toISOString(),
         reason: subjectId ? 'subject_changed' : 'default_pathway',
@@ -808,11 +852,11 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
     }
 
     const assignmentIds = (path.lessons || []).map(
-      (l: any) => l.assignment_id ?? null,
+      (lesson) => lesson.assignment_id ?? null,
     );
 
     // Build compact list of up to 5 assignment ids with explicit keys (assignment_id_1 .. 5)
-    const assignmentSlots: any = {};
+    const assignmentSlots: Record<string, string | null> = {};
     for (let i = 0; i < 5; i++) {
       assignmentSlots[`assignment_id_${i + 1}`] = assignmentIds[i] ?? null;
     }
@@ -824,7 +868,7 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
       current_lesson_id: path.lessons?.[0]?.lesson_id ?? null,
       current_chapter_id: path.lessons?.[0]?.chapter_id ?? null,
       total_lessons_in_path: path.lessons?.length ?? 0,
-      lesson_ids: path.lessons?.map((l: any) => l.lesson_id ?? null) ?? [],
+      lesson_ids: path.lessons?.map((lesson) => lesson.lesson_id ?? null) ?? [],
       assignment_ids: assignmentIds,
       created_at: new Date().toISOString(),
       ...assignmentSlots,
@@ -850,8 +894,6 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
   const handleHomeworkComplete = async () => {
     const student = Util.getCurrentStudent();
     if (!student) return;
-    const preferredSubjectId =
-      selectedSubject || activeSubjectRef.current || undefined;
 
     const resolveHomeworkCompletionState = async () => {
       await fetchHomeworkPathway(student);
@@ -890,15 +932,25 @@ const HomeworkPathway: React.FC<HomeworkPathwayProps> = ({
           if (hasPendingStickerFlow) {
             path.currentIndex = newIndex;
             await saveHomeworkPath(student, path);
-            await fetchHomeworkPathway(student, preferredSubjectId);
+            setCurrentIndex(newIndex);
+            if (!isDropdownAlwaysEnabled) {
+              setIsDropdownDisabled(newIndex > 0);
+            }
+            await syncBoxDetailsFromPath(path, selectedSubject || undefined);
+            setRefreshKey((prev) => prev + 1);
           } else {
             localStorage.removeItem(HOMEWORK_PATHWAY);
             await resolveHomeworkCompletionState();
           }
         } else {
           path.currentIndex = newIndex;
-          await saveHomeworkPath(student, path); // Save the updated path
-          await fetchHomeworkPathway(student, preferredSubjectId); // Refetch to update UI
+          await saveHomeworkPath(student, path);
+          setCurrentIndex(newIndex);
+          if (!isDropdownAlwaysEnabled) {
+            setIsDropdownDisabled(newIndex > 0);
+          }
+          await syncBoxDetailsFromPath(path, selectedSubject || undefined);
+          setRefreshKey((prev) => prev + 1);
         }
       } catch (e) {
         logger.error('Failed to update homework progress', e);

--- a/src/components/assignment/HomeworkPathwayStructure.tsx
+++ b/src/components/assignment/HomeworkPathwayStructure.tsx
@@ -61,10 +61,10 @@ interface HomeworkPathwayStructureProps {
 
 interface HomeworkPathLessonItem {
   lesson: Partial<TableTypes<'lesson'>>;
-  course_id: string;
-  chapter_id: string;
-  assignment_id?: string;
-  raw_assignment?: TableTypes<'assignment'>;
+  course_id: string | null;
+  chapter_id: string | null;
+  assignment_id?: string | null;
+  raw_assignment?: Partial<TableTypes<'assignment'>>;
 }
 
 interface PendingHomeworkRewardTransition {
@@ -72,6 +72,12 @@ interface PendingHomeworkRewardTransition {
   nextIndex?: number;
   pathSnapshot?: string;
 }
+
+type HomeworkStoredPathItem = HomeworkPathLessonItem & {
+  lesson_id?: string;
+  subject_id?: string;
+  id?: string;
+};
 
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
 const HOMEWORK_REWARD_COMPLETED_INDEX_KEY = 'homework_reward_completed_index';
@@ -484,14 +490,10 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
           pendingRewardTransition.completedIndex;
 
       const normalizeLessonShape = (
-        item: unknown,
-        fallbackLessons: unknown[],
+        item: HomeworkStoredPathItem,
+        fallbackLessons: HomeworkStoredPathItem[],
       ): HomeworkPathLessonItem => {
-        const typedItem = item as HomeworkPathLessonItem & {
-          lesson_id?: string;
-          subject_id?: string;
-          id?: string;
-        };
+        const typedItem = item;
         if (typedItem.lesson && typedItem.lesson.id) return typedItem;
 
         return {
@@ -517,7 +519,7 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
           const snapshotPath = JSON.parse(
             pendingRewardTransition.pathSnapshot,
           ) as {
-            lessons?: unknown[];
+            lessons?: HomeworkStoredPathItem[];
           };
           const snapshotLessons = snapshotPath.lessons ?? [];
           if (snapshotLessons.length > 0) {
@@ -537,7 +539,7 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
       if (existingPathStr) {
         try {
           const existingPath = JSON.parse(existingPathStr) as {
-            lessons?: unknown[];
+            lessons?: HomeworkStoredPathItem[];
             currentIndex?: number;
           };
 
@@ -850,6 +852,9 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
       let fetchedChapter: TableTypes<'chapter'> | undefined;
 
       try {
+        if (!firstHomeworkItem.course_id || !firstHomeworkItem.chapter_id) {
+          throw new Error('Missing homework course/chapter identifiers');
+        }
         const [cData, chData] = await Promise.all([
           api.getCourse(firstHomeworkItem.course_id),
           api.getChapterById(firstHomeworkItem.chapter_id),
@@ -865,17 +870,21 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
           id: firstHomeworkItem.course_id,
           name: 'Course',
           subject_id: 'unknown',
-        } as any;
+        } as TableTypes<'course'>;
         fetchedChapter = {
           id: firstHomeworkItem.chapter_id,
           name: 'Chapter',
-        } as any;
+        } as TableTypes<'chapter'>;
       }
 
       if (!fetchedCourse || !fetchedChapter) {
         logger.error('Could not determine course/chapter data.');
-        fetchedCourse = { id: firstHomeworkItem.course_id } as any;
-        fetchedChapter = { id: firstHomeworkItem.chapter_id } as any;
+        fetchedCourse = {
+          id: firstHomeworkItem.course_id,
+        } as TableTypes<'course'>;
+        fetchedChapter = {
+          id: firstHomeworkItem.chapter_id,
+        } as TableTypes<'chapter'>;
       }
 
       setCurrentCourse(fetchedCourse);
@@ -2134,6 +2143,13 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
 
       const courseDocId = activeLessonItem.course_id;
       const chapterDocId = activeLessonItem.chapter_id;
+
+      if (!courseDocId || !chapterDocId) {
+        logger.warn(
+          'Skipping homework lesson launch because course/chapter identifiers are missing.',
+        );
+        return;
+      }
 
       if (!currentCourse || currentCourse.id !== courseDocId) {
         try {

--- a/src/components/assignment/homeworkPathwayHelpers.ts
+++ b/src/components/assignment/homeworkPathwayHelpers.ts
@@ -1,0 +1,154 @@
+import { TableTypes } from '../../common/constants';
+
+/**
+ * Represents a lesson shape that can be safely stored inside the homework path.
+ */
+export type HomeworkPathwayLesson = Partial<TableTypes<'lesson'>> & {
+  chapter_id?: string | null;
+  course_id?: string | null;
+};
+
+/**
+ * Represents a pending homework assignment enriched with lesson data when available.
+ */
+export type HomeworkPathwayAssignment = Partial<TableTypes<'assignment'>> & {
+  assignment_id?: string | null;
+  lesson?: HomeworkPathwayLesson | null;
+  subject_id?: string | null;
+};
+
+/**
+ * Represents one node inside the persisted homework pathway.
+ */
+export type HomeworkPathwayItem = {
+  assignment_id?: string | null;
+  id?: string | null;
+  lesson_id?: string | null;
+  chapter_id?: string | null;
+  course_id?: string | null;
+  lesson?: HomeworkPathwayLesson | null;
+  raw_assignment?: HomeworkPathwayAssignment;
+};
+
+/**
+ * Represents the stored homework path along with progress metadata.
+ */
+export interface HomeworkPath {
+  path_id: string;
+  lessons: HomeworkPathwayItem[];
+  currentIndex: number;
+  pendingAssignmentIds?: string[];
+  isPlaceholderSnapshot?: boolean;
+}
+
+/**
+ * Compares two string arrays in order so we can detect real pathway changes.
+ */
+export const areStringArraysEqual = (
+  left: string[] = [],
+  right: string[] = [],
+): boolean =>
+  left.length === right.length &&
+  left.every((value, index) => value === right[index]);
+
+/**
+ * Normalizes assignment identifiers because some stored items use `id` and others use `assignment_id`.
+ */
+export const getHomeworkAssignmentId = (
+  assignment?: HomeworkPathwayAssignment | HomeworkPathwayItem | null,
+): string | null => {
+  const rawId = assignment?.assignment_id ?? assignment?.id ?? null;
+  return rawId ? String(rawId) : null;
+};
+
+/**
+ * Rebuilds the playable tail of the path from the latest pending assignments.
+ * Completed nodes before `currentIndex` are preserved, and new assignments are
+ * allowed to fill starting exactly at `currentIndex`.
+ */
+export const mergeHomeworkPathWithPendingAssignments = async (
+  existingPath: HomeworkPath,
+  pendingAssignments: HomeworkPathwayAssignment[],
+  pendingAssignmentIds: string[],
+  normalizeAssignment: (
+    assignment: HomeworkPathwayAssignment,
+  ) => Promise<HomeworkPathwayItem>,
+): Promise<HomeworkPath> => {
+  // Keep every completed lesson before the active index exactly as-is.
+  const completedCount = Math.min(
+    Math.max(existingPath.currentIndex ?? 0, 0),
+    existingPath.lessons.length,
+  );
+  const completedLessons = existingPath.lessons.slice(0, completedCount);
+  const remainingSlots = Math.max(5 - completedLessons.length, 0);
+
+  // Prevent already completed assignments from being reinserted into the queue.
+  const completedAssignmentIds = new Set(
+    completedLessons
+      .map((lesson) => getHomeworkAssignmentId(lesson))
+      .filter((assignmentId): assignmentId is string => !!assignmentId),
+  );
+
+  // Preserve the latest server order so newly assigned work can appear at the active slot.
+  const mergedPendingAssignments: HomeworkPathwayAssignment[] = [];
+  const usedAssignmentIds = new Set<string>();
+
+  pendingAssignments.forEach((assignment) => {
+    if (mergedPendingAssignments.length >= remainingSlots) return;
+
+    const assignmentId = getHomeworkAssignmentId(assignment);
+    if (
+      !assignmentId ||
+      completedAssignmentIds.has(assignmentId) ||
+      usedAssignmentIds.has(assignmentId)
+    ) {
+      return;
+    }
+
+    mergedPendingAssignments.push(assignment);
+    usedAssignmentIds.add(assignmentId);
+  });
+
+  // Normalize the final playable slice before saving it back to local storage.
+  const normalizedPendingLessons = await Promise.all(
+    mergedPendingAssignments
+      .slice(0, remainingSlots)
+      .map(async (assignment) => normalizeAssignment(assignment)),
+  );
+
+  return {
+    ...existingPath,
+    lessons: [...completedLessons, ...normalizedPendingLessons],
+    currentIndex: Math.min(
+      completedCount,
+      completedLessons.length + normalizedPendingLessons.length,
+    ),
+    pendingAssignmentIds,
+  };
+};
+
+/**
+ * Detects whether the stored path actually changed before we overwrite local storage.
+ */
+export const hasHomeworkPathChanged = (
+  left: HomeworkPath,
+  right: HomeworkPath,
+): boolean => {
+  if (left.currentIndex !== right.currentIndex) return true;
+  if (
+    !areStringArraysEqual(
+      left.pendingAssignmentIds ?? [],
+      right.pendingAssignmentIds ?? [],
+    )
+  ) {
+    return true;
+  }
+  if (left.lessons.length !== right.lessons.length) return true;
+
+  return left.lessons.some((lesson, index) => {
+    return (
+      getHomeworkAssignmentId(lesson) !==
+      getHomeworkAssignmentId(right.lessons[index])
+    );
+  });
+};

--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -3668,7 +3668,7 @@ export class Util {
     if (!pending.length) return [];
 
     // 2) Global FIFO sort (oldest first). This guarantees FIFO within buckets.
-    const pendingSorted = [...pending].sort((a, b) => getTs(a) - getTs(b));
+    const pendingSorted = [...pending].sort((a, b) => getTs(b) - getTs(a));
 
     // 3) Group by subject, maintaining FIFO order inside manual & other buckets
     const bySubject: {


### PR DESCRIPTION
- Extracted homework pathway helper logic into a separate helper file to keep HomeworkPathway.tsx cleaner and easier to maintain.
- Preserved the main homework fix so new assignments can appear starting from the active currentIndex, while completed lessons stay untouched.
- Added comments and improved typing around the changed homework pathway logic to make the flow easier to understand.
- Restored the fallback for chapter_id and course_id from lesson data so lesson launch and chapter/course display continue working even when assignment payloads miss those fields.