### PR TITLE
Fix GrowthBook school_ids refresh across profile and class changes

### DIFF
--- a/src/components/LearningPathway.tsx
+++ b/src/components/LearningPathway.tsx
@@ -67,16 +67,14 @@ const LearningPathway: React.FC = () => {
 
     const currentClass = schoolUtil.getCurrentClass();
     const existingAttributes = gb.getAttributes?.() ?? {};
-    const resolvedSchoolIds = existingAttributes?.school_ids;
-    const normalizedSchoolIds =
-      Util.normalizeGrowthbookArrayAttribute(resolvedSchoolIds);
-    // Keep any existing school_ids and append the current class school for targeting.
-    const mergedSchoolIds = currentClass?.school_id
-      ? Array.from(new Set([...normalizedSchoolIds, currentClass.school_id]))
-      : normalizedSchoolIds;
+    // Always target the active student's current class school only.
+    const freshSchoolIds = currentClass?.school_id
+      ? [currentClass.school_id]
+      : [];
     gb.setAttributes({
       ...existingAttributes,
-      school_ids: mergedSchoolIds,
+      student_id: student.id,
+      school_ids: freshSchoolIds,
     });
     const resolvedMode = gb.getFeatureValue(
       'learning-pathway-mode',

--- a/src/components/ProfileMenu/ProfileMenu.tsx
+++ b/src/components/ProfileMenu/ProfileMenu.tsx
@@ -166,8 +166,8 @@ const ProfileMenu = ({ onClose }: ProfileMenuProps) => {
   };
 
   const onSchoolModeSwitchUser = async () => {
-    Util.setCurrentStudent(null);
-    schoolUtil.setCurrentClass(undefined);
+    await Util.setCurrentStudent(null);
+    await schoolUtil.setCurrentClass(undefined);
     updateLocalAttributes({
       student_id: null,
       school_ids: [],

--- a/src/components/ProfileMenu/ProfileMenu.tsx
+++ b/src/components/ProfileMenu/ProfileMenu.tsx
@@ -167,7 +167,9 @@ const ProfileMenu = ({ onClose }: ProfileMenuProps) => {
 
   const onSchoolModeSwitchUser = async () => {
     await Util.setCurrentStudent(null);
-    await schoolUtil.setCurrentClass(undefined);
+    if (currentMode === MODES.PARENT) {
+      await schoolUtil.setCurrentClass(undefined);
+    }
     updateLocalAttributes({
       student_id: null,
       school_ids: [],

--- a/src/components/ProfileMenu/ProfileMenu.tsx
+++ b/src/components/ProfileMenu/ProfileMenu.tsx
@@ -156,13 +156,26 @@ const ProfileMenu = ({ onClose }: ProfileMenuProps) => {
     schoolUtil.setCurrentClass(undefined);
     localStorage.removeItem(CURRENT_PATHWAY_MODE);
     localStorage.removeItem(HOMEWORK_PATHWAY);
-    // Also tell GrowthBook attributes are now cleared (or set to parent-level)
+    // Reset student-scoped targeting when leaving the active child profile.
     updateLocalAttributes({
       student_id: null,
+      school_ids: [],
     });
-
-    setGbUpdated(true); // cause consumers to re-evaluate
+    setGbUpdated(true);
     history.replace(PAGES.DISPLAY_STUDENT, { from: history.location.pathname });
+  };
+
+  const onSchoolModeSwitchUser = async () => {
+    Util.setCurrentStudent(null);
+    schoolUtil.setCurrentClass(undefined);
+    updateLocalAttributes({
+      student_id: null,
+      school_ids: [],
+    });
+    setGbUpdated(true);
+    history.replace(PAGES.SELECT_MODE, {
+      from: history.location.pathname,
+    });
   };
 
   const allMenuItems = [
@@ -209,10 +222,7 @@ const ProfileMenu = ({ onClose }: ProfileMenuProps) => {
       isSchoolKidsMode && item.label === 'Switch Profile'
         ? {
             ...item,
-            onClick: () =>
-              history.replace(PAGES.SELECT_MODE, {
-                from: history.location.pathname,
-              }),
+            onClick: onSchoolModeSwitchUser,
           }
         : item,
     );

--- a/src/components/parent/ParentalLock.tsx
+++ b/src/components/parent/ParentalLock.tsx
@@ -8,6 +8,10 @@ import './ParentalLock.css';
 import { FcLock } from 'react-icons/fc';
 import { Util } from '../../utility/util';
 import { schoolUtil } from '../../utility/schoolUtil';
+import {
+  updateLocalAttributes,
+  useGbContext,
+} from '../../growthbook/Growthbook';
 
 const ParentalLock: React.FC<{
   showDialogBox: boolean;
@@ -15,6 +19,7 @@ const ParentalLock: React.FC<{
   onHandleClose: React.MouseEventHandler<HTMLDivElement | HTMLImageElement>;
   onUnlock?: () => void;
 }> = ({ showDialogBox, handleClose, onHandleClose, onUnlock }) => {
+  const { setGbUpdated } = useGbContext();
   enum FourSides {
     LEFT = 'LEFT',
     RIGHT = 'RIGHT',
@@ -46,6 +51,12 @@ const ParentalLock: React.FC<{
       Util.setPathToBackButton(PAGES.PARENT, history);
       Util.setCurrentStudent(null);
       schoolUtil.setCurrentClass(undefined);
+      // Parent unlock exits the active student context, so clear student targeting.
+      updateLocalAttributes({
+        student_id: null,
+        school_ids: [],
+      });
+      setGbUpdated(true);
     }
   };
 

--- a/src/components/profileDetails/ProfileDetails.tsx
+++ b/src/components/profileDetails/ProfileDetails.tsx
@@ -33,6 +33,11 @@ import {
   reinitializeHardwareBackButton,
 } from '../../common/backButtonRegistry';
 import logger from '../../utility/logger';
+import { schoolUtil } from '../../utility/schoolUtil';
+import {
+  updateLocalAttributes,
+  useGbContext,
+} from '../../growthbook/Growthbook';
 
 const getModeFromFeature = (variation: string) => {
   switch (variation) {
@@ -53,6 +58,7 @@ const ProfileDetails = () => {
   const history = useHistory();
   const location = useLocation();
   const profileRef = useRef<HTMLDivElement>(null);
+  const { setGbUpdated } = useGbContext();
 
   const [isCreatingProfile, setIsCreatingProfile] = useState<boolean>(false);
   const [parentHasStudent, setParentHasStudent] = useState<boolean>(false);
@@ -431,6 +437,15 @@ const ProfileDetails = () => {
           : undefined,
         tmpPath === PAGES.HOME ? true : false,
       );
+      await schoolUtil.setCurrentClass(undefined);
+      // A newly created child starts without class linkage, so clear school targeting.
+      updateLocalAttributes({
+        student_id: student.id,
+        age: student.age ?? null,
+        grade_id: student.grade_id ?? null,
+        school_ids: [],
+      });
+      setGbUpdated(true);
 
       await Util.ensureLidoCommonAudioForStudent(student);
       history.replace(tmpPath);
@@ -467,6 +482,15 @@ const ProfileDetails = () => {
         selectedLanguage?.code ?? undefined,
         true,
       );
+      await schoolUtil.setCurrentClass(undefined);
+      // Auto-created child profiles also start with no school/class association.
+      updateLocalAttributes({
+        student_id: student.id,
+        age: student.age ?? null,
+        grade_id: student.grade_id ?? null,
+        school_ids: [],
+      });
+      setGbUpdated(true);
 
       const user = await auth.getCurrentUser();
 

--- a/src/growthbook/Growthbook.tsx
+++ b/src/growthbook/Growthbook.tsx
@@ -59,6 +59,8 @@ export const GbProvider = ({ children }: { children: ReactNode }) => {
   const growthbook = useGrowthBook();
   const [gbUpdated, setGbUpdated] = useState(true);
   const attributes = useAppSelector((state) => state.growthbook.attributes);
+  const hasOwn = (obj: Record<string, unknown> | undefined, key: string) =>
+    !!obj && Object.prototype.hasOwnProperty.call(obj, key);
 
   useEffect(() => {
     if (!gbUpdated) return;
@@ -107,6 +109,9 @@ export const GbProvider = ({ children }: { children: ReactNode }) => {
     } = attributes;
 
     const totalAssignments = count_of_assignment_played + assignmentCount;
+    const resolvedSchoolIds = hasOwn(attributes, 'school_ids')
+      ? Util.normalizeGrowthbookArrayAttribute(attributes?.school_ids)
+      : Util.normalizeGrowthbookArrayAttribute(schools);
 
     return {
       id: studentDetails?.id,
@@ -120,7 +125,7 @@ export const GbProvider = ({ children }: { children: ReactNode }) => {
       stars: studentDetails?.stars || 0,
       last_login_at: studentDetails?.last_sign_in_at,
       login_method: studentDetails?.login_method,
-      school_ids: schools,
+      school_ids: resolvedSchoolIds,
       school_name,
       class_ids: classes,
       language: localStorage.getItem(LANGUAGE) || 'en',
@@ -170,17 +175,11 @@ export const GbProvider = ({ children }: { children: ReactNode }) => {
       );
       return buildAttributesOnMainThread(attributes);
     });
-    // Merge instead of replace so attributes set by other screens are not lost.
+    // Keep other attributes, but school_ids must always come from the latest
+    // prepared payload for the current student.
     const existingAttributes = growthbook.getAttributes?.() ?? {};
-    const normalizedSchoolIds = Array.from(
-      new Set([
-        ...Util.normalizeGrowthbookArrayAttribute(
-          existingAttributes?.school_ids,
-        ),
-        ...Util.normalizeGrowthbookArrayAttribute(
-          preparedAttributes?.school_ids,
-        ),
-      ]),
+    const normalizedSchoolIds = Util.normalizeGrowthbookArrayAttribute(
+      preparedAttributes?.school_ids,
     );
     const mergedAttributes = {
       ...existingAttributes,

--- a/src/pages/DisplayStudents.tsx
+++ b/src/pages/DisplayStudents.tsx
@@ -86,7 +86,7 @@ const DisplayStudents: FC<{}> = () => {
       logger.warn('Failed to prefetch Lido common audio in background.', error);
     });
     let resolvedSchoolIds: string[] = [];
-    if (linkedData.classes && linkedData.classes.length > 0) {
+    if (linkedData?.classes && linkedData.classes.length > 0) {
       const firstClass = linkedData.classes[0];
       const currClass = await api.getClassById(firstClass.id);
       await schoolUtil.setCurrentClass(currClass ?? undefined);

--- a/src/pages/DisplayStudents.tsx
+++ b/src/pages/DisplayStudents.tsx
@@ -81,27 +81,28 @@ const DisplayStudents: FC<{}> = () => {
   const onStudentClick = async (student: TableTypes<'user'>) => {
     schoolUtil.setCurrMode(MODES.PARENT);
     await Util.setCurrentStudent(student, undefined, true);
-    // 2) Update GrowthBook attributes immediately for the newly selected student
-    updateLocalAttributes({
-      student_id: student.id,
-      age: student.age ?? null,
-      grade_id: student.grade_id ?? null,
-    });
-
-    // 3) Signal to GrowthBook context that attributes were updated
-    setGbUpdated(true);
     const linkedData = await api.getStudentClassesAndSchools(student.id);
     void Util.ensureLidoCommonAudioForStudent(student).catch((error) => {
       logger.warn('Failed to prefetch Lido common audio in background.', error);
     });
+    let resolvedSchoolIds: string[] = [];
     if (linkedData.classes && linkedData.classes.length > 0) {
       const firstClass = linkedData.classes[0];
       const currClass = await api.getClassById(firstClass.id);
       await schoolUtil.setCurrentClass(currClass ?? undefined);
+      resolvedSchoolIds = currClass?.school_id ? [currClass.school_id] : [];
     } else {
       logger.warn('No classes found for the student.');
       await schoolUtil.setCurrentClass(undefined);
     }
+    // Sync GrowthBook with the selected child's current school linkage.
+    updateLocalAttributes({
+      student_id: student.id,
+      age: student.age ?? null,
+      grade_id: student.grade_id ?? null,
+      school_ids: resolvedSchoolIds,
+    });
+    setGbUpdated(true);
     if (!student.language_id) {
       history.replace(PAGES.EDIT_STUDENT, {
         from: history.location.pathname,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -186,6 +186,9 @@ const Home: FC = () => {
   }, [currentHeader, canShowAvatar]);
   const handleJoinClassEvent = async (event: Event) => {
     await getAssignments(true);
+    // Rebuild student-school attributes immediately after a class join.
+    await Util.updateSchStdAttb();
+    setGbUpdated(true);
     setCanShowAvatar(true);
     setIsStudentLinked(true);
     setRefreshKey((oldKey) => oldKey + 1);
@@ -396,6 +399,10 @@ const Home: FC = () => {
       const attributeParams = {
         studentDetails: student,
         schools: linkedData.schools.map((item: any) => item.id),
+        // Keep the raw school_ids array available for GrowthBook targeting.
+        school_ids: linkedData.schools.map(
+          (item: TableTypes<'school'>) => item.id,
+        ),
         school_name: linkedData.schools[0]?.name,
         classes: linkedData.classes.map((item: any) => item.id),
         liveQuizCount: liveQuizCount,

--- a/src/pages/Leaderboard.test.tsx
+++ b/src/pages/Leaderboard.test.tsx
@@ -21,8 +21,10 @@ const mockSetGbUpdated = jest.fn();
 const mockUpdateLocalAttributes = jest.fn();
 const mockLoadBackgroundImage = jest.fn();
 const mockGetCurrentStudent = jest.fn();
+const mockSetCurrentStudent = jest.fn();
 const mockSetPathToBackButton = jest.fn();
 const mockGetCurrMode = jest.fn();
+const mockSetCurrentClass = jest.fn();
 const mockDestroyInstance = jest.fn();
 const mockChangeLanguage = jest.fn();
 const mockAddListener: jest.Mock = jest.fn((..._args: any[]) => ({
@@ -76,22 +78,23 @@ jest.mock('../i18n', () => ({
 
 jest.mock('../growthbook/Growthbook', () => ({
   useGbContext: () => ({ setGbUpdated: mockSetGbUpdated }),
-  updateLocalAttributes: (attributes: unknown) =>
-    mockUpdateLocalAttributes(attributes),
+  updateLocalAttributes: (...args: never[]) =>
+    mockUpdateLocalAttributes(...args),
 }));
 
 jest.mock('../utility/util', () => ({
   Util: {
     loadBackgroundImage: () => mockLoadBackgroundImage(),
     getCurrentStudent: () => mockGetCurrentStudent(),
-    setPathToBackButton: (...args: any[]) =>
-      mockSetPathToBackButton.apply(null, args),
+    setCurrentStudent: (...args: never[]) => mockSetCurrentStudent(...args),
+    setPathToBackButton: (...args: never[]) => mockSetPathToBackButton(...args),
   },
 }));
 
 jest.mock('../utility/schoolUtil', () => ({
   schoolUtil: {
     getCurrMode: () => mockGetCurrMode(),
+    setCurrentClass: (...args: never[]) => mockSetCurrentClass(...args),
   },
 }));
 
@@ -294,7 +297,9 @@ describe('Leaderboard', () => {
     window.history.pushState({}, '', '/leaderboard');
 
     mockGetCurrentStudent.mockReturnValue(currentStudent);
+    mockSetCurrentStudent.mockResolvedValue(undefined);
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
+    mockSetCurrentClass.mockResolvedValue(undefined);
     mockApiHandler.getStudentClassesAndSchools.mockResolvedValue({
       classes: [{ id: 'class-1' }],
       schools: [{ id: 'school-1' }],

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -687,6 +687,12 @@ const Leaderboard: React.FC = () => {
                 }
                 const currentMOde = localStorage.getItem(CURRENT_MODE);
                 await api.removeAssignmentChannel();
+                // Leaderboard switch profile should drop the active student target.
+                updateLocalAttributes({
+                  student_id: null,
+                  school_ids: [],
+                });
+                setGbUpdated(true);
                 if (currentMOde === MODES.PARENT) {
                   Util.setPathToBackButton(PAGES.DISPLAY_STUDENT, history);
                 } else {

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -688,6 +688,8 @@ const Leaderboard: React.FC = () => {
                 const currentMOde = localStorage.getItem(CURRENT_MODE);
                 await api.removeAssignmentChannel();
                 // Leaderboard switch profile should drop the active student target.
+                await Util.setCurrentStudent(null);
+                await schoolUtil.setCurrentClass(undefined);
                 updateLocalAttributes({
                   student_id: null,
                   school_ids: [],

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -689,7 +689,9 @@ const Leaderboard: React.FC = () => {
                 await api.removeAssignmentChannel();
                 // Leaderboard switch profile should drop the active student target.
                 await Util.setCurrentStudent(null);
-                await schoolUtil.setCurrentClass(undefined);
+                if (currentMOde === MODES.PARENT) {
+                  await schoolUtil.setCurrentClass(undefined);
+                }
                 updateLocalAttributes({
                   student_id: null,
                   school_ids: [],

--- a/src/pages/SelectMode.tsx
+++ b/src/pages/SelectMode.tsx
@@ -41,6 +41,7 @@ import {
 import { RootState } from '../redux/store';
 import type { ServiceApi } from '../services/api/ServiceApi';
 import { ServiceConfig } from '../services/ServiceConfig';
+import { updateLocalAttributes, useGbContext } from '../growthbook/Growthbook';
 import {
   requireTeacherModeAuth,
   TeacherModeAuthResult,
@@ -209,6 +210,7 @@ const SelectMode: FC = () => {
   const api = ServiceConfig.getI().apiHandler;
   const auth = ServiceConfig.getI().authHandler;
   const history = useHistory();
+  const { setGbUpdated } = useGbContext();
   const [stage, setStage] = useState(STAGES.MODE);
   const [isOkayButtonDisabled, setIsOkayButtonDisabled] = useState(true);
   const dispatch = useAppDispatch();
@@ -764,6 +766,15 @@ const SelectMode: FC = () => {
   const onStudentClick = async (student: TableTypes<'user'>) => {
     await Util.ensureLidoCommonAudioForStudent(student);
     await Util.setCurrentStudent(student, undefined, true);
+    const resolvedSchoolIds = currClass?.school_id ? [currClass.school_id] : [];
+    // School mode selection should target only the selected class's school.
+    updateLocalAttributes({
+      student_id: student.id,
+      age: student.age ?? null,
+      grade_id: student.grade_id ?? null,
+      school_ids: resolvedSchoolIds,
+    });
+    setGbUpdated(true);
     history.replace(PAGES.HOME);
   };
   const onClassSelect = async (

--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -3956,11 +3956,31 @@ export class Util {
       if (!student?.id) return [];
       const api = ServiceConfig.getI().apiHandler;
       const linkedData = await api.getStudentClassesAndSchools(student.id);
-      if (!linkedData) return [];
+      if (!linkedData) {
+        api.currentClass = undefined;
+        localStorage.removeItem(CURRENT_CLASS);
+        // Clear school targeting when the active student has no linkage data.
+        updateLocalAttributes({
+          student_id: student.id,
+          school_ids: [],
+          schools: [],
+          classes: [],
+          school_name: null,
+        });
+        return [];
+      }
       const device = await Util.logDeviceInfo();
+      const resolvedSchoolIds = linkedData.schools.map(
+        (item: TableTypes<'school'>) => item.id,
+      );
+      if (linkedData.classes.length === 0) {
+        api.currentClass = undefined;
+        localStorage.removeItem(CURRENT_CLASS);
+      }
       const attributeParams = {
         studentDetails: student,
-        schools: linkedData.schools.map((item: any) => item.id),
+        schools: resolvedSchoolIds,
+        school_ids: resolvedSchoolIds,
         school_name: linkedData.schools[0]?.name,
         classes: linkedData.classes.map((item: any) => item.id),
         ...device,


### PR DESCRIPTION
- Ensure GrowthBook always uses fresh school_ids for the active student.
- Refresh GrowthBook attributes on profile switch.
- Refresh GrowthBook attributes on student selection.
- Refresh GrowthBook attributes after class join.
- Refresh GrowthBook attributes after new profile creation.
- Clear stale student targeting when leaving a child profile.