### PR TITLE
Fix Digital Skills continue playing popup

### DIFF
--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -112,7 +112,6 @@ const LidoPlayer: FC = () => {
   });
 
   const isExitingRef = useRef(false);
-  const isLessonEndProcessingRef = useRef(false);
 
   const resolveStudentContext = async (): Promise<{
     student: TableTypes<'user'> | undefined;
@@ -561,10 +560,6 @@ const LidoPlayer: FC = () => {
   };
 
   const onLessonEnd = async (e: any) => {
-    if (isLessonEndProcessingRef.current) {
-      return;
-    }
-    isLessonEndProcessingRef.current = true;
     setIsLoading(true);
     const lessonData = ((e?.detail ?? {}) as LidoEventDetail) ?? {};
     const {
@@ -873,14 +868,12 @@ const LidoPlayer: FC = () => {
       logger.error('❌ Failed to process lesson end', error);
       localStorage.removeItem(LIDO_SCORES_KEY);
       push();
-    } finally {
-      isLessonEndProcessingRef.current = false;
     }
   };
 
   const onGameExit = async (e: any) => {
     const data = (e.detail ?? {}) as LidoEventDetail;
-    if (isLessonEndProcessingRef.current || showDialogBox) {
+    if (showDialogBox) {
       return;
     }
 

--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -891,13 +891,6 @@ const LidoPlayer: FC = () => {
     const isCompletedExit =
       data.gameCompleted === true || data.quizCompleted === true;
 
-    if (isCompletedExit) {
-      if (!showDialogBox && !isLoading) {
-        await onLessonEnd(e);
-      }
-      return;
-    }
-
     if (isLessonEndProcessingRef.current || showDialogBox) {
       return;
     }

--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -888,9 +888,6 @@ const LidoPlayer: FC = () => {
 
   const onGameExit = async (e: any) => {
     const data = (e.detail ?? {}) as LidoEventDetail;
-    const isCompletedExit =
-      data.gameCompleted === true || data.quizCompleted === true;
-
     if (isLessonEndProcessingRef.current || showDialogBox) {
       return;
     }

--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -561,7 +561,7 @@ const LidoPlayer: FC = () => {
 
   const onLessonEnd = async (e: any) => {
     setIsLoading(true);
-    const lessonData = ((e?.detail ?? {}) as LidoEventDetail) ?? {};
+    const lessonData = (e?.detail ?? {}) as LidoEventDetail;
     const {
       student: currentStudent,
       studentId,
@@ -872,10 +872,6 @@ const LidoPlayer: FC = () => {
   };
 
   const onGameExit = async (e: any) => {
-    if (showDialogBox) {
-      return;
-    }
-
     const data = (e.detail ?? {}) as LidoEventDetail;
     const { studentId, userId } = await resolveStudentContext();
     if (!studentId) {

--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -111,6 +111,17 @@ const LidoPlayer: FC = () => {
     isStudentLinked: false,
   });
   const isExitingRef = useRef(false);
+  const isLessonEndProcessingRef = useRef(false);
+  const isLoadingRef = useRef(isLoading);
+  const showDialogBoxRef = useRef(showDialogBox);
+
+  useEffect(() => {
+    isLoadingRef.current = isLoading;
+  }, [isLoading]);
+
+  useEffect(() => {
+    showDialogBoxRef.current = showDialogBox;
+  }, [showDialogBox]);
 
   const resolveStudentContext = async (): Promise<{
     student: TableTypes<'user'> | undefined;
@@ -233,9 +244,50 @@ const LidoPlayer: FC = () => {
   const getTotalStoredLessonTime = (scoresList: StoredLidoScore[]): number =>
     scoresList.reduce((total, record) => total + (record.timeSpent ?? 0), 0);
 
+  const buildFallbackLessonResult = (
+    detail: LidoEventDetail,
+  ): LidoEventDetail => {
+    const scoresList = getStoredLidoScores();
+    const derivedFinalScore =
+      parseNumericValue(detail.finalScore) ??
+      parseNumericValue(detail.score) ??
+      (scoresList.length > 0
+        ? Math.round(
+            scoresList.reduce((sum, item) => sum + (item.score ?? 0), 0) /
+              scoresList.length,
+          )
+        : 0);
+    const derivedLessonTime =
+      parseNumericValue(detail.timeSpendForLesson) ??
+      getTotalStoredLessonTime(scoresList);
+    const derivedCorrectMoves =
+      parseNumericValue(detail.correctMoves) ??
+      parseNumericValue(detail.rightMoves) ??
+      scoresList.reduce((sum, item) => sum + (item.correctMoves ?? 0), 0);
+    const derivedWrongMoves =
+      parseNumericValue(detail.wrongMoves) ??
+      scoresList.reduce((sum, item) => sum + (item.wrongMoves ?? 0), 0);
+
+    return {
+      ...detail,
+      finalScore: derivedFinalScore,
+      score: derivedFinalScore,
+      timeSpendForLesson: derivedLessonTime,
+      correctMoves: derivedCorrectMoves,
+      wrongMoves: derivedWrongMoves,
+    };
+  };
+
   const onNextContainer = (e: any) => logger.info('Next', e);
-  const gameCompleted = (e: any) => {
-    // setShowDialogBox(true);
+  const gameCompleted = async (e: Event) => {
+    // The bundled Lido player emits `lidoGameCompleted` only when the full
+    // lesson flow is complete, and Digital Skills can send it with an empty
+    // detail payload. Route that event through the normal lesson-end flow.
+    if (!showDialogBoxRef.current && !isLoadingRef.current) {
+      await onLessonEnd(e);
+      return;
+    }
+
     const popupConfig = growthbook?.getFeatureValue('generic-pop-up', null);
 
     if (popupConfig) {
@@ -560,7 +612,12 @@ const LidoPlayer: FC = () => {
   };
 
   const onLessonEnd = async (e: any) => {
+    if (isLessonEndProcessingRef.current) {
+      return;
+    }
+    isLessonEndProcessingRef.current = true;
     setIsLoading(true);
+    const lessonData = ((e?.detail ?? {}) as LidoEventDetail) ?? {};
     const {
       student: currentStudent,
       studentId,
@@ -574,7 +631,6 @@ const LidoPlayer: FC = () => {
       }
       const parentUserId = userId;
       const courseDocId: string | undefined = state.courseDocId;
-      const lessonData = (e.detail ?? {}) as LidoEventDetail;
       const { correctMoves, wrongMoves } = getNormalizedMoveCounts(lessonData);
       if (isAssessmentLesson) {
         const courseKey = courseDetail?.id ?? courseDocId ?? '';
@@ -867,12 +923,22 @@ const LidoPlayer: FC = () => {
       setShowDialogBox(true);
     } catch (error) {
       logger.error('❌ Failed to process lesson end', error);
-      localStorage.removeItem(LIDO_SCORES_KEY);
-      push();
+      const fallbackResult = buildFallbackLessonResult(lessonData);
+      setGameResult(fallbackResult);
+      setIsLoading(false);
+      setShowDialogBox(true);
+    } finally {
+      isLessonEndProcessingRef.current = false;
     }
   };
 
   const onGameExit = async (e: any) => {
+    const data = (e.detail ?? {}) as LidoEventDetail;
+
+    if (isLessonEndProcessingRef.current || showDialogBoxRef.current) {
+      return;
+    }
+
     const { studentId, userId } = await resolveStudentContext();
     if (!studentId) {
       push();
@@ -882,17 +948,6 @@ const LidoPlayer: FC = () => {
     const parentUserId = userId;
     const courseKey = courseDetail?.id ?? courseDocId ?? '';
     Util.removeCourseScopedKey(FAIL_STREAK_KEY, studentId, courseKey);
-    const data = (e.detail ?? {}) as LidoEventDetail;
-
-    const isCompletedExit =
-      data.gameCompleted === true || data.quizCompleted === true;
-
-    if (isCompletedExit) {
-      if (!showDialogBox && !isLoading) {
-        await onLessonEnd(e);
-      }
-      return;
-    }
 
     const { correctMoves, wrongMoves } = getNormalizedMoveCounts(data);
     const storedScores = getStoredLidoScores();

--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -110,18 +110,9 @@ const LidoPlayer: FC = () => {
     chapterId: undefined as string | undefined,
     isStudentLinked: false,
   });
+
   const isExitingRef = useRef(false);
   const isLessonEndProcessingRef = useRef(false);
-  const isLoadingRef = useRef(isLoading);
-  const showDialogBoxRef = useRef(showDialogBox);
-
-  useEffect(() => {
-    isLoadingRef.current = isLoading;
-  }, [isLoading]);
-
-  useEffect(() => {
-    showDialogBoxRef.current = showDialogBox;
-  }, [showDialogBox]);
 
   const resolveStudentContext = async (): Promise<{
     student: TableTypes<'user'> | undefined;
@@ -244,46 +235,12 @@ const LidoPlayer: FC = () => {
   const getTotalStoredLessonTime = (scoresList: StoredLidoScore[]): number =>
     scoresList.reduce((total, record) => total + (record.timeSpent ?? 0), 0);
 
-  const buildFallbackLessonResult = (
-    detail: LidoEventDetail,
-  ): LidoEventDetail => {
-    const scoresList = getStoredLidoScores();
-    const derivedFinalScore =
-      parseNumericValue(detail.finalScore) ??
-      parseNumericValue(detail.score) ??
-      (scoresList.length > 0
-        ? Math.round(
-            scoresList.reduce((sum, item) => sum + (item.score ?? 0), 0) /
-              scoresList.length,
-          )
-        : 0);
-    const derivedLessonTime =
-      parseNumericValue(detail.timeSpendForLesson) ??
-      getTotalStoredLessonTime(scoresList);
-    const derivedCorrectMoves =
-      parseNumericValue(detail.correctMoves) ??
-      parseNumericValue(detail.rightMoves) ??
-      scoresList.reduce((sum, item) => sum + (item.correctMoves ?? 0), 0);
-    const derivedWrongMoves =
-      parseNumericValue(detail.wrongMoves) ??
-      scoresList.reduce((sum, item) => sum + (item.wrongMoves ?? 0), 0);
-
-    return {
-      ...detail,
-      finalScore: derivedFinalScore,
-      score: derivedFinalScore,
-      timeSpendForLesson: derivedLessonTime,
-      correctMoves: derivedCorrectMoves,
-      wrongMoves: derivedWrongMoves,
-    };
-  };
-
   const onNextContainer = (e: any) => logger.info('Next', e);
   const gameCompleted = async (e: Event) => {
     // The bundled Lido player emits `lidoGameCompleted` only when the full
     // lesson flow is complete, and Digital Skills can send it with an empty
     // detail payload. Route that event through the normal lesson-end flow.
-    if (!showDialogBoxRef.current && !isLoadingRef.current) {
+    if (!showDialogBox && !isLoading) {
       await onLessonEnd(e);
       return;
     }
@@ -844,7 +801,6 @@ const LidoPlayer: FC = () => {
         await Util.updateHomeworkPath(homeworkIndex);
       }
 
-      // ⭐ 2) Bonus +10 stars if this was the last lesson in pathway
       if (shouldGiveHomeworkBonus) {
         try {
           const student = Util.getCurrentStudent() ?? currentStudent;
@@ -923,10 +879,8 @@ const LidoPlayer: FC = () => {
       setShowDialogBox(true);
     } catch (error) {
       logger.error('❌ Failed to process lesson end', error);
-      const fallbackResult = buildFallbackLessonResult(lessonData);
-      setGameResult(fallbackResult);
-      setIsLoading(false);
-      setShowDialogBox(true);
+      localStorage.removeItem(LIDO_SCORES_KEY);
+      push();
     } finally {
       isLessonEndProcessingRef.current = false;
     }
@@ -934,8 +888,17 @@ const LidoPlayer: FC = () => {
 
   const onGameExit = async (e: any) => {
     const data = (e.detail ?? {}) as LidoEventDetail;
+    const isCompletedExit =
+      data.gameCompleted === true || data.quizCompleted === true;
 
-    if (isLessonEndProcessingRef.current || showDialogBoxRef.current) {
+    if (isCompletedExit) {
+      if (!showDialogBox && !isLoading) {
+        await onLessonEnd(e);
+      }
+      return;
+    }
+
+    if (isLessonEndProcessingRef.current || showDialogBox) {
       return;
     }
 

--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -872,11 +872,11 @@ const LidoPlayer: FC = () => {
   };
 
   const onGameExit = async (e: any) => {
-    const data = (e.detail ?? {}) as LidoEventDetail;
     if (showDialogBox) {
       return;
     }
 
+    const data = (e.detail ?? {}) as LidoEventDetail;
     const { studentId, userId } = await resolveStudentContext();
     if (!studentId) {
       push();

--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -25,7 +25,7 @@ import Loading from '../components/Loading';
 import ScoreCard from '../components/parent/ScoreCard';
 import { IonPage, useIonToast } from '@ionic/react';
 import { Capacitor } from '@capacitor/core';
-import { ScreenOrientation } from '@capacitor/screen-orientation';
+import { ScreenOrientation } from '../utility/screenOrientation';
 import { ServiceConfig } from '../services/ServiceConfig';
 import { Lesson } from '../interface/curriculumInterfaces';
 import { AvatarObj } from '../components/animation/Avatar';
@@ -830,7 +830,7 @@ const LidoPlayer: FC = () => {
         ml_class_id: data.mlClassId,
         ml_student_id: data.mlStudentId,
         course_id: data.courseId,
-        course_name: courseDetail.name,
+        course_name: courseDetail?.name ?? '',
         time_spent: lessonTimeSpent,
         total_moves: data.totalMoves,
         total_games: data.totalGames,
@@ -863,6 +863,7 @@ const LidoPlayer: FC = () => {
         ASSIGNMENT_COMPLETED_IDS,
         JSON.stringify(assignmentCompletedIds),
       );
+      setIsLoading(false);
       setShowDialogBox(true);
     } catch (error) {
       logger.error('❌ Failed to process lesson end', error);
@@ -880,6 +881,14 @@ const LidoPlayer: FC = () => {
     const courseKey = courseDetail?.id ?? courseDocId ?? '';
     Util.removeCourseScopedKey(FAIL_STREAK_KEY, studentId, courseKey);
     const data = (e.detail ?? {}) as LidoEventDetail;
+    const isCompletedExit =
+      data.gameCompleted === true || data.quizCompleted === true;
+
+    if (isCompletedExit) {
+      await onLessonEnd(e);
+      return;
+    }
+
     const { correctMoves, wrongMoves } = getNormalizedMoveCounts(data);
     const storedScores = getStoredLidoScores();
     const lessonTimeSpent = parseNumericValue(data.timeSpendForLesson) ?? 0;

--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -236,15 +236,7 @@ const LidoPlayer: FC = () => {
     scoresList.reduce((total, record) => total + (record.timeSpent ?? 0), 0);
 
   const onNextContainer = (e: any) => logger.info('Next', e);
-  const gameCompleted = async (e: Event) => {
-    // The bundled Lido player emits `lidoGameCompleted` only when the full
-    // lesson flow is complete, and Digital Skills can send it with an empty
-    // detail payload. Route that event through the normal lesson-end flow.
-    if (!showDialogBox && !isLoading) {
-      await onLessonEnd(e);
-      return;
-    }
-
+  const gameCompleted = () => {
     const popupConfig = growthbook?.getFeatureValue('generic-pop-up', null);
 
     if (popupConfig) {

--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -871,21 +871,26 @@ const LidoPlayer: FC = () => {
       push();
     }
   };
+
   const onGameExit = async (e: any) => {
     const { studentId, userId } = await resolveStudentContext();
     if (!studentId) {
       push();
       return;
     }
+
     const parentUserId = userId;
     const courseKey = courseDetail?.id ?? courseDocId ?? '';
     Util.removeCourseScopedKey(FAIL_STREAK_KEY, studentId, courseKey);
     const data = (e.detail ?? {}) as LidoEventDetail;
+
     const isCompletedExit =
       data.gameCompleted === true || data.quizCompleted === true;
 
     if (isCompletedExit) {
-      await onLessonEnd(e);
+      if (!showDialogBox && !isLoading) {
+        await onLessonEnd(e);
+      }
       return;
     }
 

--- a/src/utility/screenOrientation.ts
+++ b/src/utility/screenOrientation.ts
@@ -1,0 +1,36 @@
+import { ScreenOrientation as CapacitorScreenOrientation } from '@capacitor/screen-orientation';
+import { Capacitor } from '@capacitor/core';
+import logger from './logger';
+
+type OrientationLockType = Parameters<
+  typeof CapacitorScreenOrientation.lock
+>[0];
+
+const isUnavailableError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.toLowerCase().includes('not available');
+};
+
+export const ScreenOrientation = {
+  async lock(options: OrientationLockType): Promise<void> {
+    if (!Capacitor.isNativePlatform()) return;
+
+    try {
+      await CapacitorScreenOrientation.lock(options);
+    } catch (error) {
+      if (isUnavailableError(error)) return;
+      logger.error('ScreenOrientation lock failed', error);
+    }
+  },
+
+  async unlock(): Promise<void> {
+    if (!Capacitor.isNativePlatform()) return;
+
+    try {
+      await CapacitorScreenOrientation.unlock();
+    } catch (error) {
+      if (isUnavailableError(error)) return;
+      logger.error('ScreenOrientation unlock failed', error);
+    }
+  },
+};


### PR DESCRIPTION
## Issue
After completing a lesson in the Learning Pathway, users were being redirected to the Learning Pathway home screen instead of seeing the "Continue Playing" popup.

## Root Cause
Lesson completion events coming through the exit flow were being treated as incomplete exits, causing immediate navigation back to the pathway screen.

## Fix
- Added handling for completed exit events (`gameCompleted` / `quizCompleted`).
- Routed completed exits through `onLessonEnd()`.
- This ensures the normal completion flow is executed and the "Continue Playing" popup is displayed.

## Testing
- Verified the popup appears after lesson completion.
- Verified the project builds successfully.