### PR TITLE
fix: Script skip orphan skill_lesson rows when importing

### DIFF
--- a/recommend.ts
+++ b/recommend.ts
@@ -256,10 +256,25 @@ const useImportJsonForCurriculum = async () => {
     table('skill_relation').filter(
       (r) => targetSkillIds.includes(r.target_skill_id) && isActive(r),
     );
-  service.getSkillLessonsBySkillIds = async (skillIds) =>
-    table('skill_lesson')
-      .filter((sl) => skillIds.includes(sl.skill_id) && isActive(sl))
+  service.getSkillLessonsBySkillIds = async (skillIds) => {
+    const lessonIds = new Set(
+      table('lesson')
+        .filter(isActive)
+        .map((lesson) => lesson.id),
+    );
+
+    return table('skill_lesson')
+      .filter((sl) => {
+        if (!skillIds.includes(sl.skill_id) || !isActive(sl)) return false;
+        if (lessonIds.has(sl.lesson_id)) return true;
+
+        log(
+          `skipping orphan skill_lesson lesson_id=${sl.lesson_id} skill_id=${sl.skill_id} sort_index=${sl.sort_index ?? ''}; lesson row not found in local import.json`,
+        );
+        return false;
+      })
       .sort((a, b) => (a.sort_index ?? 0) - (b.sort_index ?? 0));
+  };
   service.getLessonsBylessonIds = async (lessonIds) => {
     const lessons = table('lesson').filter(
       (lesson) => lessonIds.includes(lesson.id) && isActive(lesson),


### PR DESCRIPTION
- Add a concrete CLI example for running the next recommendation simulation and improve import handling for skill lessons. 
- getSkillLessonsBySkillIds now builds a set of active lesson IDs and filters out skill_lesson rows whose lesson_id is not present in the local import (logging a skip message with details). 
- Returned skill_lesson rows are still sorted by sort_index. This prevents errors from orphaned skill_lesson entries in import.json.