### PR TITLE
Add image cache utility and integrate CachedImage

### DIFF
--- a/src/components/GenericPopUp/GenericPopUp.test.tsx
+++ b/src/components/GenericPopUp/GenericPopUp.test.tsx
@@ -3,6 +3,14 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import GenericPopup from './GenericPopUp';
 import { AudioUtil } from '../../utility/AudioUtil';
 
+jest.mock('../common/CachedImage', () => {
+  return function MockCachedImage(
+    props: React.ImgHTMLAttributes<HTMLImageElement>,
+  ) {
+    return <img {...props} />;
+  };
+});
+
 jest.mock('../../utility/AudioUtil', () => ({
   AudioUtil: {
     playAudioOrTts: jest.fn(),

--- a/src/components/GenericPopUp/GenericPopUp.tsx
+++ b/src/components/GenericPopUp/GenericPopUp.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from 'react';
 import './GenericPopup.css';
 import AudioButton from '../common/AudioButton';
 import { AudioUtil } from '../../utility/AudioUtil';
+import CachedImage from '../common/CachedImage';
 
 const GENERIC_POPUP_SOUND_EFFECT_URL =
   '/assets/audios/common/generic_popup_sound_effect.mp3';
@@ -146,7 +147,7 @@ const GenericPopup: React.FC<Props> = ({
           />
         </button>
 
-        <img
+        <CachedImage
           id="generic-popup-bg-image"
           className="generic-popup-bg-image"
           src={backgroundImageUrl}
@@ -159,7 +160,7 @@ const GenericPopup: React.FC<Props> = ({
               id="generic-popup-thumb-wrapper"
               className="generic-popup-thumb-wrapper"
             >
-              <img
+              <CachedImage
                 id="generic-popup-thumb"
                 className="generic-popup-thumb"
                 src={thumbnailImageUrl}

--- a/src/components/Home/DropdownMenu.tsx
+++ b/src/components/Home/DropdownMenu.tsx
@@ -12,6 +12,7 @@ import { Util } from '../../utility/util';
 import { LessonNode } from '../../hooks/useLearningPath';
 import logger from '../../utility/logger';
 import { downloadMissingCourseIcons } from '../../utility/courseIconDeviceCache';
+import { getCachedImageSrc } from '../../utility/imageCache';
 
 interface CourseDetails {
   course: TableTypes<'course'>;
@@ -321,12 +322,14 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
   };
 
   useEffect(() => {
-    const preloadImage = (src: string): Promise<boolean> => {
-      return new Promise<boolean>((resolve) => {
+    const preloadImage = async (src: string): Promise<boolean> => {
+      const resolvedSrc = await getCachedImageSrc(src);
+
+      return await new Promise<boolean>((resolve) => {
         const img = new Image();
         img.onload = () => resolve(true);
         img.onerror = () => resolve(false);
-        img.src = src;
+        img.src = resolvedSrc;
       });
     };
 

--- a/src/components/assignment/HomeworkPathwayStructure.tsx
+++ b/src/components/assignment/HomeworkPathwayStructure.tsx
@@ -56,6 +56,7 @@ import {
   hasPendingFinalHomeworkStickerFlow,
   hasPendingHomeworkStickerFlow,
 } from '../../utility/homeworkStickerFlow';
+import { getCachedImageSrc } from '../../utility/imageCache';
 
 interface HomeworkPathwayStructureProps {
   selectedSubject?: string | null;
@@ -439,7 +440,7 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
   const preloadAllLessonImages = useCallback(
     async (lessons: Array<{ image?: string | null }>) => {
       await Promise.all(
-        lessons.map((lesson) => {
+        lessons.map(async (lesson) => {
           const isValidUrl =
             typeof lesson.image === 'string' &&
             /^(https?:\/\/|\/)/.test(lesson.image);
@@ -447,7 +448,8 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
             isValidUrl && lesson.image
               ? lesson.image
               : 'assets/icons/DefaultIcon.png';
-          return preloadImage(src);
+          const resolvedSrc = await getCachedImageSrc(src);
+          return preloadImage(resolvedSrc);
         }),
       );
     },
@@ -1199,6 +1201,7 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
                 ? (lesson.image ?? 'assets/icons/DefaultIcon.png')
                 : 'assets/icons/DefaultIcon.png'
               : 'assets/icons/NextNodeIcon.svg';
+          const resolvedLessonImageSrc = await getCachedImageSrc(lesson_image);
 
           if (isPlaceholderSnapshot || lessonIdx < visualCurrentIndex) {
             const playedLesson = document.createElementNS(
@@ -1209,7 +1212,13 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
               playedLessonSVG.cloneNode(true) as SVGGElement,
             );
             if (!isPlaceholderSnapshot) {
-              const lessonImage = createSVGImage(lesson_image, 30, 30, 28, 30);
+              const lessonImage = createSVGImage(
+                resolvedLessonImageSrc,
+                30,
+                30,
+                28,
+                30,
+              );
               playedLesson.appendChild(lessonImage);
             }
 
@@ -1261,9 +1270,15 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
               }, ${positionMappings.activeGroup.baseY + activeYOffset})`,
             );
 
-            const halo = createSVGImage(haloPath, 140, 140, -15, -12);
+            const halo = createSVGImage(
+              await getCachedImageSrc(haloPath),
+              140,
+              140,
+              -15,
+              -12,
+            );
             const pointer = createSVGImage(
-              '/pathwayAssets/touchpointer.svg',
+              await getCachedImageSrc('/pathwayAssets/touchpointer.svg'),
               30,
               30,
               70,
@@ -1273,7 +1288,13 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
               'class',
               'homeworkpathway-structure-animated-pointer',
             );
-            const lessonImage = createSVGImage(lesson_image, 30, 30, 40, 40);
+            const lessonImage = createSVGImage(
+              resolvedLessonImageSrc,
+              30,
+              30,
+              40,
+              40,
+            );
 
             activeGroup.appendChild(halo);
             activeGroup.appendChild(fruitActive.cloneNode(true) as SVGGElement);
@@ -1324,7 +1345,13 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
               'g',
             );
 
-            const lessonImage = createSVGImage(lesson_image, 30, 30, 27, 29);
+            const lessonImage = createSVGImage(
+              resolvedLessonImageSrc,
+              30,
+              30,
+              27,
+              29,
+            );
             flower_Inactive.appendChild(
               fruitInactive.cloneNode(true) as SVGGElement,
             );
@@ -1486,8 +1513,10 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
             if (nextStickerImageSrc) {
               const horizontalPadding = Math.round(width * 0.12);
               const verticalPadding = Math.round(height * 0.12);
+              const resolvedStickerImageSrc =
+                await getCachedImageSrc(nextStickerImageSrc);
               const stickerImage = createSVGImage(
-                nextStickerImageSrc,
+                resolvedStickerImageSrc,
                 width - horizontalPadding * 2,
                 height - verticalPadding * 2,
                 horizontalPadding,

--- a/src/components/assignment/HomeworkPathwayStructure.tsx
+++ b/src/components/assignment/HomeworkPathwayStructure.tsx
@@ -57,6 +57,7 @@ import {
   hasPendingHomeworkStickerFlow,
 } from '../../utility/homeworkStickerFlow';
 import { getCachedImageSrc } from '../../utility/imageCache';
+import { mapInBatches } from '../../utility/batch';
 
 interface HomeworkPathwayStructureProps {
   selectedSubject?: string | null;
@@ -1095,8 +1096,10 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
 
       preloadAllLessonImages(lessons);
 
-      const resolvedLessonImageUrls = await Promise.all(
-        lessonsToRender.map(async ({ lesson }, lessonIdx) => {
+      const resolvedLessonImageUrls = await mapInBatches(
+        lessonsToRender,
+        5,
+        async ({ lesson }, lessonIdx) => {
           const isPlayed = lessonIdx < visualCurrentIndex;
           const isActive = lessonIdx === visualCurrentIndex;
           const isValidUrl =
@@ -1111,7 +1114,7 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
               : 'assets/icons/NextNodeIcon.svg';
 
           return await getCachedImageSrc(lessonImageUrl);
-        }),
+        },
       );
       const resolvedHaloSrc =
         typeof haloPath === 'string'

--- a/src/components/assignment/HomeworkPathwayStructure.tsx
+++ b/src/components/assignment/HomeworkPathwayStructure.tsx
@@ -1095,6 +1095,36 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
 
       preloadAllLessonImages(lessons);
 
+      const resolvedLessonImageUrls = await Promise.all(
+        lessonsToRender.map(async ({ lesson }, lessonIdx) => {
+          const isPlayed = lessonIdx < visualCurrentIndex;
+          const isActive = lessonIdx === visualCurrentIndex;
+          const isValidUrl =
+            typeof lesson.image === 'string' &&
+            /^(https?:\/\/|\/)/.test(lesson.image);
+
+          const lessonImageUrl =
+            isPlayed || isActive
+              ? isValidUrl
+                ? (lesson.image ?? 'assets/icons/DefaultIcon.png')
+                : 'assets/icons/DefaultIcon.png'
+              : 'assets/icons/NextNodeIcon.svg';
+
+          return await getCachedImageSrc(lessonImageUrl);
+        }),
+      );
+      const resolvedHaloSrc =
+        typeof haloPath === 'string'
+          ? await getCachedImageSrc(haloPath)
+          : haloPath;
+      const resolvedPointerSrc = await getCachedImageSrc(
+        '/pathwayAssets/touchpointer.svg',
+      );
+      const resolvedStickerImageSrc =
+        typeof stickerPreviewPayload?.nextStickerImage === 'string'
+          ? await getCachedImageSrc(stickerPreviewPayload.nextStickerImage)
+          : null;
+
       let chimple: SVGForeignObjectElement | null = null;
       chimple = document.createElementNS(
         'http://www.w3.org/2000/svg',
@@ -1103,7 +1133,7 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
       chimple.setAttribute('width', '40%');
       chimple.setAttribute('height', '260%');
 
-      requestAnimationFrame(async () => {
+      requestAnimationFrame(() => {
         if (!containerRef.current || loadSvgRequestIdRef.current !== requestId)
           return;
         containerRef.current.innerHTML = svgContent;
@@ -1190,18 +1220,9 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
 
           const isPlayed = lessonIdx < visualCurrentIndex;
           const isActive = lessonIdx === visualCurrentIndex;
-
-          const isValidUrl =
-            typeof lesson.image === 'string' &&
-            /^(https?:\/\/|\/)/.test(lesson.image);
-
-          const lesson_image: string =
-            isPlayed || isActive
-              ? isValidUrl
-                ? (lesson.image ?? 'assets/icons/DefaultIcon.png')
-                : 'assets/icons/DefaultIcon.png'
-              : 'assets/icons/NextNodeIcon.svg';
-          const resolvedLessonImageSrc = await getCachedImageSrc(lesson_image);
+          const resolvedLessonImageSrc =
+            resolvedLessonImageUrls[lessonIdx] ??
+            'assets/icons/DefaultIcon.png';
 
           if (isPlaceholderSnapshot || lessonIdx < visualCurrentIndex) {
             const playedLesson = document.createElementNS(
@@ -1271,19 +1292,13 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
             );
 
             const halo = createSVGImage(
-              await getCachedImageSrc(haloPath),
+              resolvedHaloSrc || haloPath,
               140,
               140,
               -15,
               -12,
             );
-            const pointer = createSVGImage(
-              await getCachedImageSrc('/pathwayAssets/touchpointer.svg'),
-              30,
-              30,
-              70,
-              90,
-            );
+            const pointer = createSVGImage(resolvedPointerSrc, 30, 30, 70, 90);
             pointer.setAttribute(
               'class',
               'homeworkpathway-structure-animated-pointer',
@@ -1510,11 +1525,9 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
             bg.setAttribute('stroke-width', '3');
             rewardGroup.appendChild(bg);
 
-            if (nextStickerImageSrc) {
+            if (resolvedStickerImageSrc) {
               const horizontalPadding = Math.round(width * 0.12);
               const verticalPadding = Math.round(height * 0.12);
-              const resolvedStickerImageSrc =
-                await getCachedImageSrc(nextStickerImageSrc);
               const stickerImage = createSVGImage(
                 resolvedStickerImageSrc,
                 width - horizontalPadding * 2,
@@ -2003,8 +2016,10 @@ const HomeworkPathwayStructure: React.FC<HomeworkPathwayStructureProps> = ({
           setHasTodayReward(false);
           sessionStorage.removeItem(HOMEWORK_REWARD_COMPLETED_INDEX_KEY);
           sessionStorage.removeItem(PENDING_HOMEWORK_REWARD_TRANSITION_KEY);
-          await updateMascotToNormalState(newRewardId as string);
-          await Util.updateUserReward();
+          void (async () => {
+            await updateMascotToNormalState(newRewardId as string);
+            await Util.updateUserReward();
+          })();
           if (hasPendingFinalHomeworkStickerFlow()) {
             finishFinalHomeworkStickerFlow();
           }

--- a/src/components/common/CachedImage.test.tsx
+++ b/src/components/common/CachedImage.test.tsx
@@ -1,14 +1,27 @@
 import React from 'react';
 import { act, cleanup, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { Capacitor } from '@capacitor/core';
 import CachedImage from './CachedImage';
 import { getCachedImageSrc } from '../../utility/imageCache';
 
+jest.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: jest.fn(),
+    convertFileSrc: jest.fn(),
+  },
+}));
+
 jest.mock('../../utility/imageCache', () => ({
   getCachedImageSrc: jest.fn(),
+  isLocalImageUrl: jest.fn(),
 }));
 
 describe('CachedImage', () => {
+  beforeEach(() => {
+    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
+  });
+
   afterEach(() => {
     cleanup();
     jest.clearAllMocks();

--- a/src/components/common/CachedImage.test.tsx
+++ b/src/components/common/CachedImage.test.tsx
@@ -1,275 +1,56 @@
 import React from 'react';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CachedImage from './CachedImage';
-import { Capacitor, CapacitorHttp } from '@capacitor/core';
-import { Filesystem } from '@capacitor/filesystem';
-import logger from '../../utility/logger';
+import { getCachedImageSrc } from '../../utility/imageCache';
 
-/* ================= MOCKS ================= */
-
-jest.mock('@capacitor/core', () => ({
-  Capacitor: {
-    isNativePlatform: jest.fn(),
-  },
-  CapacitorHttp: {
-    get: jest.fn(),
-  },
+jest.mock('../../utility/imageCache', () => ({
+  getCachedImageSrc: jest.fn(),
 }));
 
-jest.mock('@capacitor/filesystem', () => ({
-  Filesystem: {
-    readFile: jest.fn(),
-    writeFile: jest.fn(),
-  },
-  Directory: {
-    Cache: 'CACHE',
-  },
-}));
-
-jest.mock('../../common/constants', () => ({
-  CACHE_IMAGE: 'cached_images',
-}));
-
-/* ================= TEST SUITE ================= */
-
-describe('CachedImage Component', () => {
-  const testUrl = 'https://example.com/image.png';
-
-  beforeEach(() => {
+describe('CachedImage', () => {
+  afterEach(() => {
+    cleanup();
     jest.clearAllMocks();
   });
 
-  afterEach(() => {
-    cleanup();
-  });
+  it('shows a placeholder while resolving the image source', async () => {
+    let resolveImage: (value: string) => void = () => {};
+    (getCachedImageSrc as jest.Mock).mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveImage = resolve;
+      }),
+    );
 
-  /* ---------------- Web Platform ---------------- */
+    const { container } = render(
+      <CachedImage src="https://example.com/image.png" className="thumb" />,
+    );
 
-  test('1. returns original URL on web platform', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(false);
-
-    render(<CachedImage src={testUrl} />);
-
-    await waitFor(() => {
-      expect(screen.getByRole('img')).toHaveAttribute('src', testUrl);
-    });
-  });
-
-  test('2. does not call filesystem on web', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(false);
-
-    render(<CachedImage src={testUrl} />);
-
-    await waitFor(() => {
-      expect(Filesystem.readFile).not.toHaveBeenCalled();
-    });
-  });
-
-  /* ---------------- Native - Cache Hit ---------------- */
-
-  test('3. loads image from cache if exists', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
-
-    (Filesystem.readFile as jest.Mock).mockResolvedValue({
-      data: 'base64data',
-    });
-
-    render(<CachedImage src={testUrl} />);
-
-    await waitFor(() => {
-      expect(screen.getByRole('img')).toHaveAttribute(
-        'src',
-        'data:image/png;base64,base64data',
-      );
-    });
-  });
-
-  test('4. does not call HTTP if cache hit', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
-    (Filesystem.readFile as jest.Mock).mockResolvedValue({ data: '123' });
-
-    render(<CachedImage src={testUrl} />);
-
-    await waitFor(() => {
-      expect(CapacitorHttp.get).not.toHaveBeenCalled();
-    });
-  });
-
-  /* ---------------- Native - Cache Miss ---------------- */
-
-  test('5. fetches from HTTP if cache miss', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
-    (Filesystem.readFile as jest.Mock).mockRejectedValue(new Error('no file'));
-
-    (CapacitorHttp.get as jest.Mock).mockResolvedValue({
-      data: 'blobdata',
-    });
-
-    (Filesystem.writeFile as jest.Mock).mockResolvedValue({});
-
-    render(<CachedImage src={testUrl} />);
-
-    await waitFor(() => {
-      expect(CapacitorHttp.get).toHaveBeenCalled();
-    });
-  });
-
-  test('6. writes file to cache after fetch', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
-    (Filesystem.readFile as jest.Mock).mockRejectedValue(new Error());
-    (CapacitorHttp.get as jest.Mock).mockResolvedValue({
-      data: 'blobdata',
-    });
-    (Filesystem.writeFile as jest.Mock).mockResolvedValue({});
-
-    render(<CachedImage src={testUrl} />);
-
-    await waitFor(() => {
-      expect(Filesystem.writeFile).toHaveBeenCalled();
-    });
-  });
-
-  test('7. returns base64 after HTTP fetch', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
-    (Filesystem.readFile as jest.Mock).mockRejectedValue(new Error());
-    (CapacitorHttp.get as jest.Mock).mockResolvedValue({
-      data: 'blobdata',
-    });
-    (Filesystem.writeFile as jest.Mock).mockResolvedValue({});
-
-    render(<CachedImage src={testUrl} />);
-
-    await waitFor(() => {
-      expect(screen.getByRole('img')).toHaveAttribute(
-        'src',
-        'data:image/png;base64,blobdata',
-      );
-    });
-  });
-
-  /* ---------------- HTTP Failure ---------------- */
-
-  test('8. returns original URL if HTTP fails', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
-    (Filesystem.readFile as jest.Mock).mockRejectedValue(new Error());
-    (CapacitorHttp.get as jest.Mock).mockRejectedValue(new Error());
-
-    render(<CachedImage src={testUrl} />);
-
-    await waitFor(() => {
-      expect(screen.getByRole('img')).toHaveAttribute('src', testUrl);
-    });
-  });
-
-  test('9. logs error on HTTP failure', async () => {
-    logger.error = jest.fn();
-
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
-    (Filesystem.readFile as jest.Mock).mockRejectedValue(new Error());
-    (CapacitorHttp.get as jest.Mock).mockRejectedValue(new Error());
-
-    render(<CachedImage src={testUrl} />);
-
-    await waitFor(() => {
-      expect(logger.error).toHaveBeenCalled();
-    });
-  });
-
-  /* ---------------- Edge Cases ---------------- */
-
-  test('10. renders empty div if no src', () => {
-    render(<CachedImage />);
+    expect(container.firstChild).toHaveClass('thumb');
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveImage('capacitor://cached-image');
+    });
+
+    const image = await screen.findByRole('img');
+    expect(image).toHaveAttribute('src', 'capacitor://cached-image');
+    expect(image).toHaveAttribute('loading', 'lazy');
   });
 
-  test('11. updates when src changes', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(false);
+  it('passes through local or empty sources unchanged', async () => {
+    (getCachedImageSrc as jest.Mock).mockResolvedValueOnce('/assets/icon.png');
 
-    const { rerender } = render(<CachedImage src="url1" />);
-    rerender(<CachedImage src="url2" />);
+    render(<CachedImage src="/assets/icon.png" alt="Example" />);
 
-    await waitFor(() => {
-      expect(screen.getByRole('img')).toHaveAttribute('src', 'url2');
-    });
+    const image = await screen.findByRole('img');
+    expect(image).toHaveAttribute('src', '/assets/icon.png');
+    expect(image).toHaveAttribute('alt', 'Example');
   });
 
-  test('12. alt equals imgSrc', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(false);
-
-    render(<CachedImage src={testUrl} />);
-
-    await waitFor(() => {
-      const img = screen.getByRole('img');
-      expect(img).toHaveAttribute('alt', testUrl);
-    });
-  });
-
-  test('13. loading attribute is lazy', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(false);
-
-    render(<CachedImage src={testUrl} />);
-
-    await waitFor(() => {
-      expect(screen.getByRole('img')).toHaveAttribute('loading', 'lazy');
-    });
-  });
-
-  test('14. handles writeFile failure gracefully', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
-    (Filesystem.readFile as jest.Mock).mockRejectedValue(new Error());
-    (CapacitorHttp.get as jest.Mock).mockResolvedValue({
-      data: 'blobdata',
-    });
-    (Filesystem.writeFile as jest.Mock).mockRejectedValue(new Error());
-
-    render(<CachedImage src={testUrl} />);
-
-    await waitFor(() => {
-      expect(screen.getByRole('img')).toBeInTheDocument();
-    });
-  });
-
-  /* 15–30 Additional Coverage */
-
-  test('15. readFile called with correct path', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
-    (Filesystem.readFile as jest.Mock).mockRejectedValue(new Error());
-
-    render(<CachedImage src={testUrl} />);
-
-    await waitFor(() => {
-      expect(Filesystem.readFile).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: expect.stringContaining('https:--example.com-image.png'),
-        }),
-      );
-    });
-  });
-
-  test('16. http called with correct url', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
-    (Filesystem.readFile as jest.Mock).mockRejectedValue(new Error());
-    (CapacitorHttp.get as jest.Mock).mockResolvedValue({ data: 'blob' });
-    (Filesystem.writeFile as jest.Mock).mockResolvedValue({});
-
-    render(<CachedImage src={testUrl} />);
-
-    await waitFor(() => {
-      expect(CapacitorHttp.get).toHaveBeenCalledWith(
-        expect.objectContaining({ url: testUrl }),
-      );
-    });
-  });
-
-  test('17-30. component mounts/unmounts cleanly', async () => {
-    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(false);
-
-    for (let i = 0; i < 14; i++) {
-      const { unmount } = render(<CachedImage src={testUrl} />);
-      unmount();
-    }
-
-    expect(true).toBe(true);
+  it('renders an empty div when src is missing', () => {
+    const { container } = render(<CachedImage />);
+    expect(container.firstChild).toBeInstanceOf(HTMLDivElement);
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
 });

--- a/src/components/common/CachedImage.tsx
+++ b/src/components/common/CachedImage.tsx
@@ -1,16 +1,46 @@
 import { ImgHTMLAttributes, useEffect, useState } from 'react';
-import { getCachedImageSrc } from '../../utility/imageCache';
+import { getCachedImageSrc, isLocalImageUrl } from '../../utility/imageCache';
+import { Capacitor } from '@capacitor/core';
+
+const shouldBypassCache = (src?: string): boolean => {
+  if (!src) {
+    return false;
+  }
+
+  return !Capacitor.isNativePlatform() || isLocalImageUrl(src);
+};
 
 function CachedImage(props: ImgHTMLAttributes<HTMLImageElement>) {
   const { src, alt, ...imgProps } = props;
-  const [localSrc, setLocalSrc] = useState<string>();
-  const [isLoading, setIsLoading] = useState<boolean>(!!src);
+  const bypassCache = src ? shouldBypassCache(src) : false;
+  const [localSrc, setLocalSrc] = useState<string | undefined>(() => {
+    if (!src) {
+      return undefined;
+    }
+
+    return bypassCache ? src : undefined;
+  });
+  const [isLoading, setIsLoading] = useState<boolean>(() => {
+    if (!src) {
+      return false;
+    }
+
+    return !bypassCache;
+  });
 
   useEffect(() => {
     let isMounted = true;
 
     if (!src) {
       setLocalSrc(undefined);
+      setIsLoading(false);
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    if (bypassCache) {
+      setLocalSrc(src);
       setIsLoading(false);
       return () => {
         isMounted = false;
@@ -41,10 +71,14 @@ function CachedImage(props: ImgHTMLAttributes<HTMLImageElement>) {
     return () => {
       isMounted = false;
     };
-  }, [src]);
+  }, [src, bypassCache]);
 
   if (!src) {
     return <div />;
+  }
+
+  if (bypassCache) {
+    return <img loading="lazy" {...imgProps} src={src} alt={alt ?? src} />;
   }
 
   if (isLoading || !localSrc) {

--- a/src/components/common/CachedImage.tsx
+++ b/src/components/common/CachedImage.tsx
@@ -1,62 +1,62 @@
 import { ImgHTMLAttributes, useEffect, useState } from 'react';
-import { Capacitor, CapacitorHttp } from '@capacitor/core';
-import { Filesystem, Directory } from '@capacitor/filesystem';
-import { CACHE_IMAGE } from '../../common/constants';
-import logger from '../../utility/logger';
+import { getCachedImageSrc } from '../../utility/imageCache';
 
 function CachedImage(props: ImgHTMLAttributes<HTMLImageElement>) {
-  const [imgSrc, setImgSrc] = useState<string>();
+  const { src, alt, ...imgProps } = props;
+  const [localSrc, setLocalSrc] = useState<string>();
+  const [isLoading, setIsLoading] = useState<boolean>(!!src);
 
-  async function getCachedImage(url: string): Promise<string> {
-    if (!Capacitor.isNativePlatform()) return url;
-    try {
-      const result = await Filesystem.readFile({
-        path: CACHE_IMAGE + '/' + url.replaceAll('/', '-'),
-        directory: Directory.Cache,
-      });
-      return 'data:image/png;base64,' + result.data;
-    } catch (error) {
-      try {
-        // retrieve the image
-        const response = await CapacitorHttp.get({
-          url: url,
-          responseType: 'blob',
-        });
-        const blob = await response.data;
-        await Filesystem.writeFile({
-          path: CACHE_IMAGE + '/' + url.replaceAll('/', '-'),
-          data: blob,
-          directory: Directory.Cache,
-        });
-        return 'data:image/png;base64,' + blob;
-      } catch (error) {
-        logger.error(
-          '🚀 ~ file: util.ts:698 ~ getCachedImage ~ error:',
-          JSON.stringify(error),
-        );
-        return url;
-      }
-    }
-  }
   useEffect(() => {
-    if (!!props.src) {
-      getCachedImage(props.src)
-        .then((src) => {
-          setImgSrc(src);
-        })
-        .catch((error) => {
-          logger.error(
-            '🚀 ~ file: CachedImage.tsx:14 ~ useEffect ~ error:',
-            JSON.stringify(error),
-          );
-          setImgSrc(props.src);
-        });
+    let isMounted = true;
+
+    if (!src) {
+      setLocalSrc(undefined);
+      setIsLoading(false);
+      return () => {
+        isMounted = false;
+      };
     }
-  }, [props]);
-  return !!imgSrc ? (
-    <img loading="lazy" {...props} src={imgSrc} alt={imgSrc} />
-  ) : (
-    <div></div>
-  );
+
+    setIsLoading(true);
+    setLocalSrc(undefined);
+
+    void getCachedImageSrc(src)
+      .then((resolvedSrc) => {
+        if (!isMounted) {
+          return;
+        }
+
+        setLocalSrc(resolvedSrc);
+        setIsLoading(false);
+      })
+      .catch(() => {
+        if (!isMounted) {
+          return;
+        }
+
+        setLocalSrc(src);
+        setIsLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [src]);
+
+  if (!src) {
+    return <div />;
+  }
+
+  if (isLoading || !localSrc) {
+    return (
+      <div
+        className={imgProps.className}
+        style={imgProps.style}
+        aria-hidden="true"
+      />
+    );
+  }
+
+  return <img loading="lazy" {...imgProps} src={localSrc} alt={alt ?? src} />;
 }
 export default CachedImage;

--- a/src/components/displaySubjects/SelectChapter.tsx
+++ b/src/components/displaySubjects/SelectChapter.tsx
@@ -51,6 +51,7 @@ const SelectChapter: FC<{
                     localSrc={`courses/${course.code}/icons/${chapter.id}.webp`}
                     defaultSrc={'assets/icons/DefaultIcon.png'}
                     webSrc={chapter.image || 'assets/icons/DefaultIcon.png'}
+                    enableOfflineDownload={true}
                     imageWidth={'100%'}
                     imageHeight={'auto'}
                   />

--- a/src/components/displaySubjects/SelectIconImage.tsx
+++ b/src/components/displaySubjects/SelectIconImage.tsx
@@ -1,10 +1,12 @@
 import { FC, useEffect, useRef, useState } from 'react';
 import './SelectIconImage.css';
+import CachedImage from '../common/CachedImage';
 import {
   downloadCourseIconToDevice,
   getCachedCourseIconUri,
   getCachedCourseIconUriSync,
 } from '../../utility/courseIconDeviceCache';
+import logger from '../../utility/logger';
 
 interface SelectIconImageProps {
   localSrc?: string;
@@ -91,10 +93,19 @@ const SelectIconImage: FC<SelectIconImageProps> = ({
     }
 
     setIsLocalLookupResolved(false);
+    logger.warn('[SelectIconImage] resolving local source', {
+      localSrc,
+      webSrc,
+      enableOfflineDownload,
+    });
 
     // Resolve local icon path to on-device file URI when it already exists.
     const syncCachedUri = getCachedCourseIconUriSync(localSrc);
     if (syncCachedUri) {
+      logger.warn('[SelectIconImage] local cache sync hit', {
+        localSrc,
+        syncCachedUri,
+      });
       setDownloadedLocalSrc(syncCachedUri);
       setIsLocalLookupResolved(true);
       return () => {
@@ -110,6 +121,10 @@ const SelectIconImage: FC<SelectIconImageProps> = ({
         }
 
         if (cachedUri) {
+          logger.warn('[SelectIconImage] local cache hit', {
+            localSrc,
+            cachedUri,
+          });
           setDownloadedLocalSrc(cachedUri);
         }
         setIsLocalLookupResolved(true);
@@ -118,6 +133,7 @@ const SelectIconImage: FC<SelectIconImageProps> = ({
         if (!isMounted) {
           return;
         }
+        logger.warn('[SelectIconImage] local cache miss', { localSrc });
         setIsLocalLookupResolved(true);
       });
 
@@ -180,6 +196,30 @@ const SelectIconImage: FC<SelectIconImageProps> = ({
   }, [localSrc, webSrc, downloadedLocalSrc, defaultSrc, isLocalLookupResolved]);
 
   useEffect(() => {
+    if (!activeSrc) {
+      return;
+    }
+
+    const renderSourceKind =
+      activeSrc.startsWith('file:') ||
+      activeSrc.startsWith('capacitor:') ||
+      activeSrc.includes('/_capacitor_file_/')
+        ? 'local-file'
+        : activeSrc.startsWith('http')
+          ? 'remote'
+          : 'asset-or-other';
+
+    logger.warn('[SelectIconImage] render source state', {
+      localSrc,
+      webSrc,
+      activeSrc,
+      downloadedLocalSrc,
+      isLocalLookupResolved,
+      renderSourceKind,
+    });
+  }, [activeSrc, downloadedLocalSrc, isLocalLookupResolved, localSrc, webSrc]);
+
+  useEffect(() => {
     if (disableLoader) {
       setShowLoader(false);
       return;
@@ -239,12 +279,25 @@ const SelectIconImage: FC<SelectIconImageProps> = ({
     }
 
     if (enableOfflineDownload && webSrc && localSrc && activeSrc === webSrc) {
+      logger.warn('[SelectIconImage] backing up remote image to device', {
+        localSrc,
+        webSrc,
+      });
       void downloadCourseIconToDevice(localSrc, webSrc).then(
         (downloadedUri) => {
           if (!downloadedUri) {
+            logger.warn('[SelectIconImage] remote backup download skipped', {
+              localSrc,
+              webSrc,
+            });
             return;
           }
 
+          logger.warn('[SelectIconImage] remote backup download complete', {
+            localSrc,
+            webSrc,
+            downloadedUri,
+          });
           setDownloadedLocalSrc(downloadedUri);
         },
       );
@@ -273,10 +326,19 @@ const SelectIconImage: FC<SelectIconImageProps> = ({
     ) {
       hasRetriedBeforeDefaultRef.current = true;
       setIsLoading(true);
+      logger.warn('[SelectIconImage] retrying remote backup before default', {
+        localSrc,
+        webSrc,
+      });
 
       void downloadCourseIconToDevice(localSrc, webSrc, true)
         .then((downloadedUri) => {
           if (downloadedUri) {
+            logger.warn('[SelectIconImage] retry download complete', {
+              localSrc,
+              webSrc,
+              downloadedUri,
+            });
             setDownloadedLocalSrc(downloadedUri);
             setActiveSrc(downloadedUri);
 
@@ -286,12 +348,25 @@ const SelectIconImage: FC<SelectIconImageProps> = ({
             return;
           }
 
+          logger.warn('[SelectIconImage] falling back to default src', {
+            localSrc,
+            webSrc,
+            defaultSrc,
+          });
           setActiveSrc(defaultSrc);
           if (isImageReady(defaultSrc)) {
             finishLoadingImmediately();
           }
         })
         .catch(() => {
+          logger.warn(
+            '[SelectIconImage] retry download failed, using default',
+            {
+              localSrc,
+              webSrc,
+              defaultSrc,
+            },
+          );
           setActiveSrc(defaultSrc);
           if (isImageReady(defaultSrc)) {
             finishLoadingImmediately();
@@ -333,7 +408,7 @@ const SelectIconImage: FC<SelectIconImageProps> = ({
         </div>
       )}
       {activeSrc && (
-        <img
+        <CachedImage
           src={activeSrc}
           alt=""
           className={`select-icon-image ${!isLoading ? 'imageLoaded' : ''}`}

--- a/src/hooks/usePathwaySVG.ts
+++ b/src/hooks/usePathwaySVG.ts
@@ -525,8 +525,30 @@ export function usePathwaySVG({
         }
       }
 
+      const resolvedLessonImageUrls = await Promise.all(
+        lessons.map(async (lesson) => {
+          const isValidUrl =
+            typeof lesson.image === 'string' &&
+            /^(https?:\/\/|\/)/.test(lesson.image);
+          const lessonImageUrl = isValidUrl
+            ? (lesson.image ?? 'assets/icons/DefaultIcon.png')
+            : 'assets/icons/DefaultIcon.png';
+
+          return await getCachedImageSrc(lessonImageUrl);
+        }),
+      );
+      const resolvedHaloSrc =
+        typeof halo === 'string' ? await getCachedImageSrc(halo) : null;
+      const resolvedPointerSrc = await getCachedImageSrc(
+        '/pathwayAssets/touchpointer.svg',
+      );
+      const resolvedStickerImageSrc =
+        typeof stickerPreviewPayload?.nextStickerImage === 'string'
+          ? await getCachedImageSrc(stickerPreviewPayload.nextStickerImage)
+          : null;
+
       // Build SVG in next frame to keep main thread responsive
-      requestAnimationFrame(async () => {
+      requestAnimationFrame(() => {
         if (!containerRef.current) {
           stopPathwayLoading();
           return;
@@ -623,19 +645,9 @@ export function usePathwaySVG({
           const isActive =
             startIndex + idx === currentIndex && activeIndex !== -1;
 
-          const isValidUrl =
-            typeof lesson.image === 'string' &&
-            /^(https?:\/\/|\/)/.test(lesson.image);
-
           logger.warn('lesson image:', lesson.image);
-          const lessonImageUrl =
-            isPlayed || isActive
-              ? isValidUrl
-                ? lesson.image
-                : 'assets/icons/DefaultIcon.png'
-              : 'assets/icons/NextNodeIcon.svg';
           const resolvedLessonImageUrl =
-            await getCachedImageSrc(lessonImageUrl);
+            resolvedLessonImageUrls[idx] ?? 'assets/icons/DefaultIcon.png';
 
           const positionMappings = {
             playedLesson: {
@@ -687,7 +699,7 @@ export function usePathwaySVG({
             // halo
             if (typeof halo === 'string') {
               const haloImg = createSVGImage(
-                await getCachedImageSrc(halo),
+                resolvedHaloSrc || halo,
                 140,
                 140,
                 -15,
@@ -718,7 +730,7 @@ export function usePathwaySVG({
             activeGroup.appendChild(lessonImage);
 
             const pointer = createSVGImage(
-              await getCachedImageSrc('/pathwayAssets/touchpointer.svg'),
+              resolvedPointerSrc,
               35,
               35,
               85,
@@ -886,9 +898,7 @@ export function usePathwaySVG({
 
           rewardGroup.appendChild(bg);
           // Reuse the same resolved sticker image that powers the preview modal.
-          if (nextStickerImageSrc) {
-            const resolvedStickerImageSrc =
-              await getCachedImageSrc(nextStickerImageSrc);
+          if (resolvedStickerImageSrc) {
             rewardGroup.appendChild(
               createSVGImage(
                 resolvedStickerImageSrc,
@@ -1042,8 +1052,10 @@ export function usePathwaySVG({
 
         if (shouldSkipRewardAnimationForSticker) {
           setHasTodayReward(false);
-          await updateMascotToNormalState(newRewardIdFromCheck as string);
-          await Util.updateUserReward();
+          void (async () => {
+            await updateMascotToNormalState(newRewardIdFromCheck as string);
+            await Util.updateUserReward();
+          })();
         }
 
         if (shouldRunRewardAnimation) {

--- a/src/hooks/usePathwaySVG.ts
+++ b/src/hooks/usePathwaySVG.ts
@@ -34,6 +34,7 @@ import { setCachedGrowthBookFeatureValue } from '../growthbook/Growthbook';
 import { useAppSelector } from '../redux/hooks';
 import { t } from 'i18next';
 import { getCachedImageSrc } from '../utility/imageCache';
+import { mapInBatches } from '../utility/batch';
 
 interface UsePathwaySVGParams {
   containerRef: RefObject<HTMLDivElement | null>;
@@ -525,8 +526,10 @@ export function usePathwaySVG({
         }
       }
 
-      const resolvedLessonImageUrls = await Promise.all(
-        lessons.map(async (lesson) => {
+      const resolvedLessonImageUrls = await mapInBatches(
+        lessons,
+        5,
+        async (lesson) => {
           const isValidUrl =
             typeof lesson.image === 'string' &&
             /^(https?:\/\/|\/)/.test(lesson.image);
@@ -535,7 +538,7 @@ export function usePathwaySVG({
             : 'assets/icons/DefaultIcon.png';
 
           return await getCachedImageSrc(lessonImageUrl);
-        }),
+        },
       );
       const resolvedHaloSrc =
         typeof halo === 'string' ? await getCachedImageSrc(halo) : null;

--- a/src/hooks/usePathwaySVG.ts
+++ b/src/hooks/usePathwaySVG.ts
@@ -33,6 +33,7 @@ import { fetchStickerBookSvgText } from '../utility/stickerBookAssets';
 import { setCachedGrowthBookFeatureValue } from '../growthbook/Growthbook';
 import { useAppSelector } from '../redux/hooks';
 import { t } from 'i18next';
+import { getCachedImageSrc } from '../utility/imageCache';
 
 interface UsePathwaySVGParams {
   containerRef: RefObject<HTMLDivElement | null>;
@@ -610,7 +611,8 @@ export function usePathwaySVG({
           return flower_Inactive;
         };
         // Build lesson nodes
-        lessons.forEach((lesson: any, idx: number) => {
+        for (let idx = 0; idx < lessons.length; idx += 1) {
+          const lesson = lessons[idx];
           const path = paths[idx];
           const point = path.getPointAtLength(0);
           const flowerX = point.x - 40;
@@ -625,12 +627,15 @@ export function usePathwaySVG({
             typeof lesson.image === 'string' &&
             /^(https?:\/\/|\/)/.test(lesson.image);
 
+          logger.warn('lesson image:', lesson.image);
           const lessonImageUrl =
             isPlayed || isActive
               ? isValidUrl
                 ? lesson.image
                 : 'assets/icons/DefaultIcon.png'
               : 'assets/icons/NextNodeIcon.svg';
+          const resolvedLessonImageUrl =
+            await getCachedImageSrc(lessonImageUrl);
 
           const positionMappings = {
             playedLesson: {
@@ -649,7 +654,13 @@ export function usePathwaySVG({
               'http://www.w3.org/2000/svg',
               'g',
             );
-            const lessonImage = createSVGImage(lessonImageUrl, 30, 30, 28, 30);
+            const lessonImage = createSVGImage(
+              resolvedLessonImageUrl,
+              30,
+              30,
+              28,
+              30,
+            );
             playedLesson.appendChild(
               playedLessonSVG.cloneNode(true) as SVGGElement,
             );
@@ -675,7 +686,13 @@ export function usePathwaySVG({
 
             // halo
             if (typeof halo === 'string') {
-              const haloImg = createSVGImage(halo, 140, 140, -15, -12);
+              const haloImg = createSVGImage(
+                await getCachedImageSrc(halo),
+                140,
+                140,
+                -15,
+                -12,
+              );
               activeGroup.appendChild(haloImg);
             } else {
               const haloNode = halo.cloneNode(true) as
@@ -688,14 +705,20 @@ export function usePathwaySVG({
               activeGroup.appendChild(haloNode);
             }
 
-            const lessonImage = createSVGImage(lessonImageUrl, 30, 30, 40, 40);
+            const lessonImage = createSVGImage(
+              resolvedLessonImageUrl,
+              30,
+              30,
+              40,
+              40,
+            );
             activeGroup.appendChild(
               flowerActive.cloneNode(true) as SVGGElement,
             );
             activeGroup.appendChild(lessonImage);
 
             const pointer = createSVGImage(
-              '/pathwayAssets/touchpointer.svg',
+              await getCachedImageSrc('/pathwayAssets/touchpointer.svg'),
               35,
               35,
               85,
@@ -723,8 +746,7 @@ export function usePathwaySVG({
             );
           }
           lastIndex = idx;
-        });
-
+        }
         for (let i = lastIndex + 1; i < PATH_SIZE; i++) {
           const path = paths[i];
           const point = path.getPointAtLength(0);
@@ -865,9 +887,11 @@ export function usePathwaySVG({
           rewardGroup.appendChild(bg);
           // Reuse the same resolved sticker image that powers the preview modal.
           if (nextStickerImageSrc) {
+            const resolvedStickerImageSrc =
+              await getCachedImageSrc(nextStickerImageSrc);
             rewardGroup.appendChild(
               createSVGImage(
-                nextStickerImageSrc,
+                resolvedStickerImageSrc,
                 contentWidth,
                 contentHeight,
                 horizontalPadding,
@@ -1361,13 +1385,15 @@ export function usePathwaySVG({
   };
 
   async function preloadAllLessonImages(lessons: any[]) {
-    Promise.all(
-      lessons.map((lesson) => {
+    await Promise.all(
+      lessons.map(async (lesson) => {
+        logger.warn('lesson image:', lesson.image);
         const isValidUrl =
           typeof lesson.image === 'string' &&
           /^(https?:\/\/|\/)/.test(lesson.image);
         const src = isValidUrl ? lesson.image : 'assets/icons/DefaultIcon.png';
-        return preloadImage(src);
+        const resolvedSrc = await getCachedImageSrc(src);
+        return preloadImage(resolvedSrc);
       }),
     );
   }

--- a/src/teachers-module/components/DisplaySubjects.tsx
+++ b/src/teachers-module/components/DisplaySubjects.tsx
@@ -3,6 +3,7 @@ import { t } from 'i18next';
 import { checkmarkCircle } from 'ionicons/icons';
 import React, { useEffect, useState } from 'react';
 import { TableTypes } from '../../common/constants';
+import CachedImage from '../../components/common/CachedImage';
 import { RoleType } from '../../interface/modelInterfaces';
 import logger from '../../utility/logger';
 import { schoolUtil } from '../../utility/schoolUtil';
@@ -110,7 +111,7 @@ const DisplaySubjects: React.FC<DisplaySubjectsProps> = ({
                   style={{ cursor: canModify ? 'pointer' : 'not-allowed' }}
                 >
                   <div className="display-subject-name">
-                    <img
+                    <CachedImage
                       src={course?.image || 'assets/icons/DefaultIcon.png'}
                       alt={course.name || 'Default Subject Icon'}
                       className="subject-icon-in-display-subject-page"

--- a/src/teachers-module/components/SubjectSelectionComponent.tsx
+++ b/src/teachers-module/components/SubjectSelectionComponent.tsx
@@ -4,6 +4,7 @@ import { checkmarkCircle, ellipseOutline } from 'ionicons/icons';
 import './SubjectSelectionComponent.css';
 import { t } from 'i18next';
 import logger from '../../utility/logger';
+import CachedImage from '../../components/common/CachedImage';
 
 interface SubjectSelectionProps {
   curriculumsWithCourses: {
@@ -68,7 +69,7 @@ const SubjectSelectionComponent: React.FC<SubjectSelectionProps> = ({
             return (
               <div key={course.id} className="subject-item">
                 <div className="subject-selection-div">
-                  <img
+                  <CachedImage
                     src={course?.image || 'assets/icons/DefaultIcon.png'}
                     alt={course.name || 'Default Subject Icon'}
                     className="subject-icon"

--- a/src/teachers-module/components/imageDropdown.tsx
+++ b/src/teachers-module/components/imageDropdown.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { MenuItem, Select, SelectChangeEvent } from '@mui/material';
 import './imageDropdown.css';
 import { t } from 'i18next';
+import CachedImage from '../../components/common/CachedImage';
 
 interface DropdownOption {
   id: string | number;
@@ -60,7 +61,7 @@ const ImageDropdown: React.FC<ImageDropdownProps> = ({
             selectedValue?.id ? (
               <div className="imageDropdown-selected">
                 {selectedValue.icon && (
-                  <img
+                  <CachedImage
                     src={selectedValue.icon}
                     alt={selectedValue.name}
                     className="imageDropdown-icon"
@@ -70,7 +71,7 @@ const ImageDropdown: React.FC<ImageDropdownProps> = ({
               </div>
             ) : (
               <div className="placeholder">
-                <img
+                <CachedImage
                   src={options[0]?.icon || ''}
                   alt="placeholder-icon"
                   className="imageDropdown-icon"
@@ -98,7 +99,7 @@ const ImageDropdown: React.FC<ImageDropdownProps> = ({
               className="menu-item-in-image-dropdown"
             >
               {option.icon && (
-                <img
+                <CachedImage
                   src={option.icon}
                   alt={option.name}
                   className="imageDropdown-icon"

--- a/src/teachers-module/pages/SubjectSelection.tsx
+++ b/src/teachers-module/pages/SubjectSelection.tsx
@@ -21,6 +21,7 @@ import { useAppSelector } from '../../redux/hooks';
 import { AuthState } from '../../redux/slices/auth/authSlice';
 import { RootState } from '../../redux/store';
 import logger from '../../utility/logger';
+import { getCachedImageSrc } from '../../utility/imageCache';
 
 interface CurriculumWithCourses {
   curriculum: { id: string; name: string; grade?: string };
@@ -282,14 +283,15 @@ const SubjectSelection: React.FC = () => {
     }
     return connectedClasses;
   }
-  const generateCourseHTML = (
+  const generateCourseHTML = async (
     curriculumImage: string,
     courseName: string,
     className: string,
-  ): string => {
+  ): Promise<string> => {
+    const cachedCurriculumImage = await getCachedImageSrc(curriculumImage);
     return `
       <div class="course-item">
-        <img src="${curriculumImage}" alt="Curriculum Image" />
+        <img src="${cachedCurriculumImage}" alt="Curriculum Image" />
         <span>${courseName} — ${className}</span>
       </div>`;
   };
@@ -345,18 +347,18 @@ const SubjectSelection: React.FC = () => {
             ),
           );
 
-          const courseDisplayNames = coursesThatCannotBeRemoved.map(
-            (entry, index) => {
+          const courseDisplayNames = await Promise.all(
+            coursesThatCannotBeRemoved.map(async (entry, index) => {
               const courseName = courseDetails[index]?.name || 'Unknown Course';
               const curriculumName =
                 curriculumDetails[index]?.name || 'Unknown Curriculum';
               const curriculumImage = curriculumDetails[index]?.image || '';
-              return generateCourseHTML(
+              return await generateCourseHTML(
                 curriculumImage,
                 courseName,
                 entry.className,
               ); // Return the HTML here
-            },
+            }),
           );
 
           setAlertState({
@@ -491,7 +493,7 @@ const SubjectSelection: React.FC = () => {
             courseDetails?.curriculum_id ?? '',
           );
           const curriculumImage = curriculumDetails?.image || '';
-          const courseDisplayName = generateCourseHTML(
+          const courseDisplayName = await generateCourseHTML(
             curriculumImage,
             courseDetails?.name || 'Unknown Course',
             connectedClasses[0]?.name,

--- a/src/utility/batch.ts
+++ b/src/utility/batch.ts
@@ -1,0 +1,18 @@
+export const mapInBatches = async <Input, Output>(
+  items: Input[],
+  batchSize: number,
+  mapper: (item: Input, index: number) => Promise<Output>,
+): Promise<Output[]> => {
+  const resolvedItems: Output[] = [];
+
+  for (let startIndex = 0; startIndex < items.length; startIndex += batchSize) {
+    const batch = items.slice(startIndex, startIndex + batchSize);
+    const resolvedBatch = await Promise.all(
+      batch.map((item, batchIndex) => mapper(item, startIndex + batchIndex)),
+    );
+
+    resolvedItems.push(...resolvedBatch);
+  }
+
+  return resolvedItems;
+};

--- a/src/utility/imageCache.test.ts
+++ b/src/utility/imageCache.test.ts
@@ -27,6 +27,9 @@ describe('imageCache', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
+    (Capacitor.convertFileSrc as jest.Mock).mockImplementation(
+      (uri: string) => `converted:${uri}`,
+    );
   });
 
   it('returns the original URL for local or web-only paths', async () => {
@@ -84,26 +87,16 @@ describe('imageCache', () => {
 
   it('deduplicates simultaneous requests for the same URL', async () => {
     const cacheFileName = `${MD5(remoteUrl).toString()}.img`;
-    let resolveDownload: (() => void) | undefined;
 
     (Filesystem.stat as jest.Mock)
       .mockRejectedValueOnce(new Error('missing'))
       .mockResolvedValueOnce({
         uri: `file:///cache/image_cache/${cacheFileName}`,
       });
-    (Filesystem.downloadFile as jest.Mock).mockReturnValueOnce(
-      new Promise<void>((resolve) => {
-        resolveDownload = resolve;
-      }),
-    );
+    (Filesystem.downloadFile as jest.Mock).mockResolvedValueOnce({});
 
     const firstRequest = getCachedImageSrc(remoteUrl);
     const secondRequest = getCachedImageSrc(remoteUrl);
-
-    expect(Filesystem.stat).toHaveBeenCalledTimes(1);
-    expect(Filesystem.downloadFile).toHaveBeenCalledTimes(1);
-
-    resolveDownload?.();
 
     await expect(firstRequest).resolves.toBe(
       `converted:file:///cache/image_cache/${cacheFileName}`,
@@ -111,5 +104,8 @@ describe('imageCache', () => {
     await expect(secondRequest).resolves.toBe(
       `converted:file:///cache/image_cache/${cacheFileName}`,
     );
+
+    expect(Filesystem.stat).toHaveBeenCalledTimes(2);
+    expect(Filesystem.downloadFile).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/utility/imageCache.test.ts
+++ b/src/utility/imageCache.test.ts
@@ -1,0 +1,115 @@
+import { Capacitor } from '@capacitor/core';
+import { Directory, Filesystem } from '@capacitor/filesystem';
+import MD5 from 'crypto-js/md5';
+import { getCachedImageSrc } from './imageCache';
+
+jest.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: jest.fn(),
+    convertFileSrc: jest.fn((uri: string) => `converted:${uri}`),
+  },
+}));
+
+jest.mock('@capacitor/filesystem', () => ({
+  Directory: {
+    Cache: 'CACHE',
+  },
+  Filesystem: {
+    stat: jest.fn(),
+    mkdir: jest.fn(),
+    downloadFile: jest.fn(),
+  },
+}));
+
+describe('imageCache', () => {
+  const remoteUrl = 'https://cdn.example.com/images/course.png';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(true);
+  });
+
+  it('returns the original URL for local or web-only paths', async () => {
+    (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(false);
+
+    await expect(getCachedImageSrc('/assets/local.png')).resolves.toBe(
+      '/assets/local.png',
+    );
+    expect(Filesystem.stat).not.toHaveBeenCalled();
+  });
+
+  it('returns a cached file URI when the image already exists', async () => {
+    (Filesystem.stat as jest.Mock).mockResolvedValueOnce({
+      uri: 'file:///cache/image_cache/existing.img',
+    });
+
+    await expect(getCachedImageSrc(remoteUrl)).resolves.toBe(
+      'converted:file:///cache/image_cache/existing.img',
+    );
+
+    expect(Filesystem.downloadFile).not.toHaveBeenCalled();
+    expect(Capacitor.convertFileSrc).toHaveBeenCalledWith(
+      'file:///cache/image_cache/existing.img',
+    );
+  });
+
+  it('downloads and stores a missing image in the cache directory', async () => {
+    const cacheFileName = `${MD5(remoteUrl).toString()}.img`;
+    (Filesystem.stat as jest.Mock)
+      .mockRejectedValueOnce(new Error('missing'))
+      .mockResolvedValueOnce({
+        uri: `file:///cache/image_cache/${cacheFileName}`,
+      });
+    (Filesystem.downloadFile as jest.Mock).mockResolvedValueOnce({});
+
+    await expect(getCachedImageSrc(remoteUrl)).resolves.toBe(
+      `converted:file:///cache/image_cache/${cacheFileName}`,
+    );
+
+    expect(Filesystem.mkdir).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: 'image_cache',
+        directory: Directory.Cache,
+        recursive: true,
+      }),
+    );
+    expect(Filesystem.downloadFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: remoteUrl,
+        path: `image_cache/${cacheFileName}`,
+        directory: Directory.Cache,
+      }),
+    );
+  });
+
+  it('deduplicates simultaneous requests for the same URL', async () => {
+    const cacheFileName = `${MD5(remoteUrl).toString()}.img`;
+    let resolveDownload: (() => void) | undefined;
+
+    (Filesystem.stat as jest.Mock)
+      .mockRejectedValueOnce(new Error('missing'))
+      .mockResolvedValueOnce({
+        uri: `file:///cache/image_cache/${cacheFileName}`,
+      });
+    (Filesystem.downloadFile as jest.Mock).mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveDownload = resolve;
+      }),
+    );
+
+    const firstRequest = getCachedImageSrc(remoteUrl);
+    const secondRequest = getCachedImageSrc(remoteUrl);
+
+    expect(Filesystem.stat).toHaveBeenCalledTimes(1);
+    expect(Filesystem.downloadFile).toHaveBeenCalledTimes(1);
+
+    resolveDownload?.();
+
+    await expect(firstRequest).resolves.toBe(
+      `converted:file:///cache/image_cache/${cacheFileName}`,
+    );
+    await expect(secondRequest).resolves.toBe(
+      `converted:file:///cache/image_cache/${cacheFileName}`,
+    );
+  });
+});

--- a/src/utility/imageCache.ts
+++ b/src/utility/imageCache.ts
@@ -6,7 +6,7 @@ import logger from './logger';
 const IMAGE_CACHE_DIRECTORY = 'image_cache';
 const inflightDownloads = new Map<string, Promise<string>>();
 
-const isLocalImageUrl = (url: string): boolean => {
+export const isLocalImageUrl = (url: string): boolean => {
   return (
     url.startsWith('file:') ||
     url.startsWith('capacitor:') ||
@@ -84,14 +84,16 @@ export const getCachedImageSrc = async (url: string): Promise<string> => {
     return inflight;
   }
 
-  const request = resolveCachedRemoteImage(url).catch((error) => {
-    logger.warn('[imageCache] Falling back to remote image URL', error);
-    return url;
-  });
-
-  const trackedRequest = request.finally(() => {
-    inflightDownloads.delete(url);
-  });
+  const trackedRequest = (async () => {
+    try {
+      return await resolveCachedRemoteImage(url);
+    } catch (error) {
+      logger.warn('[imageCache] Falling back to remote image URL', error);
+      return url;
+    } finally {
+      inflightDownloads.delete(url);
+    }
+  })();
 
   inflightDownloads.set(url, trackedRequest);
   return trackedRequest;

--- a/src/utility/imageCache.ts
+++ b/src/utility/imageCache.ts
@@ -1,0 +1,98 @@
+import { Capacitor } from '@capacitor/core';
+import { Directory, Filesystem } from '@capacitor/filesystem';
+import MD5 from 'crypto-js/md5';
+import logger from './logger';
+
+const IMAGE_CACHE_DIRECTORY = 'image_cache';
+const inflightDownloads = new Map<string, Promise<string>>();
+
+const isLocalImageUrl = (url: string): boolean => {
+  return (
+    url.startsWith('file:') ||
+    url.startsWith('capacitor:') ||
+    url.startsWith('/assets/') ||
+    url.includes('/_capacitor_file_/')
+  );
+};
+
+const isRemoteImageUrl = (url: string): boolean =>
+  /^https?:\/\//i.test(url) && !isLocalImageUrl(url);
+
+const getCacheFileName = (url: string): string => `${MD5(url).toString()}.img`;
+
+const ensureCacheDirectory = async (): Promise<void> => {
+  try {
+    await Filesystem.mkdir({
+      path: IMAGE_CACHE_DIRECTORY,
+      directory: Directory.Cache,
+      recursive: true,
+    });
+  } catch {
+    // The directory may already exist.
+  }
+};
+
+const resolveCachedRemoteImage = async (url: string): Promise<string> => {
+  const filePath = `${IMAGE_CACHE_DIRECTORY}/${getCacheFileName(url)}`;
+
+  try {
+    logger.warn('[imageCache] checking cache', { url, filePath });
+    const stat = await Filesystem.stat({
+      path: filePath,
+      directory: Directory.Cache,
+    });
+
+    logger.warn('[imageCache] cache hit', { url, filePath, uri: stat.uri });
+    return Capacitor.convertFileSrc(stat.uri);
+  } catch {
+    logger.warn('[imageCache] cache miss, downloading', { url, filePath });
+    await ensureCacheDirectory();
+
+    await Filesystem.downloadFile({
+      url,
+      path: filePath,
+      directory: Directory.Cache,
+    });
+
+    const stat = await Filesystem.stat({
+      path: filePath,
+      directory: Directory.Cache,
+    });
+
+    logger.warn('[imageCache] download complete', {
+      url,
+      filePath,
+      uri: stat.uri,
+    });
+    return Capacitor.convertFileSrc(stat.uri);
+  }
+};
+
+export const getCachedImageSrc = async (url: string): Promise<string> => {
+  if (
+    !url ||
+    !Capacitor.isNativePlatform() ||
+    isLocalImageUrl(url) ||
+    !isRemoteImageUrl(url)
+  ) {
+    return url;
+  }
+
+  const inflight = inflightDownloads.get(url);
+  if (inflight) {
+    logger.warn('[imageCache] reusing in-flight request', { url });
+    return inflight;
+  }
+
+  const request = resolveCachedRemoteImage(url).catch((error) => {
+    logger.warn('[imageCache] Falling back to remote image URL', error);
+    return url;
+  });
+
+  const trackedRequest = request.finally(() => {
+    inflightDownloads.delete(url);
+  });
+
+  inflightDownloads.set(url, trackedRequest);
+  return trackedRequest;
+};


### PR DESCRIPTION
Introduce a native-safe image caching utility (src/utility/imageCache.ts) providing getCachedImageSrc with on-device download, cache-directory management, and in-flight deduplication, plus comprehensive tests (src/utility/imageCache.test.ts).

Refactor CachedImage to use getCachedImageSrc and update its tests to mock the new utility. Replace many direct <img> usages with CachedImage and/or call getCachedImageSrc where assets are resolved (components and hooks updated include DropdownMenu, HomeworkPathwayStructure, usePathwaySVG, SelectChapter, SelectIconImage, DisplaySubjects, SubjectSelectionComponent, imageDropdown, SubjectSelection, GenericPopUp). Add logging around cache resolution and download flows and adjust behavior to show placeholders while resolving.