### PR TITLE
Consolidate PAL-Enabled Subjects in Course Dropdown & Unify Assessment State

### DIFF
--- a/src/components/Home/DropdownMenu.tsx
+++ b/src/components/Home/DropdownMenu.tsx
@@ -17,6 +17,7 @@ interface CourseDetails {
   course: TableTypes<'course'>;
   grade?: TableTypes<'grade'> | null;
   curriculum?: TableTypes<'curriculum'> | null;
+  displayName?: string;
 }
 const ImageUrlCache: Record<string, string> = {};
 
@@ -191,6 +192,7 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
               course,
               grade: gradeDoc,
               curriculum: curriculumDoc,
+              displayName: entry.display_name,
             };
           } catch (error) {
             logger.error(
@@ -309,6 +311,9 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
     const parts = name.split(' ');
     return parts.length > 1 ? parts[1] : name;
   };
+
+  const getDisplayName = (detail: CourseDetails) =>
+    detail.displayName || detail.course.name;
 
   const handleToggleExpand = () => {
     if (hideArrow) return;
@@ -446,7 +451,7 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
                   </div>
                 </div>
                 <div className="dropdownmenu-truncate-style">
-                  {truncateName(detail.course.name)}
+                  {truncateName(getDisplayName(detail))}
                 </div>
               </div>
             ))}
@@ -470,7 +475,7 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
       <div>
         {!expanded && selected && (
           <div className=" dropdownmenu-dropdown-label">
-            {selected.course.name}
+            {getDisplayName(selected)}
           </div>
         )}
       </div>

--- a/src/components/LearningPathway.test.tsx
+++ b/src/components/LearningPathway.test.tsx
@@ -6,6 +6,7 @@ import { Util } from '../utility/util';
 import { schoolUtil } from '../utility/schoolUtil';
 import { useGrowthBook } from '@growthbook/growthbook-react';
 import {
+  consolidatePalEnabledCourses,
   sortCoursesByStudentLanguage,
   useLearningPath,
 } from '../hooks/useLearningPath';
