### PR TITLE
fix: Support forced final reward audio & wait for Homework Pathway

### DIFF
--- a/src/components/assignment/HomeworkPathwayStructure.tsx
+++ b/src/components/assignment/HomeworkPathwayStructure.tsx
@@ -91,6 +91,9 @@ const MASCOT_X_OFFSET = -155;
 const REWARD_FLIGHT_TARGET_X_OFFSET = MASCOT_X_OFFSET + 84;
 const REWARD_FLIGHT_DURATION_MS = 4000;
 const REWARD_FLIGHT_ARC_Y_OFFSET = 150;
+const FINAL_HOMEWORK_REWARD_AUDIO_DELAY_MS = 1000;
+const FINAL_HOMEWORK_REWARD_AUDIO_TIMEOUT_MS = 6000;
+type DailyRewardAudioClipName = 'reward' | 'reward_01' | 'reward_02';
 
 const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
   selectedSubject,
@@ -688,10 +691,11 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
       playbackOptions?: {
         onPlaybackStop?: () => void;
       },
+      clipName: DailyRewardAudioClipName = 'reward',
     ): Promise<boolean> => {
       const localAudioPath = await AudioUtil.getLocalizedAudioUrl(
         'dailyReward',
-        'reward',
+        clipName,
       );
       if (!localAudioPath) {
         playbackOptions?.onPlaybackStop?.();
@@ -1688,8 +1692,32 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
           });
         };
 
+        const waitForFinalHomeworkRewardAudio = (): {
+          promise: Promise<void>;
+          resolve: () => void;
+        } => {
+          let didResolve = false;
+          let resolveAudio = () => {};
+
+          const resolve = () => {
+            if (didResolve) return;
+            didResolve = true;
+            resolveAudio();
+          };
+
+          const promise = Promise.race([
+            new Promise<void>((resolvePromise) => {
+              resolveAudio = resolvePromise;
+            }),
+            delay(FINAL_HOMEWORK_REWARD_AUDIO_TIMEOUT_MS).then(() => undefined),
+          ]);
+
+          return { promise, resolve };
+        };
+
         const runRewardAnimation = async (
           newRewardId: string,
+          shouldPlayFinalRewardAudioBeforeComplete: boolean,
           onComplete?: () => void,
         ) => {
           // If offline, this might fail, wrap in try/catch or skip if no internet
@@ -1779,6 +1807,11 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
                   detail: {
                     rewardId: newRewardId,
                     stateValue: rewardStateValue,
+                    forceRewardAudio: shouldPlayFinalRewardAudioBeforeComplete,
+                    dailyRewardAudioClipName:
+                      shouldPlayFinalRewardAudioBeforeComplete
+                        ? 'reward_02'
+                        : 'reward',
                   },
                 }),
               );
@@ -1797,15 +1830,32 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
               } else {
                 await animateChimpleMovement();
               }
+              const finalRewardAudioWait =
+                shouldPlayFinalRewardAudioBeforeComplete
+                  ? waitForFinalHomeworkRewardAudio()
+                  : null;
               window.dispatchEvent(
                 new CustomEvent(PATHWAY_REWARD_AUDIO_READY_EVENT, {
                   detail: {
                     rewardId: newRewardId,
                     stateValue: rewardStateValue,
+                    forceRewardAudio: shouldPlayFinalRewardAudioBeforeComplete,
+                    dailyRewardAudioClipName:
+                      shouldPlayFinalRewardAudioBeforeComplete
+                        ? 'reward_02'
+                        : 'reward',
+                    onRewardAudioComplete:
+                      shouldPlayFinalRewardAudioBeforeComplete
+                        ? finalRewardAudioWait?.resolve
+                        : undefined,
                   },
                 }),
               );
               await Util.updateUserReward();
+              if (finalRewardAudioWait) {
+                await finalRewardAudioWait.promise;
+                await delay(FINAL_HOMEWORK_REWARD_AUDIO_DELAY_MS);
+              }
               onComplete?.();
             };
             const rewardDiv = document.createElement('div');
