### PR TITLE
fix: Adjust assessment flow and abort logic

### DIFF
--- a/src/hooks/useLearningPath.test.ts
+++ b/src/hooks/useLearningPath.test.ts
@@ -230,12 +230,14 @@ describe('useLearningPath features used by Home tab', () => {
     );
   });
 
-  test('continues assessment sequence in assessment-only mode after prior assessment history', async () => {
+  test('skips subject assessment in assessment-only mode after prior assessment history', async () => {
     mockApi.isStudentPlayedPalLesson.mockResolvedValue(true);
     mockApi.getSubjectLessonsBySubjectId.mockResolvedValue({
       id: 'asmt-doc-2',
       lesson_id: 'assessment-lesson-2',
     });
+    mockApi.getChaptersForCourse.mockResolvedValue([{ id: 'chapter-1' }]);
+    mockApi.getLessonsForChapter.mockResolvedValue([{ id: 'normal-lesson-1' }]);
 
     const next = await recommendNextLesson({
       student: { id: 'stu-1' },
@@ -243,15 +245,14 @@ describe('useLearningPath features used by Home tab', () => {
       mode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
     });
 
-    expect(next).toMatchObject({
-      lesson_id: 'assessment-lesson-2',
-      is_assessment: true,
+    expect(next).toEqual({
+      lesson_id: 'normal-lesson-1',
+      chapter_id: 'chapter-1',
+      source: SOURCE.LEARNING_PATHWAY_HOME_NO_PAL,
+      is_assessment: false,
+      isPlayed: false,
     });
-    expect(mockApi.getSubjectLessonsBySubjectId).toHaveBeenCalledWith(
-      's1',
-      { id: 'stu-1' },
-      'c1',
-    );
+    expect(mockApi.getSubjectLessonsBySubjectId).not.toHaveBeenCalled();
     expect(palUtil.getPalLessonPathForCourse).not.toHaveBeenCalled();
   });
 

--- a/src/hooks/useLearningPath.ts
+++ b/src/hooks/useLearningPath.ts
@@ -264,7 +264,7 @@ export async function recommendNextLesson({
   /* -------------------------------
    * 1️⃣ TEACHER ASSIGNED ASSESSMENT
    * ------------------------------- */
-  const hasCompletedInitialAssessment = shouldUsePAL(mode)
+  const hasCompletedInitialAssessment = shouldUseAssessment(mode)
     ? await api.isStudentPlayedPalLesson(student.id, course.id)
     : false;
   if (classId) {

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -9401,7 +9401,7 @@ order by
         ) t
         WHERE rn = 1
         ORDER BY created_at DESC
-        LIMIT 2;
+        LIMIT 50;
       `;
 
       const abortParams: (string | null)[] = [
@@ -9411,10 +9411,11 @@ order by
       ];
       const abortRes = await this.executeQuery(abortQuery, abortParams);
 
-      const lastTwo = ((abortRes as DBSQLiteValues | undefined)?.values ??
-        []) as ResultStatusRow[];
+      const uniqueAssessmentResults = ((abortRes as DBSQLiteValues | undefined)
+        ?.values ?? []) as ResultStatusRow[];
+      const lastTwo = uniqueAssessmentResults.slice(0, 2);
 
-      const isAssessmentTerminated = lastTwo.some(
+      const isAssessmentTerminated = uniqueAssessmentResults.some(
         (r) => r.status === 'assessment_terminated',
       );
       const isAborted =
@@ -9422,7 +9423,7 @@ order by
         lastTwo.every((r) => r.status === 'system_exit');
 
       if (isAssessmentTerminated || isAborted) {
-        return {} as TableTypes<'subject_lesson'>; // 🚫 Aborted group
+        return {} as TableTypes<'subject_lesson'>; // Aborted group
       }
 
       /* ==========================================

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -9251,6 +9251,7 @@ order by
         set_number: number;
         language_id: string | null;
         locale_id: string | null;
+        lesson_id: string | null;
       };
       type ResultStatusRow = {
         lesson_id: string | null;
@@ -9313,7 +9314,7 @@ order by
 
       // 1️⃣ Fetch all available set_numbers (+ language/locale for in-memory preference)
       const setQuery = `
-      SELECT DISTINCT set_number, language_id, locale_id
+      SELECT DISTINCT set_number, language_id, locale_id, lesson_id
       FROM subject_lesson
       WHERE subject_id = ?
         AND is_deleted = 0
@@ -9365,10 +9366,24 @@ order by
       const setNumber = candidateSets[randomIndex];
       const useStrictLanguageTrack =
         !!langId && preferredSets.includes(setNumber);
+      const assessmentLessonIds = Array.from(
+        new Set(
+          setRows
+            .map((row) => row.lesson_id)
+            .filter((lessonId): lessonId is string => !!lessonId),
+        ),
+      );
+
+      if (!assessmentLessonIds.length) {
+        return {} as TableTypes<'subject_lesson'>;
+      }
 
       /* ==========================================
        * 3️⃣ Abort Check (with assignment_id IS NULL)
        * ========================================== */
+      const abortLessonPlaceholders = assessmentLessonIds
+        .map(() => '?')
+        .join(', ');
       const abortQuery = `
         SELECT lesson_id, status
         FROM (
@@ -9381,6 +9396,7 @@ order by
             WHERE student_id = ?
               AND subject_id = ?
               AND assignment_id IS NULL
+              AND lesson_id IN (${abortLessonPlaceholders})
               AND is_deleted = 0
         ) t
         WHERE rn = 1
@@ -9388,7 +9404,11 @@ order by
         LIMIT 2;
       `;
 
-      const abortParams: (string | null)[] = [studentId, subjectId];
+      const abortParams: (string | null)[] = [
+        studentId,
+        subjectId,
+        ...assessmentLessonIds,
+      ];
       const abortRes = await this.executeQuery(abortQuery, abortParams);
 
       const lastTwo = ((abortRes as DBSQLiteValues | undefined)?.values ??
@@ -9779,16 +9799,27 @@ order by
     ) t
     WHERE rn = 1
     ORDER BY created_at DESC
-    LIMIT 2;
+    LIMIT 50;
     `;
 
     const abortRes = await this._db?.query(abortCheckQuery);
-    const lastTwoResults = abortRes?.values ?? [];
+    type AssignmentAbortResultRow = {
+      assignment_id?: string | null;
+      status?: string | null;
+    };
+    const uniqueAssignmentResults = (abortRes?.values ??
+      []) as AssignmentAbortResultRow[];
+    const lastTwoResults = uniqueAssignmentResults.slice(0, 2);
 
-    if (
-      lastTwoResults.length === 2 &&
-      lastTwoResults.every((r: any) => r.status === 'system_exit')
-    ) {
+    const isAssessmentTerminated = uniqueAssignmentResults.some(
+      (result) => result.status === 'assessment_terminated',
+    );
+    const isAborted =
+      isAssessmentTerminated ||
+      (lastTwoResults.length === 2 &&
+        lastTwoResults.every((r) => r.status === 'system_exit'));
+
+    if (isAborted) {
       // 🚫 Assessment group is aborted
       return [];
     }

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -14405,7 +14405,7 @@ export class SupabaseApi implements ServiceApi {
        * ========================================== */
       const { data: setRows, error: setError } = await this.supabase
         .from('subject_lesson')
-        .select('set_number, language_id, locale_id')
+        .select('set_number, language_id, locale_id, lesson_id')
         .eq('subject_id', subjectId)
         .eq('is_deleted', false)
         .not('set_number', 'is', null);
@@ -14457,6 +14457,17 @@ export class SupabaseApi implements ServiceApi {
       const setNumber = candidateSets[randomIndex];
       const useStrictLanguageTrack =
         !!langId && preferredSets.includes(setNumber);
+      const assessmentLessonIds = Array.from(
+        new Set(
+          (setRows ?? [])
+            .map((row) => row.lesson_id)
+            .filter((lessonId): lessonId is string => !!lessonId),
+        ),
+      );
+
+      if (!assessmentLessonIds.length) {
+        return {} as TableTypes<'subject_lesson'>;
+      }
 
       /* ==========================================
        * 2️⃣ Abort Check (assignment_id IS NULL)
@@ -14467,6 +14478,7 @@ export class SupabaseApi implements ServiceApi {
         .eq('student_id', studentId)
         .eq('subject_id', subjectId)
         .is('assignment_id', null)
+        .in('lesson_id', assessmentLessonIds)
         .eq('is_deleted', false)
         .order('created_at', { ascending: false })
         .limit(50);
@@ -14919,19 +14931,21 @@ export class SupabaseApi implements ServiceApi {
       if (!uniqueMap.has(row.assignment_id)) {
         uniqueMap.set(row.assignment_id, row);
       }
-
-      // stop early once we have 2 unique assignments
-      if (uniqueMap.size === 2) break;
     }
 
-    const lastTwoUniqueAssignments = Array.from(uniqueMap.values());
+    const uniqueAssignments = Array.from(uniqueMap.values());
+    const lastTwoUniqueAssignments = uniqueAssignments.slice(0, 2);
 
     /* -----------------------------------------
       Abort check
     ------------------------------------------ */
+    const isAssessmentTerminated = uniqueAssignments.some(
+      (r) => r.status === 'assessment_terminated',
+    );
     const isAborted =
-      lastTwoUniqueAssignments.length === 2 &&
-      lastTwoUniqueAssignments.every((r) => r.status === 'system_exit');
+      isAssessmentTerminated ||
+      (lastTwoUniqueAssignments.length === 2 &&
+        lastTwoUniqueAssignments.every((r) => r.status === 'system_exit'));
 
     if (isAborted) {
       return [];


### PR DESCRIPTION
Adjust assessment flow and abort logic across API layers and tests.

- Tests: update expectation to skip subject assessment in ASSESSMENT_ONLY when prior assessment history exists, add mocks for chapters/lessons, and assert subject assessment fetch is not called.
- useLearningPath: switch check from shouldUsePAL to shouldUseAssessment when deciding if initial assessment was completed.
- SqliteApi & SupabaseApi: include lesson_id in subject_lesson selects, derive assessmentLessonIds, and restrict abort-check queries to those lesson IDs. Return early if no assessment lessons exist. Increase abort query window and treat any 'assessment_terminated' status as an abort in addition to the previous two 'system_exit' check.

These changes ensure assessment-only mode can skip redundant subject assessments and make abort detection more robust across SQLite and Supabase implementations.