@@ -39,6 +40,7 @@ jest.mock('../hooks/useLearningPath', () => ({
   __esModule: true,
   useLearningPath: jest.fn(),
   sortCoursesByStudentLanguage: jest.fn(),
+  consolidatePalEnabledCourses: jest.fn(),
 }));
 
 const mockApi = {
@@ -86,6 +88,9 @@ describe('LearningPathway', () => {
     });
     (useLearningPath as jest.Mock).mockReturnValue({ getPath });
     (sortCoursesByStudentLanguage as jest.Mock).mockImplementation(
+      async (courses: any[]) => courses,
+    );
+    (consolidatePalEnabledCourses as jest.Mock).mockImplementation(
       async (courses: any[]) => courses,
     );
     mockApi.getUserByDocId.mockResolvedValue({ id: 'stu-1', stars: 8 });

--- a/src/components/LearningPathway.tsx
+++ b/src/components/LearningPathway.tsx
@@ -16,6 +16,7 @@ import {
 } from '../common/constants';
 import { useGrowthBook } from '@growthbook/growthbook-react';
 import {
+  consolidatePalEnabledCourses,
   sortCoursesByStudentLanguage,
   useLearningPath,
 } from '../hooks/useLearningPath';
@@ -110,6 +111,12 @@ const LearningPathway: React.FC = () => {
           courses,
           student,
         );
+        const learningPathMode = localStorage.getItem(CURRENT_PATHWAY_MODE);
+        const mode = learningPathMode ?? LEARNING_PATHWAY_MODE.DISABLED;
+        const pathwayCourses = await consolidatePalEnabledCourses(
+          sortedCourses,
+          mode,
+        );
         const learningPath = student.learning_path
           ? JSON.parse(student.learning_path)
           : null;
@@ -120,11 +127,9 @@ const LearningPathway: React.FC = () => {
                 ?.course_id
             : null;
         await updateCourseCodeFromSubject(selectedCourseId);
-        const learningPathMode = localStorage.getItem(CURRENT_PATHWAY_MODE);
-        const mode = learningPathMode ?? LEARNING_PATHWAY_MODE.DISABLED;
         updateStarCount(student);
         await getPath({
-          courses: sortedCourses,
+          courses: pathwayCourses,
           mode,
           classId: currClass?.id,
         });

--- a/src/hooks/useLearningPath.test.ts
+++ b/src/hooks/useLearningPath.test.ts
@@ -230,6 +230,31 @@ describe('useLearningPath features used by Home tab', () => {
     );
   });
 
+  test('continues assessment sequence in assessment-only mode after prior assessment history', async () => {
+    mockApi.isStudentPlayedPalLesson.mockResolvedValue(true);
+    mockApi.getSubjectLessonsBySubjectId.mockResolvedValue({
+      id: 'asmt-doc-2',
+      lesson_id: 'assessment-lesson-2',
+    });
+
+    const next = await recommendNextLesson({
+      student: { id: 'stu-1' },
+      course: { id: 'c1', subject_id: 's1' },
+      mode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
+    });
+
+    expect(next).toMatchObject({
+      lesson_id: 'assessment-lesson-2',
+      is_assessment: true,
+    });
+    expect(mockApi.getSubjectLessonsBySubjectId).toHaveBeenCalledWith(
+      's1',
+      { id: 'stu-1' },
+      'c1',
+    );
+    expect(palUtil.getPalLessonPathForCourse).not.toHaveBeenCalled();
+  });
+
   test('resumes same teacher-assigned assessment after exit', async () => {
     mockApi.getLatestAssessmentGroup.mockResolvedValue([
       { id: 'assignment-11', lesson_id: 'teacher-asmt-11' },

--- a/src/hooks/useLearningPath.ts
+++ b/src/hooks/useLearningPath.ts
@@ -178,7 +178,9 @@ export async function recommendNextLesson({
   /* -------------------------------
    * 1️⃣ TEACHER ASSIGNED ASSESSMENT
    * ------------------------------- */
-  const rawResults = await api.isStudentPlayedPalLesson(student.id, course.id);
+  const hasCompletedInitialAssessment = shouldUsePAL(mode)
+    ? await api.isStudentPlayedPalLesson(student.id, course.id)
+    : false;
   if (classId) {
     const assessments = await api.getLatestAssessmentGroup(
       classId,
@@ -201,7 +203,7 @@ export async function recommendNextLesson({
   /* ------------------------------------------------------------------------------------------
    * 2️⃣ MODE-BASED ASSESSMENT (assessment only/full adaptive mode with pal lesson not played )
    * ------------------------------------------------------------------------------------------ */
-  if (shouldUseAssessment(mode) && !rawResults) {
+  if (shouldUseAssessment(mode) && !hasCompletedInitialAssessment) {
     const res = await api.getSubjectLessonsBySubjectId(
       course.subject_id,
       student,

--- a/src/hooks/useLearningPath.ts
+++ b/src/hooks/useLearningPath.ts
@@ -29,9 +29,16 @@ export type CoursePath = {
   path_id: string;
   course_id: string;
   subject_id: string;
+  display_name?: string;
+  is_pal_consolidated?: boolean;
   type: RECOMMENDATION_TYPE;
   path: LessonNode[]; // played + ONE active
   completedPath: number;
+};
+
+export type LearningPathCourse = TableTypes<'course'> & {
+  pathway_display_name?: string;
+  is_pal_consolidated?: boolean;
 };
 
 export type LessonNode = {
@@ -50,6 +57,54 @@ export const shouldUseAssessment = (mode: string) =>
 
 export const shouldUsePAL = (mode: string) =>
   mode === LEARNING_PATHWAY_MODE.FULL_ADAPTIVE;
+
+export const isPalEnabledCourse = (course?: TableTypes<'course'> | null) =>
+  !!course?.subject_id && !!course?.framework_id;
+
+export const consolidatePalEnabledCourses = async (
+  courses: TableTypes<'course'>[],
+  mode: string,
+): Promise<LearningPathCourse[]> => {
+  if (mode !== LEARNING_PATHWAY_MODE.FULL_ADAPTIVE) return courses;
+
+  const api = ServiceConfig.getI().apiHandler;
+  const palSubjectsAdded = new Set<string>();
+  const subjectNameById = new Map<string, string>();
+  const consolidatedCourses: LearningPathCourse[] = [];
+
+  for (const course of courses) {
+    const subjectId = course.subject_id;
+
+    if (!subjectId || !isPalEnabledCourse(course)) {
+      consolidatedCourses.push(course);
+      continue;
+    }
+
+    if (palSubjectsAdded.has(subjectId)) continue;
+
+    palSubjectsAdded.add(subjectId);
+
+    let displayName = subjectNameById.get(subjectId);
+    if (!displayName) {
+      try {
+        const subject = await api.getSubject(subjectId);
+        displayName = subject?.name?.trim() || course.name;
+      } catch (e) {
+        logger.error('Error resolving PAL subject display name', e);
+        displayName = course.name;
+      }
+      subjectNameById.set(subjectId, displayName);
+    }
+
+    consolidatedCourses.push({
+      ...course,
+      pathway_display_name: displayName,
+      is_pal_consolidated: true,
+    });
+  }
+
+  return consolidatedCourses;
+};
 
 export async function buildPath({
   student,
@@ -77,6 +132,8 @@ export async function buildPath({
         path_id: uuidv4(),
         course_id: course.id,
         subject_id: course.subject_id,
+        display_name: course.pathway_display_name,
+        is_pal_consolidated: course.is_pal_consolidated,
         type: course.framework_id
           ? RECOMMENDATION_TYPE.FRAMEWORK
           : RECOMMENDATION_TYPE.CHAPTER,
@@ -672,7 +729,18 @@ export const useLearningPath = (opts?: {
     const sameOrder =
       sameCourses && newIds.every((id, idx) => id === oldIds[idx]);
 
-    if (sameOrder) {
+    const sameMetadata =
+      sameOrder &&
+      userCourses.every((course, idx) => {
+        const oldCourse = oldCourseList[idx];
+        return (
+          (oldCourse?.display_name ?? undefined) ===
+            (course.pathway_display_name ?? undefined) &&
+          !!oldCourse?.is_pal_consolidated === !!course.is_pal_consolidated
+        );
+      });
+
+    if (sameOrder && sameMetadata) {
       return { updated: false, learningPath };
     }
 
@@ -688,7 +756,11 @@ export const useLearningPath = (opts?: {
 
       if (existing) {
         // ✅ Preserve entire course state
-        newCourseList.push(existing);
+        newCourseList.push({
+          ...existing,
+          display_name: course.pathway_display_name,
+          is_pal_consolidated: course.is_pal_consolidated,
+        });
       } else {
         // ➕ New course → build fresh
         const activeLesson = await recommendNextLesson({
@@ -702,10 +774,13 @@ export const useLearningPath = (opts?: {
           path_id: uuidv4(),
           course_id: course.id,
           subject_id: course.subject_id,
+          display_name: course.pathway_display_name,
+          is_pal_consolidated: course.is_pal_consolidated,
           type: course.framework_id
             ? RECOMMENDATION_TYPE.FRAMEWORK
             : RECOMMENDATION_TYPE.CHAPTER,
           path: activeLesson ? [activeLesson] : [],
+          completedPath: 0,
           lastPlayedLesson: undefined,
         });
       }
@@ -776,6 +851,8 @@ export const useLearningPath = (opts?: {
       path_id: coursePath.path_id,
       course_id: coursePath.course_id,
       subject_id: coursePath.subject_id,
+      display_name: coursePath.display_name,
+      is_pal_consolidated: coursePath.is_pal_consolidated,
       type: coursePath.type,
       path: newPath,
       completedPath: completedPath,

--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -113,6 +113,13 @@ const LidoPlayer: FC = () => {
   });
   const isExitingRef = useRef(false);
 
+  const getAssessmentProgressKey = () => {
+    if (isAssessmentLesson && courseDetail?.subject_id) {
+      return `subject:${courseDetail.subject_id}`;
+    }
+    return courseDetail?.id ?? courseDocId ?? '';
+  };
+
   const resolveStudentContext = async (): Promise<{
     student: TableTypes<'user'> | undefined;
     studentId: string | undefined;
@@ -535,7 +542,7 @@ const LidoPlayer: FC = () => {
       }
     }
     if (!isAssessmentLesson) return;
-    const courseKey = courseDetail?.id ?? courseDocId ?? '';
+    const courseKey = getAssessmentProgressKey();
     const failKey = `${ASSESSMENT_FAIL_KEY}_${studentId}`;
     const streakKey = `${FAIL_STREAK_KEY}_${studentId}`;
     const failMap: Record<string, boolean> = JSON.parse(
@@ -558,7 +565,7 @@ const LidoPlayer: FC = () => {
       !!failMap[courseKey] ||
       (await resolvePreviousAssessmentSkipped(studentId));
     if (previousLessonSkipped && failStreak >= 2) {
-      const courseKey = courseDetail?.id ?? courseDocId ?? '';
+      const courseKey = getAssessmentProgressKey();
       Util.removeCourseScopedKey(FAIL_STREAK_KEY, studentId, courseKey);
       Util.removeCourseScopedKey(ASSESSMENT_FAIL_KEY, studentId, courseKey);
       const isAborted = true;
@@ -610,7 +617,7 @@ const LidoPlayer: FC = () => {
       const lessonData = (e.detail ?? {}) as LidoEventDetail;
       const { correctMoves, wrongMoves } = getNormalizedMoveCounts(lessonData);
       if (isAssessmentLesson) {
-        const courseKey = courseDetail?.id ?? courseDocId ?? '';
+        const courseKey = getAssessmentProgressKey();
         Util.removeCourseScopedKey(FAIL_STREAK_KEY, studentId, courseKey);
         Util.removeCourseScopedKey(ASSESSMENT_FAIL_KEY, studentId, courseKey);
         await exitLidoGame();
@@ -910,7 +917,7 @@ const LidoPlayer: FC = () => {
       return;
     }
     const parentUserId = userId;
-    const courseKey = courseDetail?.id ?? courseDocId ?? '';
+    const courseKey = getAssessmentProgressKey();
     Util.removeCourseScopedKey(FAIL_STREAK_KEY, studentId, courseKey);
     const data = (e.detail ?? {}) as LidoEventDetail;
     const { correctMoves, wrongMoves } = getNormalizedMoveCounts(data);

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -9333,11 +9333,14 @@ order by
       const lastTwo = ((abortRes as DBSQLiteValues | undefined)?.values ??
         []) as ResultStatusRow[];
 
+      const isAssessmentTerminated = lastTwo.some(
+        (r) => r.status === 'assessment_terminated',
+      );
       const isAborted =
         lastTwo.length === 2 &&
         lastTwo.every((r) => r.status === 'system_exit');
 
-      if (isAborted) {
+      if (isAssessmentTerminated || isAborted) {
         return {} as TableTypes<'subject_lesson'>; // 🚫 Aborted group
       }
 
@@ -9469,6 +9472,7 @@ order by
     try {
       const course = await this.getCourse(courseId);
       if (!course?.subject_id) return false;
+      const subjectId = course.subject_id;
 
       const assessmentLessonsQuery = `
         SELECT DISTINCT lesson_id
@@ -9479,7 +9483,7 @@ order by
       `;
       const assessmentLessonsRes = await this.executeQuery(
         assessmentLessonsQuery,
-        [course.subject_id],
+        [subjectId],
       );
       const assessmentLessonIds = Array.from(
         new Set(
@@ -9494,7 +9498,7 @@ order by
         ),
       );
 
-      const params: string[] = [studentId, course.subject_id];
+      const params: string[] = [studentId, subjectId];
       const assessmentLessonFilter = assessmentLessonIds.length
         ? `OR lesson_id IN (${assessmentLessonIds.map(() => '?').join(',')})`
         : '';

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -9308,7 +9308,6 @@ order by
       /* ==========================================
        * 3️⃣ Abort Check (with assignment_id IS NULL)
        * ========================================== */
-      const courseFilter = courseId ? ' AND course_id = ?' : '';
       const abortQuery = `
         SELECT lesson_id, status
         FROM (
@@ -9320,7 +9319,6 @@ order by
             FROM result
             WHERE student_id = ?
               AND subject_id = ?
-              ${courseFilter}
               AND assignment_id IS NULL
               AND is_deleted = 0
         ) t
@@ -9330,9 +9328,6 @@ order by
       `;
 
       const abortParams: (string | null)[] = [studentId, subjectId];
-      if (courseId) {
-        abortParams.push(courseId);
-      }
       const abortRes = await this.executeQuery(abortQuery, abortParams);
 
       const lastTwo = ((abortRes as DBSQLiteValues | undefined)?.values ??
@@ -9437,15 +9432,11 @@ order by
         FROM result
         WHERE student_id = ?
           AND subject_id = ?
-          ${courseFilter}
           AND assignment_id IS NULL
           AND is_deleted = 0
           AND lesson_id IN (${resultPlaceholders});
       `;
       const resultParams: (string | null)[] = [studentId, subjectId];
-      if (courseId) {
-        resultParams.push(courseId);
-      }
       resultParams.push(...lessonIds);
       const resultRes = await this.executeQuery(resultQuery, resultParams);
       const completedLessons = ((resultRes as DBSQLiteValues | undefined)
@@ -9503,7 +9494,7 @@ order by
         ),
       );
 
-      const params: string[] = [studentId, courseId];
+      const params: string[] = [studentId, course.subject_id];
       const assessmentLessonFilter = assessmentLessonIds.length
         ? `OR lesson_id IN (${assessmentLessonIds.map(() => '?').join(',')})`
         : '';
@@ -9513,7 +9504,7 @@ order by
         SELECT lesson_id, status
         FROM result
         WHERE student_id = ?
-          AND course_id = ?
+          AND subject_id = ?
           AND COALESCE(is_deleted, 0) = 0
           AND (status = 'assessment_terminated' ${assessmentLessonFilter});
       `;
@@ -9601,14 +9592,13 @@ order by
           SELECT status
           FROM result
           WHERE student_id = ?
-            AND course_id = ?
             AND assignment_id IS NULL
             AND COALESCE(is_deleted, 0) = 0
             AND lesson_id IN (${placeholders})
           ORDER BY created_at DESC
           LIMIT 1
         `,
-        [studentId, courseId, ...assessmentLessonIds],
+        [studentId, ...assessmentLessonIds],
       );
 
       const latestStatus = ((pendingAbortRes as DBSQLiteValues | undefined)

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -14306,7 +14306,7 @@ export class SupabaseApi implements ServiceApi {
       /* ==========================================
        * 2️⃣ Abort Check (assignment_id IS NULL)
        * ========================================== */
-      let abortQuery = this.supabase
+      const abortQuery = this.supabase
         .from('result')
         .select('lesson_id, status, created_at')
         .eq('student_id', studentId)
@@ -14315,10 +14315,6 @@ export class SupabaseApi implements ServiceApi {
         .eq('is_deleted', false)
         .order('created_at', { ascending: false })
         .limit(50);
-
-      if (courseId) {
-        abortQuery = abortQuery.eq('course_id', courseId);
-      }
 
       const { data, error } = await abortQuery;
 
@@ -14447,17 +14443,13 @@ export class SupabaseApi implements ServiceApi {
        * ========================================== */
       const lessonIds = candidateLessons.map((lesson) => lesson.lesson_id);
 
-      let resultsQuery = this.supabase
+      const resultsQuery = this.supabase
         .from('result')
         .select('lesson_id')
         .in('lesson_id', lessonIds)
         .eq('student_id', studentId)
         .is('assignment_id', null)
         .eq('is_deleted', false);
-
-      if (courseId) {
-        resultsQuery = resultsQuery.eq('course_id', courseId);
-      }
 
       const { data: results } = await resultsQuery;
 
@@ -14539,7 +14531,7 @@ export class SupabaseApi implements ServiceApi {
         .from('result')
         .select('lesson_id, status')
         .eq('student_id', studentId)
-        .eq('course_id', courseId)
+        .eq('subject_id', course.subject_id)
         .or('is_deleted.eq.false,is_deleted.is.null');
 
       if (assessmentLessonIds.length) {
@@ -14642,7 +14634,6 @@ export class SupabaseApi implements ServiceApi {
         .from('result')
         .select('status')
         .eq('student_id', studentId)
-        .eq('course_id', courseId)
         .is('assignment_id', null)
         .in('lesson_id', assessmentLessonIds)
         .or('is_deleted.eq.false,is_deleted.is.null')

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -14347,11 +14347,14 @@ export class SupabaseApi implements ServiceApi {
       /* -----------------------------------------
         Abort check
       ------------------------------------------ */
+      const isAssessmentTerminated = (data as ResultStatusRow[]).some(
+        (r) => r.status === 'assessment_terminated',
+      );
       const isAborted =
         lastTwoUniqueLessons.length === 2 &&
         lastTwoUniqueLessons.every((r) => r.status === 'system_exit');
 
-      if (isAborted) {
+      if (isAssessmentTerminated || isAborted) {
         return {} as TableTypes<'subject_lesson'>; // 🚫 Aborted group
       }
 
@@ -14503,12 +14506,13 @@ export class SupabaseApi implements ServiceApi {
 
       const course = await this.getCourse(courseId);
       if (!course?.subject_id) return false;
+      const subjectId = course.subject_id;
 
       const { data: assessmentLessons, error: assessmentLessonsError } =
         await this.supabase
           .from('subject_lesson')
           .select('lesson_id')
-          .eq('subject_id', course.subject_id)
+          .eq('subject_id', subjectId)
           .or('is_deleted.eq.false,is_deleted.is.null');
 
       if (assessmentLessonsError) {
@@ -14531,7 +14535,7 @@ export class SupabaseApi implements ServiceApi {
         .from('result')
         .select('lesson_id, status')
         .eq('student_id', studentId)
-        .eq('subject_id', course.subject_id)
+        .eq('subject_id', subjectId)
         .or('is_deleted.eq.false,is_deleted.is.null');
 
       if (assessmentLessonIds.length) {

--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -102,7 +102,11 @@ import { ASSIGNMENT_COMPLETED_IDS } from '../common/courseConstants';
 import { buildGlobalEventBaseContext } from '../common/eventBaseContext';
 import { v4 as uuidv4 } from 'uuid';
 import { updateLocalAttributes } from '../growthbook/Growthbook';
-import { recommendNextLesson } from '../hooks/useLearningPath';
+import {
+  CoursePath,
+  LessonNode,
+  recommendNextLesson,
+} from '../hooks/useLearningPath';
 import { runBackgroundWorkerTask } from '../workers/backgroundWorkerClient';
 import { store } from '../redux/store';
 import {
@@ -2828,13 +2832,16 @@ export class Util {
     // ABORT CASE: refresh current lesson with PAL recommendation only
     // ABORT CASE: Assessment aborted → rebuild learning path (legacy flow)
     if (isFullPathwayTerminated && abortCourseId && isAssessmentLesson) {
-      let courseIndex = learningPath.courses.courseList.findIndex(
-        (c: any) => c.course_id === abortCourseId,
+      const courses = learningPath.courses as {
+        courseList: CoursePath[];
+        currentCourseIndex: number;
+      };
+      let courseIndex = courses.courseList.findIndex(
+        (coursePath: CoursePath) => coursePath.course_id === abortCourseId,
       );
 
       if (courseIndex === -1) return;
 
-      const courses = learningPath.courses;
       let course = courses.courseList[courseIndex];
       course.path.length = 0;
       const nextLesson = await recommendNextLesson({
@@ -2852,6 +2859,40 @@ export class Util {
       if (nextLesson) {
         course.path.push(nextLesson);
       }
+
+      if (
+        storedPathwayMode === LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY &&
+        course.subject_id
+      ) {
+        for (const peerCourse of courses.courseList) {
+          if (
+            peerCourse === course ||
+            peerCourse.subject_id !== course.subject_id
+          ) {
+            continue;
+          }
+
+          peerCourse.path.length = 0;
+          const peerNextLesson = await recommendNextLesson({
+            student: currentStudent,
+            course: {
+              id: peerCourse.course_id,
+              subject_id: peerCourse.subject_id,
+              framework_id:
+                peerCourse.type === RECOMMENDATION_TYPE.FRAMEWORK
+                  ? 'framework'
+                  : null,
+            },
+            mode: storedPathwayMode,
+            coursePath: peerCourse,
+          });
+
+          if (peerNextLesson) {
+            peerCourse.path.push(peerNextLesson);
+          }
+        }
+      }
+
       courseIndex += 1;
       if (courseIndex >= courses.courseList.length) {
         courseIndex = 0;
@@ -2878,14 +2919,17 @@ export class Util {
       const PATH_SIZE = 5;
       const api = ServiceConfig.getI().apiHandler;
 
-      const courses = learningPath.courses;
+      const courses = learningPath.courses as {
+        courseList: CoursePath[];
+        currentCourseIndex: number;
+      };
       let courseIndex = courses.currentCourseIndex;
       let course = courses.courseList[courseIndex];
       if (!course) return;
 
       /* 1️⃣ Identify active lesson */
       const activeLessonIndex = course.path.findIndex(
-        (l: any) => l.isPlayed === false,
+        (lesson: LessonNode) => lesson.isPlayed === false,
       );
       const activeLesson =
         activeLessonIndex !== -1 ? course.path[activeLessonIndex] : null;
@@ -2915,6 +2959,56 @@ export class Util {
         isPlayed: true,
       };
 
+      const syncSameSubjectAssessmentPaths = (
+        nextAssessmentLesson: LessonNode | null,
+      ) => {
+        if (
+          storedPathwayMode !== LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY ||
+          !activeLesson.is_assessment ||
+          !course.subject_id
+        ) {
+          return;
+        }
+
+        for (const peerCourse of courses.courseList) {
+          if (
+            peerCourse === course ||
+            peerCourse.subject_id !== course.subject_id
+          ) {
+            continue;
+          }
+
+          const peerActiveLessonIndex = peerCourse.path.findIndex(
+            (lesson: LessonNode) =>
+              lesson.isPlayed === false &&
+              lesson.is_assessment === true &&
+              lesson.lesson_id === activeLesson.lesson_id,
+          );
+
+          if (peerActiveLessonIndex === -1) continue;
+
+          const peerActiveLesson = peerCourse.path[peerActiveLessonIndex];
+          peerCourse.path[peerActiveLessonIndex] = {
+            ...peerActiveLesson,
+            isPlayed: true,
+          };
+
+          if (nextAssessmentLesson) {
+            peerCourse.path.push({ ...nextAssessmentLesson });
+          }
+
+          if (peerCourse.path.length > PATH_SIZE) {
+            const peerActive = peerCourse.path.find(
+              (lesson: LessonNode) => !lesson.isPlayed,
+            );
+            peerCourse.path.length = 0;
+            if (peerActive) peerCourse.path.push(peerActive);
+            peerCourse.path_id = uuidv4();
+            peerCourse.completedPath = (peerCourse.completedPath ?? 0) + 1;
+          }
+        }
+      };
+
       const completedPathwaySnapshot = JSON.stringify(learningPath);
 
       /* 3️⃣ Compute next active lesson */
@@ -2935,13 +3029,17 @@ export class Util {
       }
 
       /* 4️⃣ Check path overflow */
+      syncSameSubjectAssessmentPaths(nextLesson);
+
       let pathCompleted = false;
 
       if (course.path.length > PATH_SIZE) {
         // if exceeding max path size i.e '5', remove played lessons from old path keep active lesson from currentPath
-        const active = course.path.find((l: any) => !l.isPlayed);
+        const active = course.path.find(
+          (lesson: LessonNode) => !lesson.isPlayed,
+        );
         course.path.length = 0;
-        course.path.push(active);
+        if (active) course.path.push(active);
         pathCompleted = true;
       }
 
@@ -2987,7 +3085,7 @@ export class Util {
       /* 6️⃣ Event collection */
       const newCourse = courses.courseList[courses.currentCourseIndex];
       const newActiveLesson = newCourse.path.find(
-        (l: any) => l.isPlayed === false,
+        (lesson: LessonNode) => lesson.isPlayed === false,
       );
 
       const eventPayload = {

--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -2964,6 +2964,7 @@ export class Util {
       ) => {
         if (
           storedPathwayMode !== LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY ||
+          !activeLesson ||
           !activeLesson.is_assessment ||
           !course.subject_id
         ) {


### PR DESCRIPTION
- Add PAL consolidation and subject-scoped assessment handling across the learning path and playback stack.
- Introduces consolidatePalEnabledCourses and LearningPathCourse fields (pathway_display_name, is_pal_consolidated) and threads display_name/is_pal_consolidated into path construction and metadata checks to avoid unnecessary rebuilds. 
- Update DropdownMenu to show consolidated display names. 
- LidoPlayer now computes assessment progress keys by subject for assessment lessons to deduplicate progress across same-subject courses. 
- Adjusted SQLite and Supabase result/abort queries to use subject_id (removed course_id filters) and updated util logic to sync assessment-only pathways and next-lesson recommendations across courses sharing a subject.