### PR TITLE
refactor: Introduce TermsGate component for terms agreement management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,6 +139,7 @@ import CreateSchool from './teachers-module/pages/CreateSchool';
 import ScanRedirect from './teachers-module/components/homePage/assignment/ScanRedirect';
 import GenericPopup from './components/GenericPopUp/GenericPopUp';
 import PopupManager from './components/GenericPopUp/GenericPopUpManager';
+import TermsGate from './components/termsandconditons/TermsGate';
 import { useGrowthBook } from '@growthbook/growthbook-react';
 import { setCachedGrowthBookFeatureValue } from './growthbook/Growthbook';
 import { HardwareBackButtonHandler } from './common/backButtonRegistry';
@@ -559,6 +560,7 @@ const App: React.FC = () => {
     <IonApp>
       <IonReactRouter basename={BASE_NAME}>
         <OpsConsoleRouteWatcher />
+        <TermsGate />
         <HardwareBackButtonHandler
           popupDataRef={popupDataRef}
           setPopupData={setPopupData}

--- a/src/ProtectedRoute.test.tsx
+++ b/src/ProtectedRoute.test.tsx
@@ -1,67 +1,18 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import type { ReactElement } from 'react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Switch, useLocation } from 'react-router-dom';
-import {
-  __resetGrowthBookMock,
-  __setGrowthBookMock,
-} from './tests/__mocks__/@growthbook/growthbook-react';
 
 import ProtectedRoute from './ProtectedRoute';
-import { LATEST_TC_VERSION, PAGES } from './common/constants';
-import TermsAndConditions from './pages/TermsAndConditions';
-import {
-  mockApiHandler,
-  mockAuthHandler,
-} from './tests/__mocks__/serviceConfigMock';
-
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (value: string) => value,
-  }),
-  Trans: ({
-    i18nKey,
-    components,
-  }: {
-    i18nKey: string;
-    components?: Record<number, ReactElement>;
-  }) => {
-    const parts = i18nKey.split(/<1>|<\/1>/);
-
-    return (
-      <>
-        {parts[0]}
-        {components?.[1]}
-        {parts[2] ?? ''}
-      </>
-    );
-  },
-}));
-
-jest.mock('./utility/util', () => ({
-  Util: {
-    logEvent: jest.fn(),
-  },
-}));
+import { PAGES } from './common/constants';
+import { mockAuthHandler } from './tests/__mocks__/serviceConfigMock';
 
 describe('ProtectedRoute', () => {
   const ProtectedContent = () => {
-    const location = useLocation<{ lessonId?: string } | undefined>();
+    const location = useLocation();
 
-    return (
-      <>
-        <div>Protected Content</div>
-        <div data-testid="route-path">
-          {location.pathname}
-          {location.search}
-        </div>
-        <div data-testid="route-state">{location.state?.lessonId ?? ''}</div>
-      </>
-    );
+    return <div>{`Protected Content: ${location.pathname}`}</div>;
   };
 
   beforeEach(() => {
-    __resetGrowthBookMock();
     jest.clearAllMocks();
   });
 
@@ -75,7 +26,6 @@ describe('ProtectedRoute', () => {
           <ProtectedRoute path="/protected">
             <ProtectedContent />
           </ProtectedRoute>
-
           <Route path={PAGES.LOGIN}>
             <div>Login Page</div>
           </Route>
@@ -86,15 +36,11 @@ describe('ProtectedRoute', () => {
     expect(await screen.findByText(/login page/i)).toBeInTheDocument();
   });
 
-  it('renders children without popup when user is up to date with T&C version', async () => {
-    __setGrowthBookMock({
-      features: { [LATEST_TC_VERSION]: 2 },
-    });
+  it('renders children when user is authenticated', async () => {
     mockAuthHandler.isUserLoggedIn.mockResolvedValue(true);
     mockAuthHandler.getCurrentUser.mockResolvedValue({
       id: 'parent-1',
-      is_tc_accepted: true,
-      tc_agreed_version: 2,
+      tc_agreed_version: 1,
     });
 
     render(
@@ -107,129 +53,8 @@ describe('ProtectedRoute', () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText(/protected content/i)).toBeInTheDocument();
-    expect(screen.queryByText(/agree as parent/i)).not.toBeInTheDocument();
-  });
-
-  it('shows the T&C modal for outdated users and updates the agreed version', async () => {
-    __setGrowthBookMock({
-      features: { [LATEST_TC_VERSION]: 3 },
-    });
-    mockAuthHandler.isUserLoggedIn.mockResolvedValue(true);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({
-      id: 'parent-1',
-      is_tc_accepted: true,
-      tc_agreed_version: 1,
-    });
-
-    const user = userEvent.setup();
-
-    render(
-      <MemoryRouter initialEntries={['/protected']}>
-        <Switch>
-          <ProtectedRoute path="/protected">
-            <ProtectedContent />
-          </ProtectedRoute>
-        </Switch>
-      </MemoryRouter>,
-    );
-
-    expect(await screen.findByText(/protected content/i)).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: /agree as parent/i }));
-
-    await waitFor(() => {
-      expect(mockApiHandler.updateTcAgreedVersion).toHaveBeenCalledWith(
-        'parent-1',
-        3,
-      );
-    });
-    await waitFor(() => {
-      expect(
-        screen.queryByRole('button', { name: /agree as parent/i }),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  it('restores search params and location state after closing the terms page', async () => {
-    __setGrowthBookMock({
-      features: { [LATEST_TC_VERSION]: 3 },
-    });
-    mockAuthHandler.isUserLoggedIn.mockResolvedValue(true);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({
-      id: 'parent-1',
-      is_tc_accepted: true,
-      tc_agreed_version: 1,
-    });
-
-    const user = userEvent.setup();
-
-    render(
-      <MemoryRouter
-        initialEntries={[
-          {
-            pathname: '/protected',
-            search: '?lessonid=lesson-1',
-            state: { lessonId: 'lesson-1', from: PAGES.HOME },
-          },
-        ]}
-      >
-        <Switch>
-          <ProtectedRoute path="/protected">
-            <ProtectedContent />
-          </ProtectedRoute>
-          <Route path={PAGES.TERMS_AND_CONDITIONS}>
-            <TermsAndConditions />
-          </Route>
-        </Switch>
-      </MemoryRouter>,
-    );
-
-    expect(await screen.findByText(/protected content/i)).toBeInTheDocument();
-    expect(screen.getByTestId('route-path')).toHaveTextContent(
-      '/protected?lessonid=lesson-1',
-    );
-    expect(screen.getByTestId('route-state')).toHaveTextContent('lesson-1');
-
-    await user.click(
-      screen.getByRole('button', { name: /terms & conditions/i }),
-    );
     expect(
-      await screen.findByTitle(/terms and conditions/i),
+      await screen.findByText(/protected content: \/protected/i),
     ).toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: /close/i }));
-
-    expect(await screen.findByText(/protected content/i)).toBeInTheDocument();
-    expect(screen.getByTestId('route-path')).toHaveTextContent(
-      '/protected?lessonid=lesson-1',
-    );
-    expect(screen.getByTestId('route-state')).toHaveTextContent('lesson-1');
-  });
-
-  it('defers the T&C modal on gameplay routes', async () => {
-    __setGrowthBookMock({
-      features: { [LATEST_TC_VERSION]: 3 },
-    });
-    mockAuthHandler.isUserLoggedIn.mockResolvedValue(true);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({
-      id: 'parent-1',
-      is_tc_accepted: true,
-      tc_agreed_version: 1,
-    });
-
-    render(
-      <MemoryRouter initialEntries={[PAGES.LIDO_PLAYER]}>
-        <Switch>
-          <ProtectedRoute path={PAGES.LIDO_PLAYER}>
-            <ProtectedContent />
-          </ProtectedRoute>
-        </Switch>
-      </MemoryRouter>,
-    );
-
-    expect(await screen.findByText(/protected content/i)).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: /agree as parent/i }),
-    ).not.toBeInTheDocument();
   });
 });

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -1,58 +1,20 @@
-import { useFeatureValue } from '@growthbook/growthbook-react';
-import { ReactNode, useEffect, useRef, useState } from 'react';
-import {
-  Redirect,
-  Route,
-  RouteProps,
-  useHistory,
-  useLocation,
-} from 'react-router-dom';
+import { ReactNode, useEffect, useState } from 'react';
+import { Redirect, Route, RouteProps } from 'react-router-dom';
 
-import { EVENTS, LATEST_TC_VERSION, PAGES } from './common/constants';
+import { PAGES } from './common/constants';
 import Loading from './components/Loading';
-import TermsAndCoditionsModal from './components/termsandconditons/TermsAndCoditionsModal';
-import { TableTypes } from './common/constants';
 import { ServiceConfig } from './services/ServiceConfig';
 import { logAuthDebug } from './utility/authDebug';
-import {
-  buildTcAnalyticsContext,
-  needsTermsAgreement,
-  normalizeTcVersion,
-} from './utility/termsAndConditions';
-import { Util } from './utility/util';
 
 type ProtectedRouteProps = RouteProps & {
   children: ReactNode;
 };
-
-const TERMS_MODAL_DEFERRED_PATHS = new Set<string>([
-  PAGES.GAME,
-  PAGES.LIDO_PLAYER,
-  PAGES.LIVE_QUIZ_GAME,
-]);
 
 export default function ProtectedRoute({
   children,
   ...rest
 }: ProtectedRouteProps) {
   const [isAuth, setIsAuth] = useState<boolean | null>(null); // initially undefined
-  const history = useHistory();
-  const location = useLocation();
-  const latestTcVersion = useFeatureValue<number>(LATEST_TC_VERSION, 0);
-  const requiredTcVersion = normalizeTcVersion(latestTcVersion);
-  const [currentUser, setCurrentUser] = useState<TableTypes<'user'> | null>(
-    null,
-  );
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const viewedEventKeyRef = useRef('');
-  const shouldRequireTerms = needsTermsAgreement(
-    currentUser,
-    requiredTcVersion,
-  );
-  const shouldDeferTermsModal = TERMS_MODAL_DEFERRED_PATHS.has(
-    location.pathname,
-  );
-  const shouldShowTermsModal = shouldRequireTerms && !shouldDeferTermsModal;
 
   useEffect(() => {
     void checkAuth();
@@ -63,7 +25,6 @@ export default function ProtectedRoute({
       const authHandler = ServiceConfig.getI()?.authHandler;
       const isUserLoggedIn = await authHandler?.isUserLoggedIn();
       const user = await authHandler?.getCurrentUser();
-      setCurrentUser(user ?? null);
       setIsAuth(!!isUserLoggedIn && !!user);
       if (!isUserLoggedIn || !user) {
         logAuthDebug('ProtectedRoute redirecting to login.', {
@@ -82,72 +43,8 @@ export default function ProtectedRoute({
         from_page: window.location.pathname,
         to_page: PAGES.LOGIN,
       });
-      setCurrentUser(null);
       setIsAuth(false);
     }
-  };
-
-  const handleAgree = async () => {
-    if (!currentUser || isSubmitting) {
-      return;
-    }
-
-    setIsSubmitting(true);
-    try {
-      await ServiceConfig.getI().apiHandler.updateTcAgreedVersion(
-        currentUser.id,
-        requiredTcVersion,
-      );
-
-      void Util.logEvent(EVENTS.TC_AGREED, {
-        agreed_version: requiredTcVersion,
-        ...buildTcAnalyticsContext(currentUser),
-      });
-
-      setCurrentUser({
-        ...currentUser,
-        is_tc_accepted: true,
-        tc_agreed_version: requiredTcVersion,
-      });
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleTermsClick = () => {
-    const from =
-      location.pathname + (location.search ?? '') + (location.hash ?? '');
-
-    history.push({
-      pathname: PAGES.TERMS_AND_CONDITIONS,
-      state: {
-        from,
-        returnLocation: {
-          pathname: location.pathname,
-          search: location.search,
-          hash: location.hash,
-          state: location.state,
-        },
-      },
-    });
-  };
-
-  const handleTermsModalViewed = () => {
-    if (!currentUser || !shouldShowTermsModal) {
-      return;
-    }
-
-    const eventKey = `${currentUser.id}:${requiredTcVersion}`;
-    if (viewedEventKeyRef.current === eventKey) {
-      return;
-    }
-
-    viewedEventKeyRef.current = eventKey;
-    void Util.logEvent(EVENTS.TC_POPUP_VIEWED, {
-      target_version: requiredTcVersion,
-      current_local_version: currentUser.tc_agreed_version ?? 0,
-      ...buildTcAnalyticsContext(currentUser),
-    });
   };
 
   if (isAuth == null) return <Loading isLoading />;
@@ -155,17 +52,7 @@ export default function ProtectedRoute({
   return (
     <Route {...rest}>
       {isAuth === true ? (
-        <>
-          {children}
-          {shouldShowTermsModal && (
-            <TermsAndCoditionsModal
-              isSubmitting={isSubmitting}
-              onAgree={handleAgree}
-              onTermsClick={handleTermsClick}
-              onViewed={handleTermsModalViewed}
-            />
-          )}
-        </>
+        children
       ) : (
         <Redirect
           to={{

--- a/src/components/termsandconditons/TermsGate.test.tsx
+++ b/src/components/termsandconditons/TermsGate.test.tsx
@@ -6,7 +6,12 @@ import type { ReactElement } from 'react';
 import { MemoryRouter, Route, Switch, useLocation } from 'react-router-dom';
 
 import ProtectedRoute from '../../ProtectedRoute';
-import { LATEST_TC_VERSION, PAGES, TableTypes } from '../../common/constants';
+import {
+  EVENTS,
+  LATEST_TC_VERSION,
+  PAGES,
+  TableTypes,
+} from '../../common/constants';
 import TermsAndConditions from '../../pages/TermsAndConditions';
 import authReducer from '../../redux/slices/auth/authSlice';
 import growthbookReducer from '../../redux/slices/growthbook/growthbookSlice';
@@ -48,6 +53,10 @@ jest.mock('../../utility/util', () => ({
     logEvent: jest.fn(),
   },
 }));
+
+const { Util } = jest.requireMock('../../utility/util') as {
+  Util: { logEvent: jest.Mock };
+};
 
 describe('TermsGate', () => {
   const renderWithStore = (ui: ReactElement, userVersion = 1) => {
@@ -145,6 +154,44 @@ describe('TermsGate', () => {
     expect(
       screen.queryByRole('button', { name: /agree as parent/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it('rolls back the optimistic agreement and skips TC_AGREED analytics on persistence failure', async () => {
+    __setGrowthBookMock({
+      features: { [LATEST_TC_VERSION]: 3 },
+    });
+    mockApiHandler.updateTcAgreedVersion.mockRejectedValue(
+      new Error('persist failed'),
+    );
+
+    const user = userEvent.setup();
+
+    renderWithStore(
+      <MemoryRouter initialEntries={['/protected']}>
+        <TermsGate />
+        <Switch>
+          <ProtectedRoute path="/protected">
+            <ProtectedContent />
+          </ProtectedRoute>
+        </Switch>
+      </MemoryRouter>,
+      1,
+    );
+
+    expect(await screen.findByText(/protected content/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /agree as parent/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /agree as parent/i }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      Util.logEvent.mock.calls.some(
+        ([eventName]: [string]) => eventName === EVENTS.TC_AGREED,
+      ),
+    ).toBe(false);
   });
 
   it('renders only one modal even when nested protected routes are mounted', async () => {

--- a/src/components/termsandconditons/TermsGate.test.tsx
+++ b/src/components/termsandconditons/TermsGate.test.tsx
@@ -1,0 +1,253 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement } from 'react';
+import { MemoryRouter, Route, Switch, useLocation } from 'react-router-dom';
+
+import ProtectedRoute from '../../ProtectedRoute';
+import { LATEST_TC_VERSION, PAGES, TableTypes } from '../../common/constants';
+import TermsAndConditions from '../../pages/TermsAndConditions';
+import authReducer from '../../redux/slices/auth/authSlice';
+import growthbookReducer from '../../redux/slices/growthbook/growthbookSlice';
+import {
+  __resetGrowthBookMock,
+  __setGrowthBookMock,
+} from '../../tests/__mocks__/@growthbook/growthbook-react';
+import {
+  mockApiHandler,
+  mockAuthHandler,
+} from '../../tests/__mocks__/serviceConfigMock';
+import TermsGate from './TermsGate';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (value: string) => value,
+  }),
+  Trans: ({
+    i18nKey,
+    components,
+  }: {
+    i18nKey: string;
+    components?: Record<number, ReactElement>;
+  }) => {
+    const parts = i18nKey.split(/<1>|<\/1>/);
+
+    return (
+      <>
+        {parts[0]}
+        {components?.[1]}
+        {parts[2] ?? ''}
+      </>
+    );
+  },
+}));
+
+jest.mock('../../utility/util', () => ({
+  Util: {
+    logEvent: jest.fn(),
+  },
+}));
+
+describe('TermsGate', () => {
+  const renderWithStore = (ui: ReactElement, userVersion = 1) => {
+    const store = createStore(userVersion);
+
+    return render(<Provider store={store}>{ui}</Provider>);
+  };
+
+  const createStore = (userVersion = 1) =>
+    configureStore({
+      reducer: { auth: authReducer, growthbook: growthbookReducer },
+      middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware({ serializableCheck: false }),
+      preloadedState: {
+        auth: {
+          authUser: { id: 'parent-1' },
+          user: {
+            id: 'parent-1',
+            is_tc_accepted: true,
+            tc_agreed_version: userVersion,
+          } as TableTypes<'user'>,
+          refreshToken: null,
+          isOpsUser: false,
+          roles: [],
+          loading: false,
+          error: {
+            phone: null,
+            student: null,
+            email: null,
+            otp: null,
+            general: null,
+          },
+        },
+        growthbook: {
+          attributes: {},
+          featureValues: {},
+        },
+      },
+    });
+
+  const ProtectedContent = () => {
+    const location = useLocation<{ lessonId?: string } | undefined>();
+
+    return (
+      <>
+        <div>Protected Content</div>
+        <div data-testid="route-path">
+          {location.pathname}
+          {location.search}
+        </div>
+        <div data-testid="route-state">{location.state?.lessonId ?? ''}</div>
+      </>
+    );
+  };
+
+  beforeEach(() => {
+    __resetGrowthBookMock();
+    jest.clearAllMocks();
+    mockAuthHandler.isUserLoggedIn.mockResolvedValue(true);
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'parent-1',
+      is_tc_accepted: true,
+      tc_agreed_version: 1,
+    });
+    localStorage.removeItem('currentMode');
+  });
+
+  it('dismisses the modal immediately after agree without waiting for API completion', async () => {
+    __setGrowthBookMock({
+      features: { [LATEST_TC_VERSION]: 3 },
+    });
+    mockApiHandler.updateTcAgreedVersion.mockReturnValue(new Promise(() => {}));
+
+    const user = userEvent.setup();
+
+    renderWithStore(
+      <MemoryRouter initialEntries={['/protected']}>
+        <TermsGate />
+        <Switch>
+          <ProtectedRoute path="/protected">
+            <ProtectedContent />
+          </ProtectedRoute>
+        </Switch>
+      </MemoryRouter>,
+      1,
+    );
+
+    expect(await screen.findByText(/protected content/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /agree as parent/i }));
+
+    expect(mockApiHandler.updateTcAgreedVersion).toHaveBeenCalledWith(
+      'parent-1',
+      3,
+    );
+    expect(
+      screen.queryByRole('button', { name: /agree as parent/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders only one modal even when nested protected routes are mounted', async () => {
+    __setGrowthBookMock({
+      features: { [LATEST_TC_VERSION]: 3 },
+    });
+
+    renderWithStore(
+      <MemoryRouter initialEntries={['/outer/inner']}>
+        <TermsGate />
+        <Switch>
+          <ProtectedRoute path="/outer">
+            <Switch>
+              <ProtectedRoute path="/outer/inner">
+                <ProtectedContent />
+              </ProtectedRoute>
+            </Switch>
+          </ProtectedRoute>
+        </Switch>
+      </MemoryRouter>,
+      1,
+    );
+
+    expect(await screen.findByText(/protected content/i)).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('button', { name: /agree as parent/i }),
+    ).toHaveLength(1);
+  });
+
+  it('restores search params and route state after closing the terms page', async () => {
+    __setGrowthBookMock({
+      features: { [LATEST_TC_VERSION]: 3 },
+    });
+
+    const user = userEvent.setup();
+
+    renderWithStore(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/protected',
+            search: '?lessonid=lesson-1',
+            state: { lessonId: 'lesson-1', from: PAGES.HOME },
+          },
+        ]}
+      >
+        <TermsGate />
+        <Switch>
+          <ProtectedRoute path="/protected">
+            <ProtectedContent />
+          </ProtectedRoute>
+          <Route path={PAGES.TERMS_AND_CONDITIONS}>
+            <TermsAndConditions />
+          </Route>
+        </Switch>
+      </MemoryRouter>,
+      1,
+    );
+
+    expect(await screen.findByText(/protected content/i)).toBeInTheDocument();
+    expect(screen.getByTestId('route-path')).toHaveTextContent(
+      '/protected?lessonid=lesson-1',
+    );
+    expect(screen.getByTestId('route-state')).toHaveTextContent('lesson-1');
+
+    await user.click(
+      screen.getByRole('button', { name: /terms & conditions/i }),
+    );
+    expect(
+      await screen.findByTitle(/terms and conditions/i),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /close/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/protected content/i)).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('route-path')).toHaveTextContent(
+      '/protected?lessonid=lesson-1',
+    );
+    expect(screen.getByTestId('route-state')).toHaveTextContent('lesson-1');
+  });
+
+  it('does not show the modal on deferred gameplay routes', async () => {
+    __setGrowthBookMock({
+      features: { [LATEST_TC_VERSION]: 3 },
+    });
+
+    renderWithStore(
+      <MemoryRouter initialEntries={[PAGES.LIDO_PLAYER]}>
+        <TermsGate />
+        <Switch>
+          <ProtectedRoute path={PAGES.LIDO_PLAYER}>
+            <ProtectedContent />
+          </ProtectedRoute>
+        </Switch>
+      </MemoryRouter>,
+      1,
+    );
+
+    expect(await screen.findByText(/protected content/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /agree as parent/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/termsandconditons/TermsGate.tsx
+++ b/src/components/termsandconditons/TermsGate.tsx
@@ -116,6 +116,7 @@ const TermsGate: React.FC = () => {
       return;
     }
 
+    const previousUser = effectiveUser;
     const agreedUser: TableTypes<'user'> = {
       ...effectiveUser,
       is_tc_accepted: true,
@@ -137,14 +138,24 @@ const TermsGate: React.FC = () => {
           effectiveUser.id,
           requiredTcVersion,
         );
-      } catch (error) {
-        logger.error('Failed to persist T&C agreement', error);
-      } finally {
-        setIsSubmitting(false);
+
         void Util.logEvent(EVENTS.TC_AGREED, {
           agreed_version: requiredTcVersion,
           ...buildTcAnalyticsContext(effectiveUser),
         });
+      } catch (error) {
+        logger.error('Failed to persist T&C agreement', error);
+
+        setOptimisticAgreements((previous) => {
+          const next = { ...previous };
+          delete next[effectiveUser.id];
+          return next;
+        });
+        setCurrentUser(previousUser);
+        ServiceConfig.getI().authHandler.currentUser = { ...previousUser };
+        dispatch(setUser(previousUser));
+      } finally {
+        setIsSubmitting(false);
       }
     })();
   };

--- a/src/components/termsandconditons/TermsGate.tsx
+++ b/src/components/termsandconditons/TermsGate.tsx
@@ -1,0 +1,202 @@
+import { useFeatureValue } from '@growthbook/growthbook-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+
+import {
+  EVENTS,
+  LATEST_TC_VERSION,
+  PAGES,
+  TableTypes,
+} from '../../common/constants';
+import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import { setUser } from '../../redux/slices/auth/authSlice';
+import { ServiceConfig } from '../../services/ServiceConfig';
+import {
+  buildTcAnalyticsContext,
+  getUserTcAgreedVersion,
+  needsTermsAgreement,
+  normalizeTcVersion,
+} from '../../utility/termsAndConditions';
+import logger from '../../utility/logger';
+import { Util } from '../../utility/util';
+import TermsAndCoditionsModal from './TermsAndCoditionsModal';
+
+const TERMS_MODAL_DEFERRED_PATHS = new Set<string>([
+  PAGES.GAME,
+  PAGES.LIDO_PLAYER,
+  PAGES.LIVE_QUIZ_GAME,
+]);
+
+const TERMS_MODAL_HIDDEN_PATHS = new Set<string>([
+  PAGES.LOGIN,
+  PAGES.RESET_PASSWORD,
+  PAGES.TERMS_AND_CONDITIONS,
+  PAGES.APP_UPDATE,
+]);
+
+const TermsGate: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const history = useHistory();
+  const location = useLocation();
+  const latestTcVersion = useFeatureValue<number>(LATEST_TC_VERSION, 0);
+  const requiredTcVersion = normalizeTcVersion(latestTcVersion);
+  const reduxUser = useAppSelector((state) => state.auth.user);
+  const [currentUser, setCurrentUser] = useState<TableTypes<'user'> | null>(
+    reduxUser ?? null,
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [optimisticAgreements, setOptimisticAgreements] = useState<
+    Record<string, number>
+  >({});
+  const viewedEventKeyRef = useRef('');
+
+  useEffect(() => {
+    setCurrentUser(reduxUser ?? null);
+  }, [reduxUser]);
+
+  useEffect(() => {
+    if (reduxUser?.id || TERMS_MODAL_HIDDEN_PATHS.has(location.pathname)) {
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadCurrentUser = async () => {
+      try {
+        const authHandler = ServiceConfig.getI()?.authHandler;
+        const user = await authHandler?.getCurrentUser();
+        if (!isMounted || !user?.id) {
+          return;
+        }
+
+        setCurrentUser(user);
+        dispatch(setUser(user));
+      } catch (error) {
+        logger.error('Failed to resolve user for terms gate', error);
+      }
+    };
+
+    void loadCurrentUser();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [dispatch, location.pathname, reduxUser?.id]);
+
+  const effectiveUser = useMemo(() => {
+    if (!currentUser?.id) {
+      return currentUser;
+    }
+
+    const optimisticVersion = optimisticAgreements[currentUser.id] ?? 0;
+    if (optimisticVersion <= getUserTcAgreedVersion(currentUser)) {
+      return currentUser;
+    }
+
+    return {
+      ...currentUser,
+      is_tc_accepted: true,
+      tc_agreed_version: optimisticVersion,
+    };
+  }, [currentUser, optimisticAgreements]);
+
+  const shouldRequireTerms = needsTermsAgreement(
+    effectiveUser,
+    requiredTcVersion,
+  );
+  const shouldDeferTermsModal = TERMS_MODAL_DEFERRED_PATHS.has(
+    location.pathname,
+  );
+  const shouldHideTermsModal = TERMS_MODAL_HIDDEN_PATHS.has(location.pathname);
+  const shouldShowTermsModal =
+    !shouldHideTermsModal && !shouldDeferTermsModal && shouldRequireTerms;
+
+  const handleAgree = () => {
+    if (!effectiveUser?.id || isSubmitting) {
+      return;
+    }
+
+    const agreedUser: TableTypes<'user'> = {
+      ...effectiveUser,
+      is_tc_accepted: true,
+      tc_agreed_version: requiredTcVersion,
+    };
+
+    setIsSubmitting(true);
+    setOptimisticAgreements((previous) => ({
+      ...previous,
+      [effectiveUser.id]: requiredTcVersion,
+    }));
+    setCurrentUser(agreedUser);
+    ServiceConfig.getI().authHandler.currentUser = { ...agreedUser };
+    dispatch(setUser(agreedUser));
+
+    void (async () => {
+      try {
+        await ServiceConfig.getI().apiHandler.updateTcAgreedVersion(
+          effectiveUser.id,
+          requiredTcVersion,
+        );
+      } catch (error) {
+        logger.error('Failed to persist T&C agreement', error);
+      } finally {
+        setIsSubmitting(false);
+        void Util.logEvent(EVENTS.TC_AGREED, {
+          agreed_version: requiredTcVersion,
+          ...buildTcAnalyticsContext(effectiveUser),
+        });
+      }
+    })();
+  };
+
+  const handleTermsClick = () => {
+    const from =
+      location.pathname + (location.search ?? '') + (location.hash ?? '');
+
+    history.push({
+      pathname: PAGES.TERMS_AND_CONDITIONS,
+      state: {
+        from,
+        returnLocation: {
+          pathname: location.pathname,
+          search: location.search,
+          hash: location.hash,
+          state: location.state,
+        },
+      },
+    });
+  };
+
+  const handleTermsModalViewed = () => {
+    if (!currentUser?.id || !shouldShowTermsModal) {
+      return;
+    }
+
+    const eventKey = `${currentUser.id}:${requiredTcVersion}`;
+    if (viewedEventKeyRef.current === eventKey) {
+      return;
+    }
+
+    viewedEventKeyRef.current = eventKey;
+    void Util.logEvent(EVENTS.TC_POPUP_VIEWED, {
+      target_version: requiredTcVersion,
+      current_local_version: currentUser.tc_agreed_version ?? 0,
+      ...buildTcAnalyticsContext(currentUser),
+    });
+  };
+
+  if (!shouldShowTermsModal) {
+    return null;
+  }
+
+  return (
+    <TermsAndCoditionsModal
+      isSubmitting={isSubmitting}
+      onAgree={handleAgree}
+      onTermsClick={handleTermsClick}
+      onViewed={handleTermsModalViewed}
+    />
+  );
+};
+
+export default TermsGate;

--- a/src/pages/Parent.css
+++ b/src/pages/Parent.css
@@ -459,7 +459,7 @@
 
 .parent-settings-language-menu {
   position: absolute;
-  top: calc(100% + 10px);
+  top: calc(100% + 3px);
   left: 0;
   z-index: 20;
   width: 100%;
@@ -505,7 +505,7 @@
   gap: 34px;
   margin-left: auto;
   padding-top: 2px;
-  min-width: 190px;
+  min-width: 140px;
   align-items: stretch;
 }
 
@@ -527,10 +527,10 @@
 
 .parent-settings-toggle-row {
   display: grid;
-  grid-template-columns: minmax(70px, auto) 48px minmax(55px, auto);
+  grid-template-columns: minmax(40px, auto) 48px minmax(40px, auto);
   align-items: center;
   justify-content: center;
-  column-gap: 8px;
+  column-gap: clamp(2px, 0.5vw, 5px);
 }
 
 .parent-settings-toggle-state {
@@ -656,7 +656,7 @@
   border-bottom: 5px solid #300d37;
   background: #c094ef;
   color: #311237;
-  font-size: clamp(16px, 1.2rem, 18px);
+  font-size: clamp(16px, 1.2rem, 17px);
   font-weight: 600;
   font-style: normal;
   line-height: 24px; /* 150% */
@@ -690,6 +690,155 @@
   height: 18px;
   display: block;
   flex-shrink: 0;
+}
+
+@media (min-width: 1200px) and (min-height: 700px) and (orientation: landscape) {
+  .parent-settings-layout {
+    width: min(94vw, 1460px);
+    gap: 20px;
+    margin-top: 20px;
+  }
+
+  .parent-settings-top-grid {
+    grid-template-columns: minmax(0, 1.6fr) minmax(380px, 1fr);
+    gap: 24px;
+  }
+
+  .parent-settings-card {
+    border-radius: 28px;
+  }
+
+  .parent-settings-application-card {
+    min-height: clamp(290px, 43vh, 380px);
+    padding: 30px 32px 34px;
+  }
+
+  .parent-settings-teachers-card {
+    min-height: clamp(290px, 43vh, 380px);
+    padding: 30px 28px 24px;
+  }
+
+  .parent-settings-account-card {
+    min-height: clamp(190px, 27vh, 260px);
+    padding: 28px 32px 30px;
+  }
+
+  .parent-settings-card-title {
+    font-size: 20px;
+  }
+
+  .parent-settings-application-content {
+    gap: 38px;
+    margin-top: 24px;
+  }
+
+  .parent-settings-language-block {
+    max-width: 340px;
+  }
+
+  .parent-settings-field-label {
+    margin-bottom: 14px;
+    font-size: 18px;
+  }
+
+  .parent-settings-language-dropdown {
+    max-width: 280px;
+  }
+
+  .parent-settings-language-trigger {
+    min-height: 68px;
+    border-radius: 12px;
+    padding: 0 18px 0 20px;
+  }
+
+  .parent-settings-language-menu {
+    top: calc(100% + 6px);
+    max-height: 340px;
+    border-radius: 12px;
+  }
+
+  .parent-settings-language-trigger-label,
+  .parent-settings-language-option {
+    font-size: 30px;
+  }
+
+  .parent-settings-language-option {
+    min-height: 54px;
+    padding: 0 18px;
+  }
+
+  .parent-settings-toggle-column {
+    min-width: 190px;
+    gap: 44px;
+    padding-top: 6px;
+  }
+
+  .parent-settings-toggle-title,
+  .parent-settings-toggle-state {
+    font-size: 18px;
+  }
+
+  .parent-settings-toggle-row {
+    grid-template-columns: minmax(48px, auto) 64px minmax(48px, auto);
+    column-gap: 12px;
+  }
+
+  .parent-settings-switch {
+    width: 64px;
+    height: 34px;
+  }
+
+  .parent-settings-switch-thumb {
+    top: 2px;
+    left: 2px;
+    width: 30px;
+    height: 30px;
+  }
+
+  .parent-settings-switch.is-on .parent-settings-switch-thumb {
+    transform: translateX(30px);
+  }
+
+  .parent-settings-teachers-button {
+    width: min(100%, 380px);
+    max-width: 72%;
+    min-height: 70px;
+    padding: 12px 24px 14px;
+    font-size: 20px;
+  }
+
+  .parent-settings-teachers-button-icon {
+    width: 20px;
+    height: 20px;
+  }
+
+  .parent-settings-account-actions {
+    justify-content: center;
+    gap: 28px;
+    margin-top: 26px;
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .parent-settings-account-button {
+    min-height: 64px;
+    padding: 10px 24px 12px;
+    font-size: 20px;
+  }
+
+  .parent-settings-account-button--terms {
+    width: min(100%, 324px);
+  }
+
+  .parent-settings-account-button--signout,
+  .parent-settings-account-button--delete {
+    width: min(100%, 236px);
+  }
+
+  .parent-settings-account-button-icon {
+    width: 20px;
+    height: 20px;
+  }
 }
 
 @media (max-width: 900px) and (orientation: portrait) {

--- a/src/pages/TermsAndConditions.css
+++ b/src/pages/TermsAndConditions.css
@@ -21,6 +21,28 @@
   border: none;
   cursor: pointer;
   padding: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.terms-and-conditions-close-button img {
+  display: block;
+}
+
+.terms-and-conditions-close-button--ops {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border-radius: 9999px;
+  color: #757575;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.terms-and-conditions-close-button--ops:hover {
+  background-color: #f5f5f5;
 }
 
 .terms-and-conditions-content {
@@ -29,7 +51,7 @@
 }
 
 .terms-and-conditions-frame {
-  height: 80vh;
+  height: 90vh;
   width: 100%;
   border: none;
 }

--- a/src/pages/TermsAndConditions.tsx
+++ b/src/pages/TermsAndConditions.tsx
@@ -1,4 +1,5 @@
 import { useFeatureValue } from '@growthbook/growthbook-react';
+import CloseIcon from '@mui/icons-material/Close';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router';
@@ -7,6 +8,7 @@ import { PAGES, TC_HTML_URL } from '../common/constants';
 import { ServiceConfig } from '../services/ServiceConfig';
 import {
   buildTermsUrl,
+  getCurrentTermsAppMode,
   getEnglishTermsUrl,
   getTermsLanguageCode,
   resolveTermsBaseUrl,
@@ -33,6 +35,7 @@ const TermsAndConditions: React.FC = () => {
   const { t } = useTranslation();
   const tcHtmlUrlFeature = useFeatureValue<string>(TC_HTML_URL, '');
   const [iframeSrc, setIframeSrc] = useState(LEGACY_TERMS_URL);
+  const appMode = getCurrentTermsAppMode();
 
   const redirectTarget = location.state?.from || PAGES.SELECT_MODE;
   const returnLocation = location.state?.returnLocation;
@@ -94,11 +97,26 @@ const TermsAndConditions: React.FC = () => {
       <div className="terms-and-conditions-header">
         <button
           type="button"
-          className="terms-and-conditions-close-button"
+          className={`terms-and-conditions-close-button ${
+            appMode === 'ops' ? 'terms-and-conditions-close-button--ops' : ''
+          }`}
           onClick={handleClose}
           aria-label={String(t('Close'))}
         >
-          <img src={CLOSE_ICON_SRC} alt="" aria-hidden="true" />
+          {appMode === 'ops' ? (
+            <CloseIcon aria-hidden="true" />
+          ) : (
+            <img
+              src={CLOSE_ICON_SRC}
+              alt=""
+              aria-hidden="true"
+              style={
+                appMode === 'teacher'
+                  ? { filter: 'brightness(0) saturate(100%)' }
+                  : undefined
+              }
+            />
+          )}
         </button>
       </div>
 
@@ -109,7 +127,7 @@ const TermsAndConditions: React.FC = () => {
           title="Terms and Conditions"
           allowFullScreen={true}
           onError={handleIframeError}
-          style={{ height: '80vh', width: '100%', border: 'none' }}
+          style={{ width: '100%', border: 'none' }}
         />
       </div>
     </div>

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -2249,32 +2249,40 @@ export class SqliteApi implements ServiceApi {
     });
   }
   async updateTcAccept(userId: string) {
-    return this.updateTcAgreedVersion(userId, 1);
-  }
-
-  async updateTcAgreedVersion(userId: string, version: number) {
     const query = `
     UPDATE "user"
-    SET is_tc_accepted = 1,
-        tc_agreed_version = ${version},
-        updated_at = "${new Date().toISOString()}"
+    SET is_tc_accepted = 1
     WHERE id = "${userId}";
   `;
     const res = await this.executeQuery(query);
     logger.info(
-      '🚀 ~ SqliteApi ~ updateTcAgreedVersion ~ res:',
+      '🚀 ~ SqliteApi ~ updateTcAccept ~ res:',
       res,
       ServiceConfig.getI().authHandler.currentUser,
     );
     const auth = ServiceConfig.getI().authHandler;
     const currentUser = await auth.getCurrentUser();
     if (currentUser) {
-      currentUser.is_tc_accepted = true;
-      currentUser.tc_agreed_version = version;
-      auth.currentUser = currentUser;
+      auth.currentUser = {
+        ...currentUser,
+        is_tc_accepted: true,
+      };
     }
     this.updatePushChanges(TABLES.User, MUTATE_TYPES.UPDATE, {
       is_tc_accepted: 1,
+      id: userId,
+    });
+  }
+
+  async updateTcAgreedVersion(userId: string, version: number) {
+    const query = `
+    UPDATE "user"
+    SET tc_agreed_version = ${version},
+        updated_at = "${new Date().toISOString()}"
+    WHERE id = "${userId}";
+  `;
+    const res = await this.executeQuery(query);
+    this.updatePushChanges(TABLES.User, MUTATE_TYPES.UPDATE, {
       tc_agreed_version: version,
       id: userId,
     });

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -2020,6 +2020,7 @@ export class SupabaseApi implements ServiceApi {
       }
     } catch (error) {
       logger.error('Error updating T&C acceptance:', error);
+      throw error;
     }
   }
 
@@ -2039,6 +2040,7 @@ export class SupabaseApi implements ServiceApi {
       }
     } catch (error) {
       logger.error('Error updating T&C acceptance:', error);
+      throw error;
     }
   }
   async getLanguageWithId(

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -1999,19 +1999,11 @@ export class SupabaseApi implements ServiceApi {
     }
   }
   async updateTcAccept(userId: string) {
-    return this.updateTcAgreedVersion(userId, 1);
-  }
-
-  async updateTcAgreedVersion(userId: string, version: number) {
     if (!this.supabase) return;
     try {
       const { error } = await this.supabase
         .from('user')
-        .update({
-          is_tc_accepted: true,
-          tc_agreed_version: version,
-          updated_at: new Date().toISOString(),
-        })
+        .update({ is_tc_accepted: true })
         .eq('id', userId);
 
       if (error) {
@@ -2021,9 +2013,29 @@ export class SupabaseApi implements ServiceApi {
       const auth = ServiceConfig.getI().authHandler;
       const currentUser = await auth.getCurrentUser();
       if (currentUser) {
-        currentUser.is_tc_accepted = true;
-        currentUser.tc_agreed_version = version;
-        auth.currentUser = currentUser;
+        auth.currentUser = {
+          ...currentUser,
+          is_tc_accepted: true,
+        };
+      }
+    } catch (error) {
+      logger.error('Error updating T&C acceptance:', error);
+    }
+  }
+
+  async updateTcAgreedVersion(userId: string, version: number) {
+    if (!this.supabase) return;
+    try {
+      const { error } = await this.supabase
+        .from('user')
+        .update({
+          tc_agreed_version: version,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', userId);
+
+      if (error) {
+        throw new Error(`Failed to update T&C acceptance: ${error.message}`);
       }
     } catch (error) {
       logger.error('Error updating T&C acceptance:', error);


### PR DESCRIPTION
## Summary

This PR improves the Terms & Conditions flow and updates related UI.

### Changes
- Introduced a single global `TermsGate` to manage the T&C modal.
- Removed T&C modal ownership from `ProtectedRoute` to prevent duplicate modals in nested routes.
- Dismiss the T&C modal immediately on `Agree`, then persist the update in the background.
- Replaced in-place auth user mutations in `SqliteApi` and `SupabaseApi` with cloned updates to avoid frozen object errors.
- Updated the Terms and Conditions page styling, including mode-specific close button behavior.
- Refreshed the parent settings page UI.

### Why
Previously, multiple mounted `ProtectedRoute` instances could each render their own T&C modal, causing duplicate overlays and blocked flows. This change ensures the modal is rendered only once app-wide.
