### PR TITLE
fix: Display student counts and set assignment ends

### DIFF
--- a/src/ops-console/components/campaignSetup/CampaignReviewStep.css
+++ b/src/ops-console/components/campaignSetup/CampaignReviewStep.css
@@ -139,6 +139,11 @@
   text-align: left !important;
 }
 
+.campaign-review-count {
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
 .campaign-review-assignment-list,
 .campaign-review-message-list {
   display: flex;
@@ -335,7 +340,6 @@
 
 @media (max-width: 48rem) {
   .campaign-review-step {
-    margin-top: 2.875rem;
     padding: 1.25rem 0 1.5rem;
   }
 
@@ -374,6 +378,10 @@
   .campaign-review-assignment-detail,
   .campaign-review-reach .campaign-review-subheading {
     color: var(--campaign-text);
+  }
+
+  .campaign-review-reach .campaign-review-subheading {
+    text-transform: capitalize;
   }
 
   .campaign-review-communication-card .campaign-review-row {
@@ -472,6 +480,10 @@
     -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
     overflow: hidden;
+  }
+
+  .campaign-review-message-line .campaign-review-label-colon {
+    display: none !important;
   }
 
   .campaign-review-message-overflow {

--- a/src/ops-console/components/campaignSetup/CampaignReviewStep.tsx
+++ b/src/ops-console/components/campaignSetup/CampaignReviewStep.tsx
@@ -69,6 +69,28 @@ const formatDate = (value: string) => {
 const formatList = (values: string[]) =>
   values.length > 0 ? values.join(', ') : emptyValue;
 
+const formatGradesWithStudentCounts = (
+  grades: CampaignOption[],
+  audienceSummary: CampaignAudienceSummary,
+) =>
+  grades.length > 0
+    ? grades.map((grade, index) => {
+        const summary = audienceSummary.grades.find(
+          (item) => item.gradeId === grade.id,
+        );
+        return (
+          <React.Fragment key={grade.id}>
+            {index > 0 && ', '}
+            {grade.name} (
+            <strong className="campaign-review-count">
+              {summary?.studentCount ?? 0}
+            </strong>
+            )
+          </React.Fragment>
+        );
+      })
+    : emptyValue;
+
 const getRewardTypeLabel = (value: CampaignSetupFormState['rewardType']) =>
   REWARD_TYPE_OPTIONS.find((option) => option.value === value)?.label ||
   emptyValue;
@@ -134,12 +156,6 @@ export const CampaignReviewStep: React.FC<CampaignReviewStepProps> = ({
       ),
     );
 
-  const gradesWithStudents = reviewData.selectedGrades.map((grade) => {
-    const summary = reviewData.audienceSummary.grades.find(
-      (item) => item.gradeId === grade.id,
-    );
-    return `${grade.name} (${summary?.studentCount ?? 0})`;
-  });
   const visibleMessagingRows = reviewData.messagingRows.slice(0, 3);
   const hiddenMessagingDayCount =
     reviewData.messagingRows.length - visibleMessagingRows.length;
@@ -204,7 +220,13 @@ export const CampaignReviewStep: React.FC<CampaignReviewStepProps> = ({
               : emptyValue
           }
         />
-        <ReviewRow label="Grades" value={formatList(gradesWithStudents)} />
+        <ReviewRow
+          label="Grades"
+          value={formatGradesWithStudentCounts(
+            reviewData.selectedGrades,
+            reviewData.audienceSummary,
+          )}
+        />
       </ReviewCard>
 
       <ReviewCard title="Assignments" editStep={1} onEditStep={onEditStep}>
@@ -221,7 +243,7 @@ export const CampaignReviewStep: React.FC<CampaignReviewStepProps> = ({
                 {t('Subjects')}: {formatList(assignment.subjects)}
               </Typography>
               <Typography className="campaign-review-assignment-detail">
-                {t('Lessons')}: {assignment.lessonCount} - {t('Frequency')}:{' '}
+                {t('Lessons')}: {assignment.lessonCount} · {t('Frequency')}:{' '}
                 {t(frequencyLabels[assignment.frequency])}
               </Typography>
             </Box>
@@ -309,24 +331,35 @@ export const CampaignReviewStep: React.FC<CampaignReviewStepProps> = ({
                 <Typography className="campaign-review-message-day">
                   {t('Day {{day}}', { day: index + 1 })}
                 </Typography>
+                <span className="campaign-review-reward-separator">·</span>{' '}
                 <Typography className="campaign-review-message-date">
                   {formatDate(row.scheduled_date)}
                 </Typography>
               </Box>
               {row.message && (
                 <Typography className="campaign-review-message-line">
-                  <strong>{t('Message')}:</strong> <span>{row.message}</span>
+                  <strong>
+                    {t('Message')}
+                    <span className="campaign-review-label-colon">:</span>
+                  </strong>{' '}
+                  <span>{row.message}</span>
                 </Typography>
               )}
               {row.media_link && (
                 <Typography className="campaign-review-message-line">
-                  <strong>{t('Media Link')}:</strong>{' '}
+                  <strong>
+                    {t('Media Link')}
+                    <span className="campaign-review-label-colon">:</span>
+                  </strong>{' '}
                   <span>{row.media_link}</span>
                 </Typography>
               )}
               {row.poll && (
                 <Typography className="campaign-review-message-line">
-                  <strong>{t('Poll')}:</strong>{' '}
+                  <strong>
+                    {t('Poll')}
+                    <span className="campaign-review-label-colon">:</span>
+                  </strong>{' '}
                   <span>
                     {row.poll.question} ({row.poll.options.length}{' '}
                     {t('options')})

--- a/src/ops-console/components/campaignSetup/campaignAssignmentUtils.test.ts
+++ b/src/ops-console/components/campaignSetup/campaignAssignmentUtils.test.ts
@@ -1,6 +1,7 @@
 import {
   buildAssignmentDrafts,
   buildRows,
+  getAssignmentEndDate,
   GradeAssignmentConfig,
   isAlternateWeekEnabled,
 } from './campaignAssignmentUtils';
@@ -138,5 +139,37 @@ describe('campaignAssignmentUtils buildRows', () => {
     expect(
       buildAssignmentDrafts(new Map([['grade-1', rows]]), ['school-1'], 'c-1'),
     ).toEqual([]);
+  });
+
+  it('sets assignment draft end dates one month after their start dates', () => {
+    const drafts = buildAssignmentDrafts(
+      new Map([
+        [
+          'grade-1',
+          [
+            {
+              rowId: 'row-1',
+              gradeId: 'grade-1',
+              courseId: 'course-1',
+              chapterId: 'chapter-1',
+              lessonId: 'lesson-1',
+              lessonNo: 1,
+              date: '2026-06-15',
+              lessonName: 'Lesson 1',
+              subjectName: 'Math',
+            },
+          ],
+        ],
+      ]),
+      ['school-1'],
+      'campaign-1',
+    );
+
+    expect(drafts[0].endsAt).toBe('2026-07-15');
+  });
+
+  it('clamps assignment end dates to the last day of the next month', () => {
+    expect(getAssignmentEndDate('2026-01-31')).toBe('2026-02-28');
+    expect(getAssignmentEndDate('2028-01-31')).toBe('2028-02-29');
   });
 });

--- a/src/ops-console/components/campaignSetup/campaignAssignmentUtils.ts
+++ b/src/ops-console/components/campaignSetup/campaignAssignmentUtils.ts
@@ -70,6 +70,28 @@ const formatIsoDate = (date: Date) => {
   return `${year}-${month}-${day}`;
 };
 
+export const getAssignmentEndDate = (startsAt: string): string | null => {
+  if (!startsAt) return null;
+
+  const start = parseDate(startsAt);
+  if (Number.isNaN(start.getTime())) return null;
+
+  const year = start.getFullYear();
+  const targetMonthIndex = start.getMonth() + 1;
+  const targetYear = year + Math.floor(targetMonthIndex / 12);
+  const normalizedTargetMonthIndex = targetMonthIndex % 12;
+  const daysInTargetMonth = new Date(
+    targetYear,
+    normalizedTargetMonthIndex + 1,
+    0,
+  ).getDate();
+  const targetDay = Math.min(start.getDate(), daysInTargetMonth);
+
+  return formatIsoDate(
+    new Date(targetYear, normalizedTargetMonthIndex, targetDay),
+  );
+};
+
 export const formatDisplayDate = (value: string) =>
   value
     ? new Intl.DateTimeFormat(undefined, {
@@ -245,7 +267,7 @@ export const buildAssignmentDrafts = (
         lessonName: row.lessonName,
         subjectName: row.subjectName,
         startsAt: row.date,
-        endsAt: null,
+        endsAt: getAssignmentEndDate(row.date),
         type: 'homework',
         source: 'campaign',
         setNumber: index + 1,


### PR DESCRIPTION
- Show student counts next to selected grades in the campaign review by adding formatGradesWithStudentCounts and styling (.campaign-review-count). 
- Compute assignment draft end dates with getAssignmentEndDate (one month after start, clamped to month end) and set endsAt when building drafts; include unit tests for date calculation and clamping. 
- Also update CampaignReviewStep markup (label colons, date/reward separator, lesson/frequency separator) and small CSS tweaks (capitalize reach subheading, hide label colons on narrow layouts, remove small-screen top margin).