### PR TITLE
Use GrowthBook for bundle ZIP URLs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,7 @@ import { App as CapApp } from '@capacitor/app';
 import {
   // APP_LANG,
   BASE_NAME,
+  BUNDLE_ZIP_URLS,
   CACHE_IMAGE,
   HOMEWORK_REMOTE_ASSETS_ENABLED,
   CAN_ACCESS_REMOTE_ASSETS,
@@ -70,6 +71,7 @@ import {
   SEARCH_LESSON_CACHE_KEY,
   SEARCH_LESSON_HISTORY,
   PAL_LEARNING_RATES_CONFIG,
+  LIDO_BUNDLE_ZIP_URLS,
 } from './common/constants';
 import { Util } from './utility/util';
 import Parent from './pages/Parent';
@@ -144,6 +146,10 @@ import { setCachedGrowthBookFeatureValue } from './growthbook/Growthbook';
 import { HardwareBackButtonHandler } from './common/backButtonRegistry';
 import { logger } from './utility/logger';
 import {
+  getBundleZipUrlsForEnv,
+  getLidoBundleZipUrlsForEnv,
+} from './services/RemoteConfig';
+import {
   Dialog,
   DialogTitle,
   DialogContent,
@@ -202,6 +208,8 @@ const App: React.FC = () => {
 
   const popupDataRef = useRef<any>(null);
   const showModalRef = useRef(showModal);
+  const bundleZipUrlsFallbackRef = useRef(getBundleZipUrlsForEnv());
+  const lidoBundleZipUrlsFallbackRef = useRef(getLidoBundleZipUrlsForEnv());
 
   useEffect(() => {
     popupDataRef.current = popupData;
@@ -219,6 +227,14 @@ const App: React.FC = () => {
   const palLearningRatesConfig = useFeatureValue<GrowthBookJsonConfig>(
     PAL_LEARNING_RATES_CONFIG,
     {},
+  );
+  const bundleZipUrls = useFeatureValue<string[]>(
+    BUNDLE_ZIP_URLS,
+    bundleZipUrlsFallbackRef.current,
+  );
+  const lidoBundleZipUrls = useFeatureValue<string[]>(
+    LIDO_BUNDLE_ZIP_URLS,
+    lidoBundleZipUrlsFallbackRef.current,
   );
 
   const OpsConsoleRouteWatcher = () => {
@@ -269,6 +285,34 @@ const App: React.FC = () => {
       );
     }
   }, [palLearningRatesConfig]);
+
+  useEffect(() => {
+    const bundleZipUrlsResult =
+      growthbook.evalFeature<string[]>(BUNDLE_ZIP_URLS);
+    const lidoBundleZipUrlsResult =
+      growthbook.evalFeature<string[]>(LIDO_BUNDLE_ZIP_URLS);
+
+    logger.info('[GrowthBook] bundle ZIP URLs evaluated', {
+      featureKey: BUNDLE_ZIP_URLS,
+      growthBookSource: bundleZipUrlsResult.source,
+      growthBookValue: bundleZipUrlsResult.value,
+      fallbackValue: bundleZipUrlsFallbackRef.current,
+      resolvedValue: bundleZipUrls,
+      usingGrowthBookValue: bundleZipUrlsResult.value !== null,
+    });
+
+    logger.info('[GrowthBook] Lido bundle ZIP URLs evaluated', {
+      featureKey: LIDO_BUNDLE_ZIP_URLS,
+      growthBookSource: lidoBundleZipUrlsResult.source,
+      growthBookValue: lidoBundleZipUrlsResult.value,
+      fallbackValue: lidoBundleZipUrlsFallbackRef.current,
+      resolvedValue: lidoBundleZipUrls,
+      usingGrowthBookValue: lidoBundleZipUrlsResult.value !== null,
+    });
+
+    setCachedGrowthBookFeatureValue(BUNDLE_ZIP_URLS, bundleZipUrls);
+    setCachedGrowthBookFeatureValue(LIDO_BUNDLE_ZIP_URLS, lidoBundleZipUrls);
+  }, [growthbook, bundleZipUrls, lidoBundleZipUrls]);
 
   useEffect(() => {
     if (!growthbook) return;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -175,6 +175,10 @@ interface WindowEventMap {
   shouldShowModal: CustomEvent<boolean>;
 }
 type GrowthBookJsonConfig = Record<string, unknown>;
+type GrowthBookFeatureDebugResult<T> = {
+  value: T | null;
+  source: string;
+};
 
 const TIME_LIMIT = 1500; // 25 * 60
 const LAST_MODAL_SHOWN_KEY = 'lastTimeExceededShown';
@@ -287,12 +291,38 @@ const App: React.FC = () => {
   }, [palLearningRatesConfig]);
 
   useEffect(() => {
-    const bundleZipUrlsResult =
-      growthbook.evalFeature<string[]>(BUNDLE_ZIP_URLS);
-    const lidoBundleZipUrlsResult =
-      growthbook.evalFeature<string[]>(LIDO_BUNDLE_ZIP_URLS);
+    if (!growthbook) return;
+    const getFeatureDebugResult = <T,>(
+      featureKey: string,
+      resolvedValue: T,
+      fallbackValue: T,
+    ): GrowthBookFeatureDebugResult<T> => {
+      if (typeof growthbook?.evalFeature === 'function') {
+        const result = growthbook.evalFeature<T>(featureKey);
+        return {
+          value: result?.value ?? null,
+          source: result?.source ?? 'unknown',
+        };
+      }
 
-    logger.info('[GrowthBook] bundle ZIP URLs evaluated', {
+      return {
+        value: resolvedValue,
+        source: resolvedValue === fallbackValue ? 'fallback-or-mock' : 'mocked',
+      };
+    };
+
+    const bundleZipUrlsResult = getFeatureDebugResult(
+      BUNDLE_ZIP_URLS,
+      bundleZipUrls,
+      bundleZipUrlsFallbackRef.current,
+    );
+    const lidoBundleZipUrlsResult = getFeatureDebugResult(
+      LIDO_BUNDLE_ZIP_URLS,
+      lidoBundleZipUrls,
+      lidoBundleZipUrlsFallbackRef.current,
+    );
+
+    logger.warn('[GrowthBook] bundle ZIP URLs evaluated', {
       featureKey: BUNDLE_ZIP_URLS,
       growthBookSource: bundleZipUrlsResult.source,
       growthBookValue: bundleZipUrlsResult.value,
@@ -301,7 +331,7 @@ const App: React.FC = () => {
       usingGrowthBookValue: bundleZipUrlsResult.value !== null,
     });
 
-    logger.info('[GrowthBook] Lido bundle ZIP URLs evaluated', {
+    logger.warn('[GrowthBook] Lido bundle ZIP URLs evaluated', {
       featureKey: LIDO_BUNDLE_ZIP_URLS,
       growthBookSource: lidoBundleZipUrlsResult.source,
       growthBookValue: lidoBundleZipUrlsResult.value,

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1213,7 +1213,8 @@ export const GRADE1_KANNADA = 'a90608de-4376-4baf-82c2-07760b2aa899';
 export const GRADE1_MARATHI = '2cada0d1-db3d-4da0-8ade-e9ba282a3558';
 export const BULK_UPLOAD_TEMPLATE_URL =
   'https://aeakbcdznktpsbrfsgys.supabase.co/storage/v1/object/public/common-files//Bulk%20School%20&%20Students%20Upload%20Template.xlsx';
-
+export const BUNDLE_ZIP_URLS = 'bundle_zip_urls';
+export const LIDO_BUNDLE_ZIP_URLS = 'lido_bundle_zip_urls';
 export const FORM_MODES = {
   ALL_REQUIRED: 'all-required',
   NAME_REQUIRED: 'name-required',

--- a/src/components/liveQuiz/LiveQuizQuestion.tsx
+++ b/src/components/liveQuiz/LiveQuizQuestion.tsx
@@ -10,6 +10,7 @@ import './LiveQuizQuestion.css';
 import { Capacitor } from '@capacitor/core';
 import { Util } from '../../utility/util';
 import {
+  BUNDLE_ZIP_URLS,
   PAGES,
   SOURCE,
   REWARD_LESSON,
@@ -22,6 +23,7 @@ import { TextToSpeech } from '@capacitor-community/text-to-speech';
 import LiveQuizNavigationDots from './LiveQuizNavigationDots';
 import { schoolUtil } from '../../utility/schoolUtil';
 import logger from '../../utility/logger';
+import { getCachedGrowthBookFeatureValue } from '../../growthbook/Growthbook';
 import { getBundleZipUrlsForEnv } from '../../services/RemoteConfig';
 
 let questionInterval: ReturnType<typeof setInterval> | undefined;
@@ -351,7 +353,10 @@ const LiveQuizQuestion: FC<{
     /* =====================
      REMOTE FETCH (UNCHANGED)
      ===================== */
-    const remoteUrls = getBundleZipUrlsForEnv();
+    const remoteUrls = getCachedGrowthBookFeatureValue<string[]>(
+      BUNDLE_ZIP_URLS,
+      getBundleZipUrlsForEnv(),
+    );
 
     for (const baseUrl of remoteUrls) {
       try {

--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -3,6 +3,8 @@ import { useHistory } from 'react-router';
 import { Util } from '../utility/util';
 import {
   ASSESSMENT_FAIL_KEY,
+  BUNDLE_ZIP_URLS,
+  LIDO_BUNDLE_ZIP_URLS,
   EVENTS,
   HOMEWORK_PATHWAY,
   LIDO_SCORES_KEY,
@@ -38,7 +40,12 @@ import PopupManager from '../components/GenericPopUp/GenericPopUpManager';
 import { useGrowthBook } from '@growthbook/growthbook-react';
 import { registerBackButtonHandler } from '../common/backButtonRegistry';
 import logger from '../utility/logger';
-import { getBundleZipUrlsForEnv } from '../services/RemoteConfig';
+import { getCachedGrowthBookFeatureValue } from '../growthbook/Growthbook';
+import {
+  getBundleZipUrlsForEnv,
+  getLidoBundleZipUrlsForEnv,
+  REMOTE_CONFIG_KEYS,
+} from '../services/RemoteConfig';
 
 const HOMEWORK_REWARD_COMPLETED_INDEX_KEY = 'homework_reward_completed_index';
 const PENDING_HOMEWORK_REWARD_TRANSITION_KEY =
@@ -1041,7 +1048,11 @@ const LidoPlayer: FC = () => {
       push();
       return;
     }
-    const dow = await Util.downloadZipBundle([lessonToDownload]);
+    const dow = await Util.downloadZipBundle(
+      [lessonToDownload],
+      undefined,
+      REMOTE_CONFIG_KEYS.LIDO_BUNDLE_ZIP_URLS,
+    );
     if (!dow) {
       presentToast();
       push();
@@ -1101,13 +1112,17 @@ const LidoPlayer: FC = () => {
       // const pathXml = `${lidoBaseUrl}${lessonId}/index.xml`;
       // setBasePath(pathBase);
       // setXmlPath(pathXml);
-      const [bundleBaseUrl] = getBundleZipUrlsForEnv();
+      const [bundleBaseUrl] = getCachedGrowthBookFeatureValue<string[]>(
+        BUNDLE_ZIP_URLS,
+        getBundleZipUrlsForEnv(),
+      );
       const directZipUrl =
         urlSearchParams.get('zipUrl') ??
         state?.zipUrl ??
         `${bundleBaseUrl}${lessonId}.zip`;
       logger.debug('Resolved Lido ZIP URL', {
         lessonId,
+        featureKey: BUNDLE_ZIP_URLS,
         bundleBaseUrl,
         zipUrl: directZipUrl,
       });

--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -149,6 +149,15 @@ const getBundleZipUrlsFallback = (
     ? getLidoBundleZipUrlsForEnv()
     : getBundleZipUrlsForEnv();
 
+const mergeBundleZipUrls = (...zipUrlLists: (string[] | null | undefined)[]) =>
+  Array.from(
+    new Set(
+      zipUrlLists.flatMap((zipUrls) =>
+        Array.isArray(zipUrls) ? zipUrls.filter(Boolean) : [],
+      ),
+    ),
+  );
+
 const getLessonBundlePlugin = (): LessonBundlePlugin | null => {
   if (lessonBundlePluginInstance) {
     return lessonBundlePluginInstance;
@@ -561,14 +570,34 @@ export class Util {
               const cachedBundleZipUrls = getCachedGrowthBookFeatureValue<
                 string[] | null
               >(bundleZipUrlsKey, null);
+              const fallbackGeneralBundleZipUrls =
+                bundleZipUrlsKey === REMOTE_CONFIG_KEYS.LIDO_BUNDLE_ZIP_URLS
+                  ? getBundleZipUrlsForEnv()
+                  : [];
+              const cachedGeneralBundleZipUrls =
+                bundleZipUrlsKey === REMOTE_CONFIG_KEYS.LIDO_BUNDLE_ZIP_URLS
+                  ? getCachedGrowthBookFeatureValue<string[] | null>(
+                      REMOTE_CONFIG_KEYS.BUNDLE_ZIP_URLS,
+                      null,
+                    )
+                  : null;
               const bundleZipUrls =
-                cachedBundleZipUrls ?? fallbackBundleZipUrls;
+                bundleZipUrlsKey === REMOTE_CONFIG_KEYS.LIDO_BUNDLE_ZIP_URLS
+                  ? mergeBundleZipUrls(
+                      cachedBundleZipUrls,
+                      fallbackBundleZipUrls,
+                      cachedGeneralBundleZipUrls,
+                      fallbackGeneralBundleZipUrls,
+                    )
+                  : (cachedBundleZipUrls ?? fallbackBundleZipUrls);
 
               logger.warn('[LessonDownloader] Resolved bundle ZIP URLs', {
                 lessonId,
                 bundleZipUrlsKey,
                 cachedBundleZipUrls,
                 fallbackBundleZipUrls,
+                cachedGeneralBundleZipUrls,
+                fallbackGeneralBundleZipUrls,
                 resolvedBundleZipUrls: bundleZipUrls,
                 usedCachedBundleZipUrls: cachedBundleZipUrls !== null,
               });

--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -90,7 +90,11 @@ import {
 } from '@capawesome/capacitor-app-update';
 import { LocalNotifications } from '@capacitor/local-notifications';
 import { getFunctions, httpsCallable } from 'firebase/functions';
-import { REMOTE_CONFIG_KEYS, RemoteConfig } from '../services/RemoteConfig';
+import {
+  getBundleZipUrlsForEnv,
+  getLidoBundleZipUrlsForEnv,
+  REMOTE_CONFIG_KEYS,
+} from '../services/RemoteConfig';
 import { schoolUtil } from './schoolUtil';
 import { TextToSpeech } from '@capacitor-community/text-to-speech';
 import { URLOpenListenerEvent } from '@capacitor/app';
@@ -101,6 +105,7 @@ import { InAppReview } from '@capacitor-community/in-app-review';
 import { ASSIGNMENT_COMPLETED_IDS } from '../common/courseConstants';
 import { buildGlobalEventBaseContext } from '../common/eventBaseContext';
 import { v4 as uuidv4 } from 'uuid';
+import { getCachedGrowthBookFeatureValue } from '../growthbook/Growthbook';
 import { updateLocalAttributes } from '../growthbook/Growthbook';
 import {
   CoursePath,
@@ -136,6 +141,13 @@ type LessonBundlePlugin = {
 };
 
 let lessonBundlePluginInstance: LessonBundlePlugin | null = null;
+
+const getBundleZipUrlsFallback = (
+  bundleZipUrlsKey: REMOTE_CONFIG_KEYS,
+): string[] =>
+  bundleZipUrlsKey === REMOTE_CONFIG_KEYS.LIDO_BUNDLE_ZIP_URLS
+    ? getLidoBundleZipUrlsForEnv()
+    : getBundleZipUrlsForEnv();
 
 const getLessonBundlePlugin = (): LessonBundlePlugin | null => {
   if (lessonBundlePluginInstance) {
@@ -544,8 +556,22 @@ export class Util {
               }
 
               // 🔥 DOWNLOAD LOGIC (UNCHANGED)
-              const bundleZipUrls: string[] =
-                await RemoteConfig.getJSON(bundleZipUrlsKey);
+              const fallbackBundleZipUrls =
+                getBundleZipUrlsFallback(bundleZipUrlsKey);
+              const cachedBundleZipUrls = getCachedGrowthBookFeatureValue<
+                string[] | null
+              >(bundleZipUrlsKey, null);
+              const bundleZipUrls =
+                cachedBundleZipUrls ?? fallbackBundleZipUrls;
+
+              logger.warn('[LessonDownloader] Resolved bundle ZIP URLs', {
+                lessonId,
+                bundleZipUrlsKey,
+                cachedBundleZipUrls,
+                fallbackBundleZipUrls,
+                resolvedBundleZipUrls: bundleZipUrls,
+                usedCachedBundleZipUrls: cachedBundleZipUrls !== null,
+              });
 
               if (!bundleZipUrls || bundleZipUrls.length < 1) {
                 logger.error('[LessonDownloader] No remote ZIP URLs found');


### PR DESCRIPTION
Add GrowthBook feature keys for bundle ZIP URLs and use cached/evaluated feature values as the source of remote bundle ZIP URLs. App: register BUNDLE_ZIP_URLS and LIDO_BUNDLE_ZIP_URLS, evaluate and log resolved values, and cache them. LiveQuizQuestion and LidoPlayer: read bundle URL lists via getCachedGrowthBookFeatureValue with environment fallbacks; LidoPlayer also uses LIDO_BUNDLE_ZIP_URLS for downloads. Util: add fallback resolver, prefer cached GrowthBook values when resolving bundle ZIP URLs for lesson downloads, and add detailed logging about source and resolution. Misc: add new constants and import adjustments across affected files.