### PR TITLE
fix: Add compact time picker and update schedule

### DIFF
--- a/src/ops-console/components/campaignSetup/CampaignCommunicationSchedule.test.tsx
+++ b/src/ops-console/components/campaignSetup/CampaignCommunicationSchedule.test.tsx
@@ -47,12 +47,12 @@ const renderSchedule = (props: RenderScheduleProps = {}) => {
 };
 
 const openMessageTimeMenu = async () => {
-  fireEvent.mouseDown(screen.getByLabelText('Message Time'));
+  fireEvent.click(screen.getByLabelText('Message Time'));
   await screen.findByRole('listbox');
 };
 
 const openPollTimeMenu = async () => {
-  fireEvent.mouseDown(screen.getByLabelText('Poll Time'));
+  fireEvent.click(screen.getByLabelText('Poll Time'));
   await screen.findByRole('listbox');
 };
 
@@ -77,6 +77,16 @@ describe('CampaignCommunicationSchedule', () => {
 
     expect(screen.getByLabelText('Message Time')).toBeInTheDocument();
     expect(screen.getByLabelText('Poll Time')).toBeInTheDocument();
+  });
+
+  it('opens the message time picker with keyboard activation', async () => {
+    renderSchedule();
+
+    fireEvent.keyDown(screen.getByLabelText('Message Time'), {
+      key: 'Enter',
+    });
+
+    expect(await screen.findByRole('listbox')).toBeInTheDocument();
   });
 
   it('renders compact message time picker columns when opened', async () => {

--- a/src/ops-console/components/campaignSetup/CampaignCommunicationSchedule.test.tsx
+++ b/src/ops-console/components/campaignSetup/CampaignCommunicationSchedule.test.tsx
@@ -56,6 +56,12 @@ const openPollTimeMenu = async () => {
   await screen.findByRole('listbox');
 };
 
+const selectTime = (hour: string, minute: string, meridiem: string) => {
+  fireEvent.click(screen.getByRole('option', { name: `Hour ${hour}` }));
+  fireEvent.click(screen.getByRole('option', { name: `Minute ${minute}` }));
+  fireEvent.click(screen.getByRole('option', { name: meridiem }));
+};
+
 describe('CampaignCommunicationSchedule', () => {
   it('renders the schedule heading text and helper note content', () => {
     renderSchedule();
@@ -73,47 +79,60 @@ describe('CampaignCommunicationSchedule', () => {
     expect(screen.getByLabelText('Poll Time')).toBeInTheDocument();
   });
 
-  it('renders all supplied message time options when the message select is opened', async () => {
+  it('renders compact message time picker columns when opened', async () => {
     renderSchedule();
 
     await openMessageTimeMenu();
 
-    for (const option of defaultTimeOptions) {
-      expect(screen.getByRole('option', { name: option })).toBeInTheDocument();
-    }
+    expect(screen.getByRole('option', { name: 'Hour 01' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Hour 12' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Minute 00' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Minute 59' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'AM' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'PM' })).toBeInTheDocument();
   });
 
-  it('renders all supplied poll time options when the poll select is opened', async () => {
+  it('renders compact poll time picker columns when opened', async () => {
     renderSchedule();
 
     await openPollTimeMenu();
 
-    for (const option of defaultTimeOptions) {
-      expect(screen.getByRole('option', { name: option })).toBeInTheDocument();
-    }
+    expect(screen.getByRole('option', { name: 'Hour 01' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Hour 12' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Minute 00' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Minute 59' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'AM' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'PM' })).toBeInTheDocument();
   });
 
   it('uses the provided message time value', () => {
     renderSchedule({ messageTime: '09:00 AM' });
 
     const messageSelect = screen.getByLabelText('Message Time');
-    expect(messageSelect).toHaveTextContent('09:00 AM');
+    expect(messageSelect).toHaveValue('09:00 AM');
   });
 
   it('uses the provided poll time value', () => {
     renderSchedule({ pollTime: '06:00 PM' });
 
     const pollSelect = screen.getByLabelText('Poll Time');
-    expect(pollSelect).toHaveTextContent('06:00 PM');
+    expect(pollSelect).toHaveValue('06:00 PM');
   });
 
   it('calls onMessageTimeChange with the selected option value', async () => {
     const { onMessageTimeChange } = renderSchedule();
 
     await openMessageTimeMenu();
-    fireEvent.click(screen.getByRole('option', { name: '09:30 AM' }));
+    selectTime('09', '30', 'AM');
 
-    expect(onMessageTimeChange).toHaveBeenCalledTimes(1);
     expect(onMessageTimeChange).toHaveBeenCalledWith('09:30 AM');
   });
 
@@ -121,9 +140,8 @@ describe('CampaignCommunicationSchedule', () => {
     const { onPollTimeChange } = renderSchedule();
 
     await openPollTimeMenu();
-    fireEvent.click(screen.getByRole('option', { name: '05:30 PM' }));
+    selectTime('05', '30', 'PM');
 
-    expect(onPollTimeChange).toHaveBeenCalledTimes(1);
     expect(onPollTimeChange).toHaveBeenCalledWith('05:30 PM');
   });
 
@@ -160,40 +178,32 @@ describe('CampaignCommunicationSchedule', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('supports a custom time option list for message selection', async () => {
+  it('keeps full hour and minute ranges for message selection', async () => {
     renderSchedule({
       timeOptions: ['07:15 AM', '11:45 AM', '03:15 PM'],
     });
 
     await openMessageTimeMenu();
 
+    expect(screen.getByRole('option', { name: 'Hour 07' })).toBeInTheDocument();
     expect(
-      screen.getByRole('option', { name: '07:15 AM' }),
+      screen.getByRole('option', { name: 'Minute 45' }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: '11:45 AM' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: '03:15 PM' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'PM' })).toBeInTheDocument();
   });
 
-  it('supports a custom time option list for poll selection', async () => {
+  it('keeps full hour and minute ranges for poll selection', async () => {
     renderSchedule({
       timeOptions: ['07:15 AM', '11:45 AM', '03:15 PM'],
     });
 
     await openPollTimeMenu();
 
+    expect(screen.getByRole('option', { name: 'Hour 07' })).toBeInTheDocument();
     expect(
-      screen.getByRole('option', { name: '07:15 AM' }),
+      screen.getByRole('option', { name: 'Minute 45' }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: '11:45 AM' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: '03:15 PM' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'PM' })).toBeInTheDocument();
   });
 
   it('preserves an already selected message value when rerendered with a new poll value', () => {
@@ -217,8 +227,8 @@ describe('CampaignCommunicationSchedule', () => {
       />,
     );
 
-    expect(screen.getByLabelText('Message Time')).toHaveTextContent('08:00 AM');
-    expect(screen.getByLabelText('Poll Time')).toHaveTextContent('06:00 PM');
+    expect(screen.getByLabelText('Message Time')).toHaveValue('08:00 AM');
+    expect(screen.getByLabelText('Poll Time')).toHaveValue('06:00 PM');
   });
 
   it('preserves an already selected poll value when rerendered with a new message value', () => {
@@ -242,8 +252,8 @@ describe('CampaignCommunicationSchedule', () => {
       />,
     );
 
-    expect(screen.getByLabelText('Message Time')).toHaveTextContent('09:00 AM');
-    expect(screen.getByLabelText('Poll Time')).toHaveTextContent('05:00 PM');
+    expect(screen.getByLabelText('Message Time')).toHaveValue('09:00 AM');
+    expect(screen.getByLabelText('Poll Time')).toHaveValue('05:00 PM');
   });
 
   it('updates the displayed message value after rerender', () => {
@@ -267,7 +277,7 @@ describe('CampaignCommunicationSchedule', () => {
       />,
     );
 
-    expect(screen.getByLabelText('Message Time')).toHaveTextContent('10:00 AM');
+    expect(screen.getByLabelText('Message Time')).toHaveValue('10:00 AM');
   });
 
   it('updates the displayed poll value after rerender', () => {
@@ -291,7 +301,7 @@ describe('CampaignCommunicationSchedule', () => {
       />,
     );
 
-    expect(screen.getByLabelText('Poll Time')).toHaveTextContent('06:00 PM');
+    expect(screen.getByLabelText('Poll Time')).toHaveValue('06:00 PM');
   });
 
   it('updates the message validation text after rerender', () => {
@@ -430,12 +440,8 @@ describe('CampaignCommunicationSchedule', () => {
 
     await openMessageTimeMenu();
 
-    expect(
-      screen.getByRole('option', { name: '08:00 AM' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: '06:00 PM' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Hour 08' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'PM' })).toBeInTheDocument();
   });
 
   it('opens the poll menu multiple times without losing options', async () => {
@@ -446,12 +452,8 @@ describe('CampaignCommunicationSchedule', () => {
 
     await openPollTimeMenu();
 
-    expect(
-      screen.getByRole('option', { name: '08:00 AM' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: '06:00 PM' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Hour 08' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'PM' })).toBeInTheDocument();
   });
 
   it('renders duplicate note text for desktop and mobile note placements', () => {
@@ -467,7 +469,7 @@ describe('CampaignCommunicationSchedule', () => {
     const { onMessageTimeChange } = renderSchedule();
 
     await openMessageTimeMenu();
-    fireEvent.click(screen.getByRole('option', { name: '08:00 AM' }));
+    selectTime('08', '00', 'AM');
 
     expect(onMessageTimeChange).toHaveBeenCalledWith('08:00 AM');
   });
@@ -476,7 +478,7 @@ describe('CampaignCommunicationSchedule', () => {
     const { onMessageTimeChange } = renderSchedule();
 
     await openMessageTimeMenu();
-    fireEvent.click(screen.getByRole('option', { name: '06:00 PM' }));
+    selectTime('06', '00', 'PM');
 
     expect(onMessageTimeChange).toHaveBeenCalledWith('06:00 PM');
   });
@@ -485,7 +487,7 @@ describe('CampaignCommunicationSchedule', () => {
     const { onPollTimeChange } = renderSchedule();
 
     await openPollTimeMenu();
-    fireEvent.click(screen.getByRole('option', { name: '08:00 AM' }));
+    selectTime('08', '00', 'AM');
 
     expect(onPollTimeChange).toHaveBeenCalledWith('08:00 AM');
   });
@@ -494,7 +496,7 @@ describe('CampaignCommunicationSchedule', () => {
     const { onPollTimeChange } = renderSchedule();
 
     await openPollTimeMenu();
-    fireEvent.click(screen.getByRole('option', { name: '06:00 PM' }));
+    selectTime('06', '00', 'PM');
 
     expect(onPollTimeChange).toHaveBeenCalledWith('06:00 PM');
   });
@@ -503,7 +505,7 @@ describe('CampaignCommunicationSchedule', () => {
     renderSchedule({ timeOptions: [] });
 
     await openMessageTimeMenu();
-    expect(screen.queryAllByRole('option')).toHaveLength(0);
+    expect(screen.getAllByRole('option')).toHaveLength(74);
   });
 
   it('supports empty time option arrays in the poll select without crashing', async () => {
@@ -513,16 +515,16 @@ describe('CampaignCommunicationSchedule', () => {
       key: 'Escape',
     });
     await openPollTimeMenu();
-    expect(screen.queryAllByRole('option')).toHaveLength(0);
+    expect(screen.getAllByRole('option')).toHaveLength(74);
   });
 
   it('keeps callback wiring isolated between message and poll changes', async () => {
     const { onMessageTimeChange, onPollTimeChange } = renderSchedule();
 
     await openMessageTimeMenu();
-    fireEvent.click(screen.getByRole('option', { name: '09:00 AM' }));
+    selectTime('09', '00', 'AM');
 
-    expect(onMessageTimeChange).toHaveBeenCalledTimes(1);
+    expect(onMessageTimeChange).toHaveBeenLastCalledWith('09:00 AM');
     expect(onPollTimeChange).not.toHaveBeenCalled();
   });
 
@@ -530,9 +532,9 @@ describe('CampaignCommunicationSchedule', () => {
     const { onMessageTimeChange, onPollTimeChange } = renderSchedule();
 
     await openPollTimeMenu();
-    fireEvent.click(screen.getByRole('option', { name: '05:00 PM' }));
+    selectTime('05', '00', 'PM');
 
-    expect(onPollTimeChange).toHaveBeenCalledTimes(1);
+    expect(onPollTimeChange).toHaveBeenLastCalledWith('05:00 PM');
     expect(onMessageTimeChange).not.toHaveBeenCalled();
   });
 
@@ -542,8 +544,8 @@ describe('CampaignCommunicationSchedule', () => {
       pollTime: '06:00 PM',
     });
 
-    expect(screen.getByLabelText('Message Time')).toHaveTextContent('09:00 AM');
-    expect(screen.getByLabelText('Poll Time')).toHaveTextContent('06:00 PM');
+    expect(screen.getByLabelText('Message Time')).toHaveValue('09:00 AM');
+    expect(screen.getByLabelText('Poll Time')).toHaveValue('06:00 PM');
   });
 
   it('keeps the title visible when values and errors are both present', () => {
@@ -569,7 +571,7 @@ describe('CampaignCommunicationSchedule', () => {
     expect(screen.getByText('Poll Time')).toBeInTheDocument();
   });
 
-  it('accepts a long time option list and renders each supplied option', async () => {
+  it('renders the complete compact picker independently of supplied options', async () => {
     const longTimeOptions = [
       '12:00 AM',
       '12:30 AM',
@@ -587,9 +589,11 @@ describe('CampaignCommunicationSchedule', () => {
     renderSchedule({ timeOptions: longTimeOptions });
     await openMessageTimeMenu();
 
-    for (const option of longTimeOptions) {
-      expect(screen.getByRole('option', { name: option })).toBeInTheDocument();
-    }
+    expect(screen.getByRole('option', { name: 'Hour 12' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Minute 30' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'PM' })).toBeInTheDocument();
   });
 
   it('can switch from one message option to another across rerenders', async () => {
@@ -604,7 +608,7 @@ describe('CampaignCommunicationSchedule', () => {
       />,
     );
 
-    expect(screen.getByLabelText('Message Time')).toHaveTextContent('08:00 AM');
+    expect(screen.getByLabelText('Message Time')).toHaveValue('08:00 AM');
 
     rerender(
       <CampaignCommunicationSchedule
@@ -616,7 +620,7 @@ describe('CampaignCommunicationSchedule', () => {
       />,
     );
 
-    expect(screen.getByLabelText('Message Time')).toHaveTextContent('09:30 AM');
+    expect(screen.getByLabelText('Message Time')).toHaveValue('09:30 AM');
   });
 
   it('can switch from one poll option to another across rerenders', () => {
@@ -630,7 +634,7 @@ describe('CampaignCommunicationSchedule', () => {
       />,
     );
 
-    expect(screen.getByLabelText('Poll Time')).toHaveTextContent('05:00 PM');
+    expect(screen.getByLabelText('Poll Time')).toHaveValue('05:00 PM');
 
     rerender(
       <CampaignCommunicationSchedule
@@ -642,7 +646,7 @@ describe('CampaignCommunicationSchedule', () => {
       />,
     );
 
-    expect(screen.getByLabelText('Poll Time')).toHaveTextContent('06:00 PM');
+    expect(screen.getByLabelText('Poll Time')).toHaveValue('06:00 PM');
   });
 
   it('continues to render after many sequential rerenders', async () => {
@@ -675,12 +679,12 @@ describe('CampaignCommunicationSchedule', () => {
       );
     });
 
-    expect(screen.getByLabelText('Message Time')).toHaveTextContent('09:30 AM');
-    expect(screen.getByLabelText('Poll Time')).toHaveTextContent('05:00 PM');
+    expect(screen.getByLabelText('Message Time')).toHaveValue('09:30 AM');
+    expect(screen.getByLabelText('Poll Time')).toHaveValue('05:00 PM');
 
     await openMessageTimeMenu();
     expect(
-      screen.getByRole('option', { name: '09:30 AM' }),
+      screen.getByRole('option', { name: 'Minute 30' }),
     ).toBeInTheDocument();
   });
 
@@ -692,12 +696,10 @@ describe('CampaignCommunicationSchedule', () => {
 
     await screen.findByText('Global Send Schedule');
     await waitFor(() =>
-      expect(screen.getByLabelText('Message Time')).toHaveTextContent(
-        '09:00 AM',
-      ),
+      expect(screen.getByLabelText('Message Time')).toHaveValue('09:00 AM'),
     );
     await waitFor(() =>
-      expect(screen.getByLabelText('Poll Time')).toHaveTextContent('05:00 PM'),
+      expect(screen.getByLabelText('Poll Time')).toHaveValue('05:00 PM'),
     );
   });
 });

--- a/src/ops-console/components/campaignSetup/CampaignCommunicationSchedule.tsx
+++ b/src/ops-console/components/campaignSetup/CampaignCommunicationSchedule.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { AccessTimeOutlined } from '@mui/icons-material';
-import { Box, MenuItem, TextField, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { CompactTimePickerField } from './CompactTimePickerField';
 
 type CampaignCommunicationScheduleProps = {
   messageTime: string;
@@ -18,14 +18,12 @@ export const CampaignCommunicationSchedule: React.FC<
 > = ({
   messageTime,
   pollTime,
-  timeOptions,
   messageTimeError,
   pollTimeError,
   onMessageTimeChange,
   onPollTimeChange,
 }) => {
   const { t } = useTranslation();
-  const TimeSelectIcon = AccessTimeOutlined;
 
   return (
     <Box className="campaign-communication-schedule">
@@ -37,45 +35,23 @@ export const CampaignCommunicationSchedule: React.FC<
           <Typography className="campaign-communication-field-label">
             {t('Message Time')}
           </Typography>
-          <TextField
-            select
-            fullWidth
-            size="small"
-            inputProps={{ 'aria-label': String(t('Message Time')) }}
+          <CompactTimePickerField
+            label={String(t('Message Time'))}
             value={messageTime}
-            onChange={(event) => onMessageTimeChange(event.target.value)}
-            error={!!messageTimeError}
-            helperText={messageTimeError}
-            SelectProps={{ IconComponent: TimeSelectIcon }}
-          >
-            {timeOptions.map((option) => (
-              <MenuItem key={option} value={option}>
-                {option}
-              </MenuItem>
-            ))}
-          </TextField>
+            error={messageTimeError}
+            onChange={onMessageTimeChange}
+          />
         </Box>
         <Box className="campaign-communication-field-block">
           <Typography className="campaign-communication-field-label">
             {t('Poll Time')}
           </Typography>
-          <TextField
-            select
-            fullWidth
-            size="small"
-            inputProps={{ 'aria-label': String(t('Poll Time')) }}
+          <CompactTimePickerField
+            label={String(t('Poll Time'))}
             value={pollTime}
-            onChange={(event) => onPollTimeChange(event.target.value)}
-            error={!!pollTimeError}
-            helperText={pollTimeError}
-            SelectProps={{ IconComponent: TimeSelectIcon }}
-          >
-            {timeOptions.map((option) => (
-              <MenuItem key={option} value={option}>
-                {option}
-              </MenuItem>
-            ))}
-          </TextField>
+            error={pollTimeError}
+            onChange={onPollTimeChange}
+          />
         </Box>
         <Typography className="campaign-communication-schedule-note campaign-communication-schedule-note-mobile">
           {t('Applied globally across all campaign days.')}

--- a/src/ops-console/components/campaignSetup/CampaignCommunicationTimelineStep.css
+++ b/src/ops-console/components/campaignSetup/CampaignCommunicationTimelineStep.css
@@ -191,8 +191,76 @@
   min-width: 7.375rem;
 }
 
+.campaign-communication-time-picker {
+  width: 9.625rem;
+  max-height: 14.375rem;
+  overflow: hidden;
+  border: 0.0625rem solid #b8c0cc;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+.campaign-communication-time-picker [role='listbox'] {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.25rem;
+  padding: 0.25rem;
+}
+
+.campaign-communication-time-picker-column {
+  max-height: 13.875rem;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+
+.campaign-communication-time-picker-column::-webkit-scrollbar {
+  display: none;
+}
+
+.campaign-communication-time-picker-option {
+  width: 100%;
+  min-height: 1.875rem;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  color: #111827;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1rem;
+  text-align: center;
+  cursor: pointer;
+}
+
+.campaign-communication-time-picker-option:hover {
+  background: #eef4ff;
+}
+
+.campaign-communication-time-picker-option[aria-selected='true'] {
+  background: #3b82f6;
+  color: #ffffff;
+}
+
+.campaign-communication-schedule .MuiInputAdornment-root svg {
+  color: #667085;
+}
+
 .campaign-communication-schedule-note-mobile {
   display: none;
+}
+
+@media (min-width: 64.0625rem) {
+  .campaign-communication-field-block {
+    width: 13.25rem;
+    grid-template-columns: auto 7.375rem;
+  }
+
+  .campaign-communication-schedule-grid
+    > .campaign-communication-field-block:nth-of-type(1),
+  .campaign-communication-schedule-grid
+    > .campaign-communication-field-block:nth-of-type(2) {
+    margin-left: 0;
+  }
 }
 
 .campaign-communication-table {

--- a/src/ops-console/components/campaignSetup/CompactTimePickerField.tsx
+++ b/src/ops-console/components/campaignSetup/CompactTimePickerField.tsx
@@ -59,6 +59,11 @@ export const CompactTimePickerField: React.FC<CompactTimePickerFieldProps> = ({
     onChange(buildTimeValue(updatedTime));
   };
 
+  const openPicker = (anchorElement: HTMLElement) => {
+    setDraftTime(parseTimeValue(value));
+    setAnchorEl(anchorElement);
+  };
+
   const renderColumn = (
     values: string[],
     selectedValue: string,
@@ -97,10 +102,14 @@ export const CompactTimePickerField: React.FC<CompactTimePickerFieldProps> = ({
           readOnly: true,
         }}
         value={value}
-        onMouseDown={(event) => {
-          event.preventDefault();
-          setDraftTime(parseTimeValue(value));
-          setAnchorEl(event.currentTarget);
+        onClick={(event) => {
+          openPicker(event.currentTarget);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === ' ' || event.key === 'Enter') {
+            event.preventDefault();
+            openPicker(event.currentTarget);
+          }
         }}
         error={!!error}
         helperText={error}

--- a/src/ops-console/components/campaignSetup/CompactTimePickerField.tsx
+++ b/src/ops-console/components/campaignSetup/CompactTimePickerField.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { AccessTimeOutlined } from '@mui/icons-material';
+import { Box, InputAdornment, Popover, TextField } from '@mui/material';
+
+type TimeParts = {
+  hour: string;
+  minute: string;
+  meridiem: string;
+};
+
+type CompactTimePickerFieldProps = {
+  label: string;
+  value: string;
+  error?: string;
+  onChange: (value: string) => void;
+};
+
+const hours = Array.from({ length: 12 }, (_, index) =>
+  String(index + 1).padStart(2, '0'),
+);
+const minutes = Array.from({ length: 60 }, (_, index) =>
+  String(index).padStart(2, '0'),
+);
+const meridiems = ['AM', 'PM'];
+
+const parseTimeValue = (value: string): TimeParts => {
+  const match = value.match(/^(\d{1,2}):(\d{2})\s?(AM|PM)$/i);
+
+  if (!match) {
+    return { hour: '09', minute: '00', meridiem: 'AM' };
+  }
+
+  return {
+    hour: match[1].padStart(2, '0'),
+    minute: match[2],
+    meridiem: match[3].toUpperCase(),
+  };
+};
+
+const buildTimeValue = ({ hour, minute, meridiem }: TimeParts) =>
+  `${hour}:${minute} ${meridiem}`;
+
+export const CompactTimePickerField: React.FC<CompactTimePickerFieldProps> = ({
+  label,
+  value,
+  error,
+  onChange,
+}) => {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+  const [draftTime, setDraftTime] = React.useState<TimeParts>(() =>
+    parseTimeValue(value),
+  );
+  const open = Boolean(anchorEl);
+  const selectedTime = open ? draftTime : parseTimeValue(value);
+
+  const updateTime = (nextTime: Partial<TimeParts>) => {
+    const updatedTime = { ...selectedTime, ...nextTime };
+    setDraftTime(updatedTime);
+    onChange(buildTimeValue(updatedTime));
+  };
+
+  const renderColumn = (
+    values: string[],
+    selectedValue: string,
+    ariaPrefix: string,
+    onSelect: (value: string) => void,
+    closeAfterSelect = false,
+  ) => (
+    <Box className="campaign-communication-time-picker-column">
+      {values.map((item) => (
+        <Box
+          key={item}
+          component="button"
+          type="button"
+          role="option"
+          aria-label={`${ariaPrefix} ${item}`.trim()}
+          aria-selected={item === selectedValue}
+          className="campaign-communication-time-picker-option"
+          onClick={() => {
+            onSelect(item);
+            if (closeAfterSelect) setAnchorEl(null);
+          }}
+        >
+          {item}
+        </Box>
+      ))}
+    </Box>
+  );
+
+  return (
+    <>
+      <TextField
+        fullWidth
+        size="small"
+        inputProps={{
+          'aria-label': label,
+          readOnly: true,
+        }}
+        value={value}
+        onMouseDown={(event) => {
+          event.preventDefault();
+          setDraftTime(parseTimeValue(value));
+          setAnchorEl(event.currentTarget);
+        }}
+        error={!!error}
+        helperText={error}
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <AccessTimeOutlined fontSize="small" />
+            </InputAdornment>
+          ),
+        }}
+      />
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        PaperProps={{
+          className: 'campaign-communication-time-picker',
+        }}
+      >
+        <Box role="listbox" aria-label={`${label} picker`}>
+          {renderColumn(hours, selectedTime.hour, 'Hour', (hour) =>
+            updateTime({ hour }),
+          )}
+          {renderColumn(minutes, selectedTime.minute, 'Minute', (minute) =>
+            updateTime({ minute }),
+          )}
+          {renderColumn(
+            meridiems,
+            selectedTime.meridiem,
+            '',
+            (meridiem) => updateTime({ meridiem }),
+            true,
+          )}
+        </Box>
+      </Popover>
+    </>
+  );
+};

--- a/src/ops-console/pages/CampaignSetupPage.test.tsx
+++ b/src/ops-console/pages/CampaignSetupPage.test.tsx
@@ -155,6 +155,20 @@ const openSelectAndChoose = async (triggerText: string, optionText: string) => {
   fireEvent.click(await screen.findByRole('option', { name: optionText }));
 };
 
+const selectCampaignTime = async (
+  fieldLabel: string,
+  hour: string,
+  minute: string,
+  meridiem: string,
+) => {
+  fireEvent.mouseDown(screen.getByLabelText(fieldLabel));
+  fireEvent.click(await screen.findByRole('option', { name: `Hour ${hour}` }));
+  fireEvent.click(
+    await screen.findByRole('option', { name: `Minute ${minute}` }),
+  );
+  fireEvent.click(await screen.findByRole('option', { name: meridiem }));
+};
+
 const getDateValueDaysFromToday = (daysFromToday: number) => {
   const date = new Date();
   date.setDate(date.getDate() + daysFromToday);
@@ -560,10 +574,8 @@ describe('CampaignSetupPage', () => {
       ),
     ).toHaveLength(1);
 
-    fireEvent.mouseDown(screen.getByLabelText('Message Time'));
-    fireEvent.click(await screen.findByRole('option', { name: '09:00 AM' }));
-    fireEvent.mouseDown(screen.getByLabelText('Poll Time'));
-    fireEvent.click(await screen.findByRole('option', { name: '05:00 PM' }));
+    await selectCampaignTime('Message Time', '09', '00', 'AM');
+    await selectCampaignTime('Poll Time', '05', '00', 'PM');
     fireEvent.change(screen.getByPlaceholderText(/Enter daily .* message/i), {
       target: { value: "Complete today's campaign task." },
     });

--- a/src/ops-console/pages/CampaignSetupPage.test.tsx
+++ b/src/ops-console/pages/CampaignSetupPage.test.tsx
@@ -161,7 +161,7 @@ const selectCampaignTime = async (
   minute: string,
   meridiem: string,
 ) => {
-  fireEvent.mouseDown(screen.getByLabelText(fieldLabel));
+  fireEvent.click(screen.getByLabelText(fieldLabel));
   fireEvent.click(await screen.findByRole('option', { name: `Hour ${hour}` }));
   fireEvent.click(
     await screen.findByRole('option', { name: `Minute ${minute}` }),


### PR DESCRIPTION
- Introduce CompactTimePickerField (compact 3-column hour/minute/AM‑PM picker) and associated CSS styles, and replace the Message/Poll TextField selects in CampaignCommunicationSchedule with this component. 
- Update schedule component to use the new picker and simplify icon handling. 
- Update tests to interact with the compact picker (add selectTime/selectCampaignTime helpers), change assertions to check values, and adjust expected option names/counts to match the new picker behavior.