@@ -1932,28 +1982,33 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
         }
 
         if (shouldRunRewardAnimation) {
-          runRewardAnimation(newRewardId, () => {
-            if (shouldOpenCelebrationPopup && stickerPreviewPayload) {
-              window.setTimeout(() => {
-                handleStickerPreviewReady(
-                  stickerPreviewPayload,
-                  'pathway_completion_auto',
-                );
-              }, 0);
-            } else if (
-              didScheduleStickerCompletionPopup &&
-              !didDispatchStickerCompletionPopupImmediately &&
-              stickerCompletionPayload
-            ) {
-              window.setTimeout(() => {
-                window.dispatchEvent(
-                  new CustomEvent(STICKER_BOOK_COMPLETION_READY_EVENT, {
-                    detail: stickerCompletionPayload,
-                  }),
-                );
-              }, 0);
-            }
-          });
+          runRewardAnimation(
+            newRewardId,
+            isFinalRewardTransition &&
+              (willShowCelebration || didScheduleStickerCompletionPopup),
+            () => {
+              if (shouldOpenCelebrationPopup && stickerPreviewPayload) {
+                window.setTimeout(() => {
+                  handleStickerPreviewReady(
+                    stickerPreviewPayload,
+                    'pathway_completion_auto',
+                  );
+                }, 0);
+              } else if (
+                didScheduleStickerCompletionPopup &&
+                !didDispatchStickerCompletionPopupImmediately &&
+                stickerCompletionPayload
+              ) {
+                window.setTimeout(() => {
+                  window.dispatchEvent(
+                    new CustomEvent(STICKER_BOOK_COMPLETION_READY_EVENT, {
+                      detail: stickerCompletionPayload,
+                    }),
+                  );
+                }, 0);
+              }
+            },
+          );
         } else if (shouldOpenCelebrationPopup && stickerPreviewPayload) {
           window.setTimeout(() => {
             handleStickerPreviewReady(

--- a/src/hooks/useHomeworkSticker.test.ts
+++ b/src/hooks/useHomeworkSticker.test.ts
@@ -7,6 +7,8 @@ import { useFeatureIsOn } from '@growthbook/growthbook-react';
 import {
   AUTO_OPEN_STICKER_COMPLETION_POPUP_KEY,
   AUTO_OPEN_STICKER_PREVIEW_KEY,
+  PATHWAY_REWARD_AUDIO_READY_EVENT,
+  PATHWAY_REWARD_CELEBRATION_STARTED_EVENT,
   PENDING_PATHWAY_STICKER_REWARD_KEY,
   REWARD_LEARNING_PATH,
   STICKER_BOOK_CELEBRATION_POPUP_ENABLED,
@@ -162,6 +164,104 @@ describe('useHomeworkSticker', () => {
     });
 
     expect(onFinalHomeworkStickerComplete).toHaveBeenCalledTimes(1);
+  });
+
+  test('forced final homework reward audio bypasses sticker suppression and waits before continuing', async () => {
+    const container = document.createElement('div');
+    const reloadHomeworkPathway = jest.fn();
+    const onRewardAudioComplete = jest.fn();
+    let crowdCheerOnComplete: (() => void) | undefined;
+    let rewardPlaybackStop: (() => void) | undefined;
+
+    const playRewardAudio = jest.fn(
+      async (
+        _stateValue?: number,
+        playbackOptions?: { onPlaybackStop?: () => void },
+        _clipName?: string,
+      ) => {
+        rewardPlaybackStop = playbackOptions?.onPlaybackStop;
+        return true;
+      },
+    );
+
+    (AudioUtil.playAudioOrTts as jest.Mock).mockImplementation(
+      ({
+        audioUrl,
+        onComplete,
+      }: {
+        audioUrl?: string;
+        onComplete?: () => void;
+      }) => {
+        if (audioUrl === '/assets/audios/common/crowd_cheer.mp3') {
+          crowdCheerOnComplete = onComplete;
+        }
+        return Promise.resolve(true);
+      },
+    );
+
+    sessionStorage.setItem(
+      AUTO_OPEN_STICKER_PREVIEW_KEY,
+      JSON.stringify({
+        studentId: 'student-1',
+        awardedStickerId: 'sticker-1',
+      }),
+    );
+
+    renderHook(() =>
+      useHomeworkSticker({
+        containerRef: { current: container },
+        riveContainer: document.createElement('div'),
+        currentMascotStateValue: 2,
+        reloadHomeworkPathway,
+        onFinalHomeworkStickerComplete: jest.fn(),
+        playMascotAudioFromLocalPath: jest.fn().mockResolvedValue(true),
+        playRewardAudio,
+      }),
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(PATHWAY_REWARD_CELEBRATION_STARTED_EVENT, {
+          detail: {
+            rewardId: 'reward-1',
+            stateValue: 4,
+            forceRewardAudio: true,
+            dailyRewardAudioClipName: 'reward_02',
+          },
+        }),
+      );
+      window.dispatchEvent(
+        new CustomEvent(PATHWAY_REWARD_AUDIO_READY_EVENT, {
+          detail: {
+            rewardId: 'reward-1',
+            stateValue: 4,
+            forceRewardAudio: true,
+            dailyRewardAudioClipName: 'reward_02',
+            onRewardAudioComplete,
+          },
+        }),
+      );
+    });
+
+    expect(onRewardAudioComplete).not.toHaveBeenCalled();
+
+    await act(async () => {
+      crowdCheerOnComplete?.();
+      await Promise.resolve();
+    });
+
+    expect(playRewardAudio).toHaveBeenCalledWith(
+      4,
+      expect.objectContaining({ onPlaybackStop: expect.any(Function) }),
+      'reward_02',
+    );
+    expect(onRewardAudioComplete).not.toHaveBeenCalled();
+
+    act(() => {
+      rewardPlaybackStop?.();
+    });
+
+    expect(onRewardAudioComplete).toHaveBeenCalledTimes(1);
   });
 
   test('finishes final homework after collecting the sticker preview without pathway reload', async () => {

--- a/src/hooks/useHomeworkSticker.ts
+++ b/src/hooks/useHomeworkSticker.ts
@@ -50,6 +50,7 @@ const STICKER_REWARD_BOX_TILT_CLASS =
   'PathwayStructure-end-reward-box--sticker-clicked';
 const CROWD_CHEER_AUDIO_URL = '/assets/audios/common/crowd_cheer.mp3';
 const stickerDataUrlCache: Record<string, string> = {};
+type DailyRewardAudioClipName = 'reward' | 'reward_01' | 'reward_02';
 
 type PlaybackStateConfig = {
   stateMachine?: string;
@@ -76,6 +77,7 @@ interface UseHomeworkStickerParams {
     playbackOptions?: {
       onPlaybackStop?: () => void;
     },
+    clipName?: DailyRewardAudioClipName,
   ) => Promise<boolean | void>;
 }
 
@@ -163,6 +165,8 @@ export function useHomeworkSticker({
     rewardReady: false,
     suppressed: false,
     stateValue: null as number | null,
+    dailyRewardAudioClipName: 'reward' as DailyRewardAudioClipName,
+    onRewardAudioComplete: null as (() => void) | null,
     token: 0,
   });
 
@@ -288,6 +292,8 @@ export function useHomeworkSticker({
       rewardReady: false,
       suppressed: false,
       stateValue: null,
+      dailyRewardAudioClipName: 'reward',
+      onRewardAudioComplete: null,
     };
   }, []);
 
@@ -866,9 +872,13 @@ export function useHomeworkSticker({
 
       const tiltRequestId = rewardStickerTiltRequestIdRef.current + 1;
       rewardStickerTiltRequestIdRef.current = tiltRequestId;
+      let didStopRewardAudio = false;
       const stopRewardStickerTilt = () => {
+        if (didStopRewardAudio) return;
         if (rewardStickerTiltRequestIdRef.current !== tiltRequestId) return;
+        didStopRewardAudio = true;
         setStickerCollectTiltActive(false);
+        rewardAudioSequence.onRewardAudioComplete?.();
       };
 
       resetRewardAudioSequence();
@@ -878,6 +888,7 @@ export function useHomeworkSticker({
         {
           onPlaybackStop: stopRewardStickerTilt,
         },
+        rewardAudioSequence.dailyRewardAudioClipName,
       ).then((didStartPlayback) => {
         if (didStartPlayback === false) {
           stopRewardStickerTilt();
@@ -889,12 +900,16 @@ export function useHomeworkSticker({
       const customEvent = event as CustomEvent<{
         rewardId?: string;
         stateValue?: number;
+        forceRewardAudio?: boolean;
+        dailyRewardAudioClipName?: DailyRewardAudioClipName;
       }>;
       const rewardId = customEvent.detail?.rewardId;
       if (!rewardId) return;
 
       const nextToken = rewardAudioSequenceRef.current.token + 1;
-      const shouldSuppress = shouldSuppressRewardAudioForStickerBook();
+      const shouldSuppress =
+        !customEvent.detail?.forceRewardAudio &&
+        shouldSuppressRewardAudioForStickerBook();
 
       rewardAudioSequenceRef.current = {
         rewardId,
@@ -902,6 +917,9 @@ export function useHomeworkSticker({
         rewardReady: false,
         suppressed: shouldSuppress,
         stateValue: customEvent.detail?.stateValue ?? currentMascotStateValue,
+        dailyRewardAudioClipName:
+          customEvent.detail?.dailyRewardAudioClipName ?? 'reward',
+        onRewardAudioComplete: null,
         token: nextToken,
       };
 
@@ -929,6 +947,9 @@ export function useHomeworkSticker({
       const customEvent = event as CustomEvent<{
         rewardId?: string;
         stateValue?: number;
+        forceRewardAudio?: boolean;
+        dailyRewardAudioClipName?: DailyRewardAudioClipName;
+        onRewardAudioComplete?: () => void;
       }>;
       const rewardId = customEvent.detail?.rewardId;
       if (!rewardId) return;
@@ -940,11 +961,18 @@ export function useHomeworkSticker({
         customEvent.detail?.stateValue ??
         rewardAudioSequence.stateValue ??
         currentMascotStateValue;
+      rewardAudioSequence.dailyRewardAudioClipName =
+        customEvent.detail?.dailyRewardAudioClipName ??
+        rewardAudioSequence.dailyRewardAudioClipName;
+      rewardAudioSequence.onRewardAudioComplete =
+        customEvent.detail?.onRewardAudioComplete ?? null;
 
       if (
         rewardAudioSequence.suppressed ||
-        shouldSuppressRewardAudioForStickerBook()
+        (!customEvent.detail?.forceRewardAudio &&
+          shouldSuppressRewardAudioForStickerBook())
       ) {
+        rewardAudioSequence.onRewardAudioComplete?.();
         resetRewardAudioSequence();
         return;
       }


### PR DESCRIPTION
- Allow forcing and waiting for the final homework reward audio before completing reward flow. 
- Update useHomeworkSticker to store clip name and completion callback, respect forceRewardAudio to bypass sticker-suppression, and call the completion callback when playback stops or is suppressed. 
- Add a unit test that verifies forced final reward audio bypasses suppression and waits before continuing.