### PR TITLE
fix: terms modal regressions around route restore and stale auth state

### DIFF
--- a/src/ProtectedRoute.test.tsx
+++ b/src/ProtectedRoute.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Switch } from 'react-router-dom';
+import type { ReactElement } from 'react';
+import { MemoryRouter, Route, Switch, useLocation } from 'react-router-dom';
 import {
   __resetGrowthBookMock,
   __setGrowthBookMock,
@@ -8,10 +9,34 @@ import {
 
 import ProtectedRoute from './ProtectedRoute';
 import { LATEST_TC_VERSION, PAGES } from './common/constants';
+import TermsAndConditions from './pages/TermsAndConditions';
 import {
   mockApiHandler,
   mockAuthHandler,
 } from './tests/__mocks__/serviceConfigMock';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (value: string) => value,
+  }),
+  Trans: ({
+    i18nKey,
+    components,
+  }: {
+    i18nKey: string;
+    components?: Record<number, ReactElement>;
+  }) => {
+    const parts = i18nKey.split(/<1>|<\/1>/);
+
+    return (
+      <>
+        {parts[0]}
+        {components?.[1]}
+        {parts[2] ?? ''}
+      </>
+    );
+  },
+}));
 
 jest.mock('./utility/util', () => ({
   Util: {
@@ -20,6 +45,21 @@ jest.mock('./utility/util', () => ({
 }));
 
 describe('ProtectedRoute', () => {
+  const ProtectedContent = () => {
+    const location = useLocation<{ lessonId?: string } | undefined>();
+
+    return (
+      <>
+        <div>Protected Content</div>
+        <div data-testid="route-path">
+          {location.pathname}
+          {location.search}
+        </div>
+        <div data-testid="route-state">{location.state?.lessonId ?? ''}</div>
+      </>
+    );
+  };
+
   beforeEach(() => {
     __resetGrowthBookMock();
     jest.clearAllMocks();
@@ -33,7 +73,7 @@ describe('ProtectedRoute', () => {
       <MemoryRouter initialEntries={['/protected']}>
         <Switch>
           <ProtectedRoute path="/protected">
-            <div>Protected Content</div>
+            <ProtectedContent />
           </ProtectedRoute>
 
           <Route path={PAGES.LOGIN}>
@@ -61,7 +101,7 @@ describe('ProtectedRoute', () => {
       <MemoryRouter initialEntries={['/protected']}>
         <Switch>
           <ProtectedRoute path="/protected">
-            <div>Protected Content</div>
+            <ProtectedContent />
           </ProtectedRoute>
         </Switch>
       </MemoryRouter>,
@@ -88,7 +128,7 @@ describe('ProtectedRoute', () => {
       <MemoryRouter initialEntries={['/protected']}>
         <Switch>
           <ProtectedRoute path="/protected">
-            <div>Protected Content</div>
+            <ProtectedContent />
           </ProtectedRoute>
         </Switch>
       </MemoryRouter>,
@@ -108,5 +148,88 @@ describe('ProtectedRoute', () => {
         screen.queryByRole('button', { name: /agree as parent/i }),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it('restores search params and location state after closing the terms page', async () => {
+    __setGrowthBookMock({
+      features: { [LATEST_TC_VERSION]: 3 },
+    });
+    mockAuthHandler.isUserLoggedIn.mockResolvedValue(true);
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'parent-1',
+      is_tc_accepted: true,
+      tc_agreed_version: 1,
+    });
+
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/protected',
+            search: '?lessonid=lesson-1',
+            state: { lessonId: 'lesson-1', from: PAGES.HOME },
+          },
+        ]}
+      >
+        <Switch>
+          <ProtectedRoute path="/protected">
+            <ProtectedContent />
+          </ProtectedRoute>
+          <Route path={PAGES.TERMS_AND_CONDITIONS}>
+            <TermsAndConditions />
+          </Route>
+        </Switch>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/protected content/i)).toBeInTheDocument();
+    expect(screen.getByTestId('route-path')).toHaveTextContent(
+      '/protected?lessonid=lesson-1',
+    );
+    expect(screen.getByTestId('route-state')).toHaveTextContent('lesson-1');
+
+    await user.click(
+      screen.getByRole('button', { name: /terms & conditions/i }),
+    );
+    expect(
+      await screen.findByTitle(/terms and conditions/i),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /close/i }));
+
+    expect(await screen.findByText(/protected content/i)).toBeInTheDocument();
+    expect(screen.getByTestId('route-path')).toHaveTextContent(
+      '/protected?lessonid=lesson-1',
+    );
+    expect(screen.getByTestId('route-state')).toHaveTextContent('lesson-1');
+  });
+
+  it('defers the T&C modal on gameplay routes', async () => {
+    __setGrowthBookMock({
+      features: { [LATEST_TC_VERSION]: 3 },
+    });
+    mockAuthHandler.isUserLoggedIn.mockResolvedValue(true);
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'parent-1',
+      is_tc_accepted: true,
+      tc_agreed_version: 1,
+    });
+
+    render(
+      <MemoryRouter initialEntries={[PAGES.LIDO_PLAYER]}>
+        <Switch>
+          <ProtectedRoute path={PAGES.LIDO_PLAYER}>
+            <ProtectedContent />
+          </ProtectedRoute>
+        </Switch>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/protected content/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /agree as parent/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -1,6 +1,12 @@
 import { useFeatureValue } from '@growthbook/growthbook-react';
 import { ReactNode, useEffect, useRef, useState } from 'react';
-import { Redirect, Route, RouteProps, useHistory } from 'react-router-dom';
+import {
+  Redirect,
+  Route,
+  RouteProps,
+  useHistory,
+  useLocation,
+} from 'react-router-dom';
 
 import { EVENTS, LATEST_TC_VERSION, PAGES } from './common/constants';
 import Loading from './components/Loading';
@@ -19,12 +25,19 @@ type ProtectedRouteProps = RouteProps & {
   children: ReactNode;
 };
 
+const TERMS_MODAL_DEFERRED_PATHS = new Set<string>([
+  PAGES.GAME,
+  PAGES.LIDO_PLAYER,
+  PAGES.LIVE_QUIZ_GAME,
+]);
+
 export default function ProtectedRoute({
   children,
   ...rest
 }: ProtectedRouteProps) {
   const [isAuth, setIsAuth] = useState<boolean | null>(null); // initially undefined
   const history = useHistory();
+  const location = useLocation();
   const latestTcVersion = useFeatureValue<number>(LATEST_TC_VERSION, 0);
   const requiredTcVersion = normalizeTcVersion(latestTcVersion);
   const [currentUser, setCurrentUser] = useState<TableTypes<'user'> | null>(
@@ -32,6 +45,14 @@ export default function ProtectedRoute({
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const viewedEventKeyRef = useRef('');
+  const shouldRequireTerms = needsTermsAgreement(
+    currentUser,
+    requiredTcVersion,
+  );
+  const shouldDeferTermsModal = TERMS_MODAL_DEFERRED_PATHS.has(
+    location.pathname,
+  );
+  const shouldShowTermsModal = shouldRequireTerms && !shouldDeferTermsModal;
 
   useEffect(() => {
     void checkAuth();
@@ -94,14 +115,25 @@ export default function ProtectedRoute({
   };
 
   const handleTermsClick = () => {
+    const from =
+      location.pathname + (location.search ?? '') + (location.hash ?? '');
+
     history.push({
       pathname: PAGES.TERMS_AND_CONDITIONS,
-      state: { from: window.location.pathname },
+      state: {
+        from,
+        returnLocation: {
+          pathname: location.pathname,
+          search: location.search,
+          hash: location.hash,
+          state: location.state,
+        },
+      },
     });
   };
 
   const handleTermsModalViewed = () => {
-    if (!currentUser || !needsTermsAgreement(currentUser, requiredTcVersion)) {
+    if (!currentUser || !shouldShowTermsModal) {
       return;
     }
 
@@ -125,7 +157,7 @@ export default function ProtectedRoute({
       {isAuth === true ? (
         <>
           {children}
-          {needsTermsAgreement(currentUser, requiredTcVersion) && (
+          {shouldShowTermsModal && (
             <TermsAndCoditionsModal
               isSubmitting={isSubmitting}
               onAgree={handleAgree}

--- a/src/components/termsandconditons/TermsAndCoditionsModal.css
+++ b/src/components/termsandconditons/TermsAndCoditionsModal.css
@@ -1,7 +1,7 @@
 .terms-update-modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 1200;
+  z-index: 20000;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/termsandconditons/TermsAndCoditionsModal.tsx
+++ b/src/components/termsandconditons/TermsAndCoditionsModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { Trans, useTranslation } from 'react-i18next';
 
 import {
@@ -29,6 +30,7 @@ const TermsAndCoditionsModal: React.FC<TermsAndCoditionsModalProps> = ({
   const shouldRender = visible ?? isOpen;
   const appMode = getCurrentTermsAppMode();
   const hasReportedViewRef = useRef(false);
+  const termsLabel = String(t('Terms & Conditions'));
 
   useEffect(() => {
     if (!shouldRender) {
@@ -63,6 +65,7 @@ const TermsAndCoditionsModal: React.FC<TermsAndCoditionsModalProps> = ({
                   type="button"
                   className="terms-update-modal-link-teacher"
                   onClick={onTermsClick}
+                  aria-label={termsLabel}
                 />
               ),
             }}
@@ -102,6 +105,7 @@ const TermsAndCoditionsModal: React.FC<TermsAndCoditionsModalProps> = ({
                   type="button"
                   className="terms-update-modal-link-ops"
                   onClick={onTermsClick}
+                  aria-label={termsLabel}
                 />
               ),
             }}
@@ -138,6 +142,7 @@ const TermsAndCoditionsModal: React.FC<TermsAndCoditionsModalProps> = ({
                   type="button"
                   className="terms-update-modal-link"
                   onClick={onTermsClick}
+                  aria-label={termsLabel}
                 />
               ),
             }}
@@ -162,7 +167,7 @@ const TermsAndCoditionsModal: React.FC<TermsAndCoditionsModalProps> = ({
     </div>
   );
 
-  return (
+  const modalContent = (
     <div
       className="terms-update-modal-overlay"
       role="dialog"
@@ -176,6 +181,12 @@ const TermsAndCoditionsModal: React.FC<TermsAndCoditionsModalProps> = ({
           : renderKidsModal()}
     </div>
   );
+
+  if (typeof document === 'undefined') {
+    return modalContent;
+  }
+
+  return createPortal(modalContent, document.body);
 };
 
 export default TermsAndCoditionsModal;

--- a/src/pages/TermsAndConditions.tsx
+++ b/src/pages/TermsAndConditions.tsx
@@ -1,6 +1,6 @@
 import { useFeatureValue } from '@growthbook/growthbook-react';
 import React, { useEffect, useMemo, useState } from 'react';
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router';
 
 import { PAGES, TC_HTML_URL } from '../common/constants';
@@ -15,6 +15,12 @@ import './TermsAndConditions.css';
 
 type TermsPageLocationState = {
   from?: string;
+  returnLocation?: {
+    pathname: string;
+    search?: string;
+    hash?: string;
+    state?: unknown;
+  };
 };
 
 const LEGACY_TERMS_URL =
@@ -24,10 +30,12 @@ const CLOSE_ICON_SRC = '/assets/loginAssets/TermsConditionsClose.svg';
 const TermsAndConditions: React.FC = () => {
   const history = useHistory();
   const location = useLocation<TermsPageLocationState>();
+  const { t } = useTranslation();
   const tcHtmlUrlFeature = useFeatureValue<string>(TC_HTML_URL, '');
   const [iframeSrc, setIframeSrc] = useState(LEGACY_TERMS_URL);
 
   const redirectTarget = location.state?.from || PAGES.SELECT_MODE;
+  const returnLocation = location.state?.returnLocation;
   const baseTermsUrl = useMemo(
     () => resolveTermsBaseUrl(tcHtmlUrlFeature),
     [tcHtmlUrlFeature],
@@ -70,6 +78,14 @@ const TermsAndConditions: React.FC = () => {
   };
 
   const handleClose = () => {
+    if (returnLocation?.pathname) {
+      history.replace(
+        `${returnLocation.pathname}${returnLocation.search ?? ''}${returnLocation.hash ?? ''}`,
+        returnLocation.state,
+      );
+      return;
+    }
+
     history.replace(redirectTarget);
   };
 

--- a/src/utility/termsAndConditions.test.ts
+++ b/src/utility/termsAndConditions.test.ts
@@ -1,0 +1,40 @@
+import { needsTermsAgreement, normalizeTcVersion } from './termsAndConditions';
+
+describe('termsAndConditions utilities', () => {
+  it('does not require terms agreement when user is null', () => {
+    expect(needsTermsAgreement(null, 3)).toBe(false);
+  });
+
+  it('does not require terms agreement when user id is missing', () => {
+    expect(
+      needsTermsAgreement(
+        {
+          tc_agreed_version: 0,
+        },
+        3,
+      ),
+    ).toBe(false);
+  });
+
+  it('requires terms agreement only for valid users below the latest version', () => {
+    expect(
+      needsTermsAgreement(
+        {
+          id: 'parent-1',
+          tc_agreed_version: 1,
+        },
+        3,
+      ),
+    ).toBe(true);
+
+    expect(
+      needsTermsAgreement(
+        {
+          id: 'parent-1',
+          tc_agreed_version: normalizeTcVersion(3),
+        },
+        3,
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/utility/termsAndConditions.ts
+++ b/src/utility/termsAndConditions.ts
@@ -78,7 +78,13 @@ export const getUserTcAgreedVersion = (user?: UserWithTermsState | null) =>
 export const needsTermsAgreement = (
   user: UserWithTermsState | null | undefined,
   latestVersion: unknown,
-): boolean => getUserTcAgreedVersion(user) < normalizeTcVersion(latestVersion);
+): boolean => {
+  if (!user?.id) {
+    return false;
+  }
+
+  return getUserTcAgreedVersion(user) < normalizeTcVersion(latestVersion);
+};
 
 export const getCurrentTermsAppMode = (): TermsAppMode => {
   const currentMode = localStorage.getItem(CURRENT_MODE);


### PR DESCRIPTION
## Summary

Fixes multiple regressions in the Terms & Conditions flow.

## Changes

- preserve query params and `location.state` when opening and closing the Terms page
- defer the Terms modal on gameplay routes like `lido-player` and `game`
- render the Terms modal above other overlays so it does not fall behind scorecards/popups
- make `needsTermsAgreement` return `false` when user data is not available yet
- avoid stale popup state caused by transient null-user checks
- add regression tests for route restore, gameplay deferral, and null-user handling

## Why

This fixes:
- infinite loading / broken return flow after opening Terms from game routes
- Terms popup appearing behind other modals
- Terms popup appearing unintentionally before user data is loaded
- Terms popup sticking around in edge cases caused by unstable auth state handling

## Validation

- focused Jest tests added and passing for `ProtectedRoute` and terms utilities

