### PR TITLE
fix: Add support for homepage learning pathway campaigns

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1381,6 +1381,11 @@ export const CAMPAIGN_ACCESS_ROLES = [
   RoleType.OPERATIONAL_DIRECTOR,
   RoleType.PROGRAM_MANAGER,
 ];
+
+export const CAMPAIGN_OBJECTIVE = {
+  HOMEWORK: 'homework_campaign',
+  HOMEPAGE_LEARNING_PATHWAY: 'homepage_learning_pathway_campaign',
+} as const;
 export const CAN_HOT_UPDATE = 'can-Hot-Update';
 export const VERSION_KEY = 'last_native_version';
 export enum SupportLevelMap {

--- a/src/ops-console/components/campaignSetup/CampaignAssignmentStep.test.tsx
+++ b/src/ops-console/components/campaignSetup/CampaignAssignmentStep.test.tsx
@@ -14,6 +14,7 @@ import {
   GradeAssignmentConfig,
 } from './campaignAssignmentUtils';
 import { CampaignSetupFormState } from './types';
+import { CAMPAIGN_OBJECTIVE } from '../../../common/constants';
 
 jest.mock('../../../utility/logger', () => ({
   __esModule: true,
@@ -24,7 +25,7 @@ jest.mock('../../../utility/logger', () => ({
 }));
 
 const baseForm: CampaignSetupFormState = {
-  objective: 'homework_campaign',
+  objective: CAMPAIGN_OBJECTIVE.HOMEWORK,
   targetType: 'percentage_completion',
   targetValue: '90',
   learningPathCount: '',

--- a/src/ops-console/components/campaignSetup/CampaignCommunicationTimelineStep.tsx
+++ b/src/ops-console/components/campaignSetup/CampaignCommunicationTimelineStep.tsx
@@ -31,8 +31,8 @@ const CampaignCommunicationTimelineStep: React.FC<
   const { t } = useTranslation();
   const timeOptions = useMemo(() => buildTimeOptions(), []);
   const timelineDates = useMemo(
-    () => buildCommunicationTimelineDates(assignmentDrafts),
-    [assignmentDrafts],
+    () => buildCommunicationTimelineDates(assignmentDrafts, form),
+    [assignmentDrafts, form],
   );
   const { campaignReach, loadingReach } = useCampaignReach(selectedSchoolIds);
 

--- a/src/ops-console/components/campaignSetup/CampaignReviewStep.tsx
+++ b/src/ops-console/components/campaignSetup/CampaignReviewStep.tsx
@@ -27,6 +27,7 @@ import {
 import { CampaignReachSummary } from './campaignCommunicationTypes';
 import { CampaignSetupFormState } from './types';
 import { ReviewCard, ReviewRow } from './CampaignReviewComponents';
+import { CAMPAIGN_OBJECTIVE } from '../../../common/constants';
 import './CampaignReviewStep.css';
 
 export type CampaignReviewData = {
@@ -96,7 +97,7 @@ const getRewardTypeLabel = (value: CampaignSetupFormState['rewardType']) =>
   emptyValue;
 
 const getObjectiveLabel = (form: CampaignSetupFormState) => {
-  if (form.objective === 'homepage_learning_pathway_campaign') {
+  if (form.objective === CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY) {
     return 'Homepage Learning Pathway Campaign';
   }
   if (!form.targetType) return 'Homework Campaign';
@@ -161,7 +162,7 @@ export const CampaignReviewStep: React.FC<CampaignReviewStepProps> = ({
     reviewData.messagingRows.length - visibleMessagingRows.length;
   const usesLessonCriteria = usesLessonRewardCriteria(reviewData.form);
   const isHomepageLearningPathwayCampaign =
-    reviewData.form.objective === 'homepage_learning_pathway_campaign';
+    reviewData.form.objective === CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY;
 
   return (
     <Box className="campaign-review-step">

--- a/src/ops-console/components/campaignSetup/CampaignReviewStep.tsx
+++ b/src/ops-console/components/campaignSetup/CampaignReviewStep.tsx
@@ -160,6 +160,8 @@ export const CampaignReviewStep: React.FC<CampaignReviewStepProps> = ({
   const hiddenMessagingDayCount =
     reviewData.messagingRows.length - visibleMessagingRows.length;
   const usesLessonCriteria = usesLessonRewardCriteria(reviewData.form);
+  const isHomepageLearningPathwayCampaign =
+    reviewData.form.objective === 'homepage_learning_pathway_campaign';
 
   return (
     <Box className="campaign-review-step">
@@ -229,27 +231,29 @@ export const CampaignReviewStep: React.FC<CampaignReviewStepProps> = ({
         />
       </ReviewCard>
 
-      <ReviewCard title="Assignments" editStep={1} onEditStep={onEditStep}>
-        <Box className="campaign-review-assignment-list">
-          {assignmentsByGrade.map((assignment) => (
-            <Box
-              key={assignment.grade.id}
-              className="campaign-review-assignment-item"
-            >
-              <Typography className="campaign-review-assignment-grade">
-                {assignment.grade.name}
-              </Typography>
-              <Typography className="campaign-review-assignment-detail">
-                {t('Subjects')}: {formatList(assignment.subjects)}
-              </Typography>
-              <Typography className="campaign-review-assignment-detail">
-                {t('Lessons')}: {assignment.lessonCount} · {t('Frequency')}:{' '}
-                {t(frequencyLabels[assignment.frequency])}
-              </Typography>
-            </Box>
-          ))}
-        </Box>
-      </ReviewCard>
+      {!isHomepageLearningPathwayCampaign && (
+        <ReviewCard title="Assignments" editStep={1} onEditStep={onEditStep}>
+          <Box className="campaign-review-assignment-list">
+            {assignmentsByGrade.map((assignment) => (
+              <Box
+                key={assignment.grade.id}
+                className="campaign-review-assignment-item"
+              >
+                <Typography className="campaign-review-assignment-grade">
+                  {assignment.grade.name}
+                </Typography>
+                <Typography className="campaign-review-assignment-detail">
+                  {t('Subjects')}: {formatList(assignment.subjects)}
+                </Typography>
+                <Typography className="campaign-review-assignment-detail">
+                  {t('Lessons')}: {assignment.lessonCount} · {t('Frequency')}:{' '}
+                  {t(frequencyLabels[assignment.frequency])}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        </ReviewCard>
+      )}
 
       <ReviewCard title="Rewards" editStep={2} onEditStep={onEditStep}>
         <ReviewRow

--- a/src/ops-console/components/campaignSetup/CampaignSetupStepper.tsx
+++ b/src/ops-console/components/campaignSetup/CampaignSetupStepper.tsx
@@ -5,10 +5,12 @@ import './CampaignSetupStepper.css';
 
 type CampaignSetupStepperProps = {
   activeStep?: number;
+  steps?: string[];
 };
 
 export const CampaignSetupStepper: React.FC<CampaignSetupStepperProps> = ({
   activeStep = 0,
+  steps = ['Setup', 'Assignments', 'Rewards', 'Messaging', 'Review'],
 }) => {
   const stepperRef = useRef<HTMLDivElement | null>(null);
   const activeStepRef = useRef<HTMLDivElement | null>(null);
@@ -44,26 +46,22 @@ export const CampaignSetupStepper: React.FC<CampaignSetupStepperProps> = ({
       aria-label="Campaign steps"
     >
       <Box className="campaign-setup-stepper-track">
-        {['Setup', 'Assignments', 'Rewards', 'Messaging', 'Review'].map(
-          (step, index) => (
-            <React.Fragment key={step}>
-              <Box
-                ref={index === activeStep ? activeStepRef : null}
-                className={`campaign-setup-stepper-step ${
-                  index === activeStep
-                    ? 'campaign-setup-stepper-step-active'
-                    : ''
-                } ${index < activeStep ? 'campaign-setup-stepper-step-complete' : ''}`}
-              >
-                <span>{index < activeStep ? <Check /> : index + 1}</span>
-                <strong>{step}</strong>
-              </Box>
-              {index < 4 && (
-                <span className="campaign-setup-stepper-step-line" />
-              )}
-            </React.Fragment>
-          ),
-        )}
+        {steps.map((step, index) => (
+          <React.Fragment key={step}>
+            <Box
+              ref={index === activeStep ? activeStepRef : null}
+              className={`campaign-setup-stepper-step ${
+                index === activeStep ? 'campaign-setup-stepper-step-active' : ''
+              } ${index < activeStep ? 'campaign-setup-stepper-step-complete' : ''}`}
+            >
+              <span>{index < activeStep ? <Check /> : index + 1}</span>
+              <strong>{step}</strong>
+            </Box>
+            {index < steps.length - 1 && (
+              <span className="campaign-setup-stepper-step-line" />
+            )}
+          </React.Fragment>
+        ))}
       </Box>
     </Box>
   );

--- a/src/ops-console/components/campaignSetup/ChapterSelection.tsx
+++ b/src/ops-console/components/campaignSetup/ChapterSelection.tsx
@@ -68,7 +68,7 @@ export const ChapterSelection: React.FC<ChapterSelectionProps> = ({
                         {chapter.name}
                       </Typography>
                       <Typography className="chapter-selection-activity-count">
-                        {chapter.lessons.length} activities
+                        {chapter.lessons.length} Lessons
                       </Typography>
                       <Button
                         type="button"

--- a/src/ops-console/components/campaignSetup/ChapterSelection.tsx
+++ b/src/ops-console/components/campaignSetup/ChapterSelection.tsx
@@ -68,7 +68,7 @@ export const ChapterSelection: React.FC<ChapterSelectionProps> = ({
                         {chapter.name}
                       </Typography>
                       <Typography className="chapter-selection-activity-count">
-                        {chapter.lessons.length} Lessons
+                        {chapter.lessons.length} {t('Lessons')}
                       </Typography>
                       <Button
                         type="button"

--- a/src/ops-console/components/campaignSetup/ChapterSelection.tsx
+++ b/src/ops-console/components/campaignSetup/ChapterSelection.tsx
@@ -4,6 +4,7 @@ import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { CampaignAssignmentSubjectOption } from '../../../services/api/ServiceApi';
 import { GradeAssignmentConfig } from './campaignAssignmentUtils';
 import './ChapterSelection.css';
+import { t } from 'i18next';
 
 type ChapterSelectionProps = {
   gradeName: string;

--- a/src/ops-console/components/campaignSetup/ObjectiveGoalSection.tsx
+++ b/src/ops-console/components/campaignSetup/ObjectiveGoalSection.tsx
@@ -18,6 +18,7 @@ import {
 } from './constants';
 import { CampaignSelectPlaceholder } from './CampaignPlaceholder';
 import { ObjectiveGoalSectionProps } from './types';
+import { CAMPAIGN_OBJECTIVE } from '../../../common/constants';
 import './ObjectiveGoalSection.css';
 
 export const ObjectiveGoalSection: React.FC<ObjectiveGoalSectionProps> = ({
@@ -69,7 +70,7 @@ export const ObjectiveGoalSection: React.FC<ObjectiveGoalSectionProps> = ({
     </Box>
 
     <Box className="campaign-setup-grid objective-goal-section-target-grid">
-      {form.objective === 'homework_campaign' && (
+      {form.objective === CAMPAIGN_OBJECTIVE.HOMEWORK && (
         <>
           <Box className="campaign-setup-field">
             <Typography className="campaign-setup-label">
@@ -118,7 +119,7 @@ export const ObjectiveGoalSection: React.FC<ObjectiveGoalSectionProps> = ({
         </>
       )}
 
-      {form.objective === 'homepage_learning_pathway_campaign' && (
+      {form.objective === CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY && (
         <Box className="campaign-setup-field">
           <Typography className="campaign-setup-label">
             {requiredLabel('Number of Learning Paths')}

--- a/src/ops-console/components/campaignSetup/RewardsConfigurationSection.tsx
+++ b/src/ops-console/components/campaignSetup/RewardsConfigurationSection.tsx
@@ -11,6 +11,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { RANK_LABELS, REWARD_TYPE_OPTIONS, requiredLabel } from './constants';
 import { RewardsConfigurationSectionProps } from './types';
+import { CAMPAIGN_OBJECTIVE } from '../../../common/constants';
 import './RewardsConfigurationSection.css';
 
 type TranslationValues = Record<string, string | number>;
@@ -48,7 +49,7 @@ export const RewardsConfigurationSection: React.FC<
     return translated === key ? fallback : translated;
   };
   const usesLessonCount =
-    form.objective === 'homepage_learning_pathway_campaign' ||
+    form.objective === CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY ||
     form.targetType === 'number_of_lessons';
   const criteriaLabel = usesLessonCount
     ? translate('Number of Lessons')

--- a/src/ops-console/components/campaignSetup/campaignCommunicationUtils.test.ts
+++ b/src/ops-console/components/campaignSetup/campaignCommunicationUtils.test.ts
@@ -3,6 +3,7 @@ import {
   buildCampaignMessagingPayload,
   formatDateTimeForDatabase,
 } from './campaignCommunicationUtils';
+import { CAMPAIGN_OBJECTIVE } from '../../../common/constants';
 
 describe('campaignCommunicationUtils', () => {
   it('formats communication times as full timestamps for timestamptz columns', () => {
@@ -49,7 +50,7 @@ describe('campaignCommunicationUtils', () => {
   it('uses campaign duration dates for homepage learning pathway campaigns', () => {
     expect(
       buildCommunicationTimelineDates([], {
-        objective: 'homepage_learning_pathway_campaign',
+        objective: CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY,
         targetType: 'percentage_completion',
         targetValue: '',
         learningPathCount: '5',

--- a/src/ops-console/components/campaignSetup/campaignCommunicationUtils.test.ts
+++ b/src/ops-console/components/campaignSetup/campaignCommunicationUtils.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildCommunicationTimelineDates,
   buildCampaignMessagingPayload,
   formatDateTimeForDatabase,
 } from './campaignCommunicationUtils';
@@ -43,5 +44,24 @@ describe('campaignCommunicationUtils', () => {
         message: 'Hello',
       }),
     ]);
+  });
+
+  it('uses campaign duration dates for homepage learning pathway campaigns', () => {
+    expect(
+      buildCommunicationTimelineDates([], {
+        objective: 'homepage_learning_pathway_campaign',
+        targetType: 'percentage_completion',
+        targetValue: '',
+        learningPathCount: '5',
+        campaignName: 'Pathway Campaign',
+        managerId: 'manager-1',
+        startDate: '2099-05-01',
+        endDate: '2099-05-03',
+        programId: 'program-1',
+        groupName: 'Group A',
+        rewardType: '',
+        rewardRanks: [],
+      }),
+    ).toEqual(['2099-05-01', '2099-05-02', '2099-05-03']);
   });
 });

--- a/src/ops-console/components/campaignSetup/campaignCommunicationUtils.ts
+++ b/src/ops-console/components/campaignSetup/campaignCommunicationUtils.ts
@@ -1,4 +1,5 @@
 import { t } from 'i18next';
+import { CAMPAIGN_OBJECTIVE } from '../../../common/constants';
 import { CampaignAssignmentDraft } from './campaignAssignmentUtils';
 import { CampaignSetupFormState } from './types';
 
@@ -51,7 +52,7 @@ export const buildCommunicationTimelineDates = (
   assignmentDrafts: CampaignAssignmentDraft[],
   form?: CampaignSetupFormState,
 ): string[] => {
-  if (form?.objective === 'homepage_learning_pathway_campaign') {
+  if (form?.objective === CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY) {
     return buildCampaignDurationTimelineDates(form.startDate, form.endDate);
   }
 

--- a/src/ops-console/components/campaignSetup/campaignCommunicationUtils.ts
+++ b/src/ops-console/components/campaignSetup/campaignCommunicationUtils.ts
@@ -49,10 +49,54 @@ export const createEmptyCommunicationRow =
 
 export const buildCommunicationTimelineDates = (
   assignmentDrafts: CampaignAssignmentDraft[],
-): string[] =>
-  Array.from(new Set(assignmentDrafts.map((draft) => draft.startsAt)))
+  form?: CampaignSetupFormState,
+): string[] => {
+  if (form?.objective === 'homepage_learning_pathway_campaign') {
+    return buildCampaignDurationTimelineDates(form.startDate, form.endDate);
+  }
+
+  return Array.from(new Set(assignmentDrafts.map((draft) => draft.startsAt)))
     .filter(Boolean)
     .sort();
+};
+
+export function buildCampaignDurationTimelineDates(
+  startDate: string,
+  endDate: string,
+): string[] {
+  if (!startDate || !endDate) return [];
+
+  const startParts = startDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  const endParts = endDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!startParts || !endParts) return [];
+
+  const start = new Date(
+    Date.UTC(
+      Number(startParts[1]),
+      Number(startParts[2]) - 1,
+      Number(startParts[3]),
+    ),
+  );
+  const end = new Date(
+    Date.UTC(Number(endParts[1]), Number(endParts[2]) - 1, Number(endParts[3])),
+  );
+  if (
+    Number.isNaN(start.getTime()) ||
+    Number.isNaN(end.getTime()) ||
+    start > end
+  ) {
+    return [];
+  }
+
+  const dates: string[] = [];
+  const cursor = new Date(start);
+  while (cursor <= end) {
+    dates.push(cursor.toISOString().slice(0, 10));
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+
+  return dates;
+}
 
 export const getCampaignDurationDays = (
   startDate: string,

--- a/src/ops-console/components/campaignSetup/constants.tsx
+++ b/src/ops-console/components/campaignSetup/constants.tsx
@@ -3,23 +3,24 @@ import {
   CampaignRewardType,
   CampaignTargetType,
 } from '../../../services/api/ServiceApi';
+import { CAMPAIGN_OBJECTIVE } from '../../../common/constants';
 import type { CampaignRewardRankFormState } from './types';
 
 export const OBJECTIVE_OPTIONS: Array<{
   value: CampaignObjective;
   label: string;
 }> = [
-  { value: 'homework_campaign', label: 'Homework Campaign' },
+  { value: CAMPAIGN_OBJECTIVE.HOMEWORK, label: 'Homework Campaign' },
   {
-    value: 'homepage_learning_pathway_campaign',
+    value: CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY,
     label: 'Homepage Learning Pathway Campaign',
   },
 ];
 
 export const OBJECTIVE_DESCRIPTION: Record<CampaignObjective, string> = {
-  homework_campaign:
+  [CAMPAIGN_OBJECTIVE.HOMEWORK]:
     'Assign subject-wise lessons to students over a defined schedule with configurable frequency and tracking.',
-  homepage_learning_pathway_campaign:
+  [CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY]:
     'Encourage students to complete structured learning paths at subject-level.',
 };
 

--- a/src/ops-console/hooks/campaignSetupFormHelpers.ts
+++ b/src/ops-console/hooks/campaignSetupFormHelpers.ts
@@ -6,9 +6,10 @@ import {
 } from '../../services/api/ServiceApi';
 import type { CampaignSetupFormState } from '../components/campaignSetup/types';
 import { DEFAULT_REWARD_RANKS } from '../components/campaignSetup/constants';
+import { CAMPAIGN_OBJECTIVE } from '../../common/constants';
 
 export const initialCampaignSetupForm: CampaignSetupFormState = {
-  objective: 'homework_campaign',
+  objective: CAMPAIGN_OBJECTIVE.HOMEWORK,
   targetType: 'percentage_completion',
   targetValue: '',
   learningPathCount: '',
@@ -78,7 +79,7 @@ export const getCampaignSetupValidationErrors = (
   const errors: Record<string, string> = {};
   const today = getTodayDateValue();
   if (!form.objective) errors.objective = 'Campaign objective is required.';
-  if (form.objective === 'homework_campaign') {
+  if (form.objective === CAMPAIGN_OBJECTIVE.HOMEWORK) {
     if (!form.targetType) errors.targetType = 'Target type is required.';
     if (!Number(form.targetValue) || Number(form.targetValue) <= 0) {
       errors.targetValue = 'Target value is required.';
@@ -86,7 +87,7 @@ export const getCampaignSetupValidationErrors = (
       errors.targetValue = 'Target value cannot be more than 100.';
     }
   }
-  if (form.objective === 'homepage_learning_pathway_campaign') {
+  if (form.objective === CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY) {
     if (
       !Number(form.learningPathCount) ||
       Number(form.learningPathCount) <= 0
@@ -123,7 +124,7 @@ export const getCampaignSetupValidationErrors = (
 };
 
 export const usesLessonRewardCriteria = (form: CampaignSetupFormState) =>
-  form.objective === 'homepage_learning_pathway_campaign' ||
+  form.objective === CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY ||
   form.targetType === 'number_of_lessons';
 
 export const getCampaignRewardsValidationErrors = (

--- a/src/ops-console/hooks/useCampaignSetupForm.ts
+++ b/src/ops-console/hooks/useCampaignSetupForm.ts
@@ -28,6 +28,7 @@ import {
   resetObjectiveFields,
   usesLessonRewardCriteria,
 } from './campaignSetupFormHelpers';
+import { CAMPAIGN_OBJECTIVE } from '../../common/constants';
 import type { CampaignRewardsDraftPayload } from './campaignSetupFormHelpers';
 import {
   CampaignSetupMessage,
@@ -404,7 +405,7 @@ export const useCampaignSetupForm = () => {
     if (!isFormValid) return;
 
     setActiveStep(
-      form.objective === 'homepage_learning_pathway_campaign' ? 2 : 1,
+      form.objective === CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY ? 2 : 1,
     );
   };
 

--- a/src/ops-console/pages/CampaignSetupPage.test.tsx
+++ b/src/ops-console/pages/CampaignSetupPage.test.tsx
@@ -175,6 +175,8 @@ const getDateValueDaysFromToday = (daysFromToday: number) => {
   return getTodayDateValue(date);
 };
 
+const getCampaignStepper = () => screen.getByLabelText('Campaign steps');
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockAssignmentComplete = false;
@@ -241,6 +243,9 @@ describe('CampaignSetupPage', () => {
     expect(screen.getByText('Campaign Details')).toBeInTheDocument();
     expect(screen.getByText('Target Audience')).toBeInTheDocument();
     expect(screen.getByText('Save this group for reuse')).toBeInTheDocument();
+    expect(
+      within(getCampaignStepper()).getByText('Assignments'),
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
   });
 
@@ -284,6 +289,9 @@ describe('CampaignSetupPage', () => {
 
     await screen.findByRole('heading', { name: 'New Campaign' });
     expect(screen.getByText('Target Type')).toBeInTheDocument();
+    expect(
+      within(getCampaignStepper()).getByText('Assignments'),
+    ).toBeInTheDocument();
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -293,6 +301,12 @@ describe('CampaignSetupPage', () => {
 
     expect(screen.getByText('Number of Learning Paths')).toBeInTheDocument();
     expect(screen.queryByText('Target Type')).not.toBeInTheDocument();
+    expect(
+      within(getCampaignStepper()).queryByText('Assignments'),
+    ).not.toBeInTheDocument();
+    expect(
+      within(getCampaignStepper()).getByText('Rewards'),
+    ).toBeInTheDocument();
   });
 
   it('opens date pickers and restricts campaign dates to today onward', async () => {
@@ -613,6 +627,7 @@ describe('CampaignSetupPage', () => {
         expect.objectContaining({
           campaignId: 'campaign-1',
           currentUserId: 'user-1',
+          objective: 'homework_campaign',
           messagingRows: [
             expect.objectContaining({
               messageTime: expect.any(String),
@@ -658,7 +673,47 @@ describe('CampaignSetupPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Next' }));
     await screen.findByText('Rewards Configuration');
 
+    expect(
+      within(getCampaignStepper()).queryByText('Assignments'),
+    ).not.toBeInTheDocument();
+    expect(
+      within(getCampaignStepper()).getByText('Rewards'),
+    ).toBeInTheDocument();
     expect(screen.getAllByText('Number of Lessons').length).toBeGreaterThan(0);
+
+    await openSelectAndChoose('Select Reward Type', 'Digital Rewards');
+    fireEvent.change(screen.getByLabelText('1st Number of Lessons'), {
+      target: { value: '10' },
+    });
+    fireEvent.change(screen.getByLabelText('2nd Number of Lessons'), {
+      target: { value: '7' },
+    });
+    fireEvent.change(screen.getByLabelText('3rd Number of Lessons'), {
+      target: { value: '5' },
+    });
+    fireEvent.change(screen.getByLabelText('1st Reward'), {
+      target: { value: 'Gold Reward' },
+    });
+    fireEvent.change(screen.getByLabelText('2nd Reward'), {
+      target: { value: 'Silver Reward' },
+    });
+    fireEvent.change(screen.getByLabelText('3rd Reward'), {
+      target: { value: 'Bronze Reward' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(
+      screen.getByRole('heading', { name: 'Campaign Communication Timeline' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'No campaign days are available yet. Complete assignment setup to generate the communication schedule.',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getAllByPlaceholderText('Enter daily campaign message...').length,
+    ).toBeGreaterThan(0);
   });
 
   it('hides save-group controls when an existing saved group is selected and restores them when cleared', async () => {

--- a/src/ops-console/pages/CampaignSetupPage.test.tsx
+++ b/src/ops-console/pages/CampaignSetupPage.test.tsx
@@ -9,6 +9,7 @@ import {
 import { getTodayDateValue } from '../hooks/campaignSetupFormHelpers';
 import CampaignSetupPage from './CampaignSetupPage';
 import { buildCampaignRewardsPayload } from '../hooks/campaignSetupFormHelpers';
+import { CAMPAIGN_OBJECTIVE } from '../../common/constants';
 
 const mockGoBack = jest.fn();
 const mockTranslate = (
@@ -627,7 +628,7 @@ describe('CampaignSetupPage', () => {
         expect.objectContaining({
           campaignId: 'campaign-1',
           currentUserId: 'user-1',
-          objective: 'homework_campaign',
+          objective: CAMPAIGN_OBJECTIVE.HOMEWORK,
           messagingRows: [
             expect.objectContaining({
               messageTime: expect.any(String),
@@ -938,7 +939,7 @@ describe('CampaignSetupPage', () => {
   it('builds rewards payload in the next-step format', () => {
     expect(
       buildCampaignRewardsPayload({
-        objective: 'homework_campaign',
+        objective: CAMPAIGN_OBJECTIVE.HOMEWORK,
         targetType: 'percentage_completion',
         targetValue: '90',
         learningPathCount: '',

--- a/src/ops-console/pages/CampaignSetupPage.tsx
+++ b/src/ops-console/pages/CampaignSetupPage.tsx
@@ -7,6 +7,7 @@ import type {
   CampaignRewardType,
   CampaignTargetType,
 } from '../../services/api/ServiceApi';
+import { CAMPAIGN_OBJECTIVE } from '../../common/constants';
 import {
   CampaignCommunicationTimelineStep,
   CampaignAssignmentStep,
@@ -102,7 +103,8 @@ const CampaignSetupPage: React.FC = () => {
   const canProceedFromCampaignSetup =
     campaignSetup.isFormValid && !hasNoTargetAudienceStudents;
   const isHomepageLearningPathwayCampaign =
-    campaignSetup.form.objective === 'homepage_learning_pathway_campaign';
+    campaignSetup.form.objective ===
+    CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY;
   const stepperSteps = isHomepageLearningPathwayCampaign
     ? ['Setup', 'Rewards', 'Messaging', 'Review']
     : ['Setup', 'Assignments', 'Rewards', 'Messaging', 'Review'];
@@ -204,7 +206,8 @@ const CampaignSetupPage: React.FC = () => {
     setActiveStepSafe(
       campaignSetup.activeStep === 1 ||
         (campaignSetup.activeStep === 2 &&
-          campaignSetup.form.objective === 'homepage_learning_pathway_campaign')
+          campaignSetup.form.objective ===
+            CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY)
         ? 0
         : campaignSetup.activeStep - 1,
     );
@@ -286,14 +289,14 @@ const CampaignSetupPage: React.FC = () => {
         campaignName: campaignSetup.form.campaignName.trim(),
         objective: campaignSetup.form.objective as CampaignObjective,
         targetType:
-          campaignSetup.form.objective === 'homework_campaign'
+          campaignSetup.form.objective === CAMPAIGN_OBJECTIVE.HOMEWORK
             ? (campaignSetup.form.targetType as CampaignTargetType)
             : undefined,
         targetValue:
-          campaignSetup.form.objective === 'homework_campaign'
+          campaignSetup.form.objective === CAMPAIGN_OBJECTIVE.HOMEWORK
             ? Number(campaignSetup.form.targetValue)
             : campaignSetup.form.objective ===
-                'homepage_learning_pathway_campaign'
+                CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY
               ? Number(campaignSetup.form.learningPathCount)
               : undefined,
         managerId: campaignSetup.form.managerId,

--- a/src/ops-console/pages/CampaignSetupPage.tsx
+++ b/src/ops-console/pages/CampaignSetupPage.tsx
@@ -62,8 +62,12 @@ const CampaignSetupPage: React.FC = () => {
   const selectedAssignmentSchoolIds = campaignSetup.selectedAssignmentSchoolIds;
 
   const communicationTimelineDates = useMemo(
-    () => buildCommunicationTimelineDates(campaignSetup.assignmentDrafts),
-    [campaignSetup.assignmentDrafts],
+    () =>
+      buildCommunicationTimelineDates(
+        campaignSetup.assignmentDrafts,
+        campaignSetup.form,
+      ),
+    [campaignSetup.assignmentDrafts, campaignSetup.form],
   );
 
   const communicationValidation = useMemo(
@@ -97,6 +101,14 @@ const CampaignSetupPage: React.FC = () => {
     !campaignSetup.loadingAudienceSummary && targetAudienceStudentCount === 0;
   const canProceedFromCampaignSetup =
     campaignSetup.isFormValid && !hasNoTargetAudienceStudents;
+  const isHomepageLearningPathwayCampaign =
+    campaignSetup.form.objective === 'homepage_learning_pathway_campaign';
+  const stepperSteps = isHomepageLearningPathwayCampaign
+    ? ['Setup', 'Rewards', 'Messaging', 'Review']
+    : ['Setup', 'Assignments', 'Rewards', 'Messaging', 'Review'];
+  const stepperActiveStep = isHomepageLearningPathwayCampaign
+    ? [0, 2, 3, 4].indexOf(campaignSetup.activeStep)
+    : campaignSetup.activeStep;
 
   const messagingRows = useMemo(
     () =>
@@ -243,7 +255,10 @@ const CampaignSetupPage: React.FC = () => {
       });
       return;
     }
-    if (!isAssignmentComplete || campaignSetup.assignmentDrafts.length === 0) {
+    if (
+      !isHomepageLearningPathwayCampaign &&
+      (!isAssignmentComplete || campaignSetup.assignmentDrafts.length === 0)
+    ) {
       setLaunchMessage({
         type: 'error',
         text: t('Complete assignment setup before launching.'),
@@ -315,6 +330,7 @@ const CampaignSetupPage: React.FC = () => {
       await ServiceConfig.getI().apiHandler.launchCampaign({
         campaignId,
         currentUserId: currentUser.id,
+        objective: campaign.objective,
         rewards,
         assignments: campaignSetup.assignmentDrafts.map((assignment) => ({
           gradeId: assignment.gradeId,
@@ -361,6 +377,7 @@ const CampaignSetupPage: React.FC = () => {
     communicationValidation.isValid,
     history,
     isAssignmentComplete,
+    isHomepageLearningPathwayCampaign,
     messagingRows,
     campaignSetup.saveGroup,
     campaignSetup.selectedGradeIds,
@@ -404,7 +421,10 @@ const CampaignSetupPage: React.FC = () => {
         onSubmit={campaignSetup.handleSubmit}
       >
         <Box className="campaign-setup-scroll-area">
-          <CampaignSetupStepper activeStep={campaignSetup.activeStep} />
+          <CampaignSetupStepper
+            activeStep={Math.max(0, stepperActiveStep)}
+            steps={stepperSteps}
+          />
 
           {campaignSetup.activeStep === 0 ? (
             <>

--- a/src/services/api/ServiceApi.ts
+++ b/src/services/api/ServiceApi.ts
@@ -4,6 +4,7 @@ import Lesson from '../../models/lesson';
 import { StudentLessonResult } from '../../common/courseConstants';
 import {
   CACHETABLES,
+  CAMPAIGN_OBJECTIVE,
   CoordinatorAPIResponse,
   EnumType,
   FilteredSchoolsForSchoolListingOps,
@@ -160,8 +161,7 @@ type ActivitiesFilterOptions = {
 };
 
 export type CampaignObjective =
-  | 'homework_campaign'
-  | 'homepage_learning_pathway_campaign';
+  (typeof CAMPAIGN_OBJECTIVE)[keyof typeof CAMPAIGN_OBJECTIVE];
 
 export type CampaignTargetType = 'percentage_completion' | 'number_of_lessons';
 

--- a/src/services/api/ServiceApi.ts
+++ b/src/services/api/ServiceApi.ts
@@ -292,6 +292,7 @@ export type CampaignLaunchDetailsPayload = {
 export type LaunchCampaignPayload = {
   campaignId: string;
   currentUserId: string;
+  objective: CampaignObjective;
   rewards: CampaignRewardsPayload;
   assignments: CampaignLaunchAssignmentPayload[];
   messagingRows: CampaignLaunchMessagingPayload[];

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -50,6 +50,7 @@ import {
   ProgramType,
   LATEST_LEARNING_PATH,
   REWARD_LEARNING_PATH,
+  CAMPAIGN_OBJECTIVE,
 } from '../../common/constants';
 import { Constants } from '../database'; // adjust the path as per your project
 import { StudentLessonResult } from '../../common/courseConstants';
@@ -9578,28 +9579,13 @@ export class SupabaseApi implements ServiceApi {
       throw new Error('Campaign rewards are required.');
     }
     const requiresAssignments =
-      payload.objective !== 'homepage_learning_pathway_campaign';
+      payload.objective !== CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY;
 
     if (requiresAssignments && payload.assignments.length === 0) {
       throw new Error('Campaign assignments are required.');
     }
     if (payload.messagingRows.length === 0) {
       throw new Error('Campaign communication is required.');
-    }
-
-    const updatedAt = new Date().toISOString();
-    const { error: assignmentCleanupError } = await this.supabase
-      .from(TABLES.Assignment)
-      .update({ is_deleted: true, updated_at: updatedAt })
-      .eq('campaign_id', payload.campaignId)
-      .eq('is_deleted', false);
-
-    if (assignmentCleanupError) {
-      logger.error(
-        'Error clearing previous campaign assignments:',
-        assignmentCleanupError,
-      );
-      throw assignmentCleanupError;
     }
 
     if (requiresAssignments) {
@@ -9704,20 +9690,6 @@ export class SupabaseApi implements ServiceApi {
           throw error;
         }
       }
-    }
-
-    const { error: messagingCleanupError } = await this.supabase
-      .from('campaign_messaging')
-      .update({ is_deleted: true, updated_at: updatedAt })
-      .eq('campaign_id', payload.campaignId)
-      .eq('is_deleted', false);
-
-    if (messagingCleanupError) {
-      logger.error(
-        'Error clearing previous campaign messaging:',
-        messagingCleanupError,
-      );
-      throw messagingCleanupError;
     }
 
     const messagingRows = payload.messagingRows.map((row) => ({

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -9577,7 +9577,10 @@ export class SupabaseApi implements ServiceApi {
     if (!payload.rewards?.type || !payload.rewards?.rules?.length) {
       throw new Error('Campaign rewards are required.');
     }
-    if (payload.assignments.length === 0) {
+    const requiresAssignments =
+      payload.objective !== 'homepage_learning_pathway_campaign';
+
+    if (requiresAssignments && payload.assignments.length === 0) {
       throw new Error('Campaign assignments are required.');
     }
     if (payload.messagingRows.length === 0) {
@@ -9585,97 +9588,6 @@ export class SupabaseApi implements ServiceApi {
     }
 
     const updatedAt = new Date().toISOString();
-    const schoolIds = Array.from(
-      new Set(
-        payload.assignments.flatMap((assignment) => assignment.schoolIds),
-      ),
-    );
-    const gradeIds = Array.from(
-      new Set(payload.assignments.map((assignment) => assignment.gradeId)),
-    );
-
-    if (schoolIds.length === 0 || gradeIds.length === 0) {
-      throw new Error('Campaign assignment schools and grades are required.');
-    }
-
-    const { data: classRowsData, error: classRowsError } = await this.supabase
-      .from(TABLES.Class)
-      .select('id, school_id, grade_id')
-      .in('school_id', schoolIds)
-      .in('grade_id', gradeIds)
-      .eq('is_deleted', false);
-
-    if (classRowsError) {
-      logger.error(
-        'Error resolving campaign assignment classes:',
-        classRowsError,
-      );
-      throw classRowsError;
-    }
-
-    const classRows = (classRowsData ?? []) as Array<{
-      id: string;
-      school_id: string;
-      grade_id: string;
-    }>;
-
-    const classesBySchoolAndGrade = new Map<
-      string,
-      Array<{ id: string; school_id: string; grade_id: string }>
-    >();
-    classRows.forEach((classRow) => {
-      const key = `${classRow.school_id}:${classRow.grade_id}`;
-      if (!classesBySchoolAndGrade.has(key)) {
-        classesBySchoolAndGrade.set(key, []);
-      }
-      classesBySchoolAndGrade.get(key)?.push(classRow);
-    });
-
-    const missingAssignmentTargets = new Set<string>();
-    const assignmentRows = payload.assignments.flatMap((assignment) =>
-      assignment.schoolIds.flatMap((schoolId) => {
-        const classes =
-          classesBySchoolAndGrade.get(`${schoolId}:${assignment.gradeId}`) ??
-          [];
-        if (classes.length === 0) {
-          missingAssignmentTargets.add(`${schoolId}:${assignment.gradeId}`);
-        }
-        return classes.map((classRow) => ({
-          campaign_id: payload.campaignId,
-          batch_id: payload.campaignId,
-          class_id: classRow.id,
-          school_id: classRow.school_id,
-          lesson_id: assignment.lessonId,
-          chapter_id: assignment.chapterId,
-          course_id: assignment.courseId,
-          starts_at: assignment.startsAt,
-          ends_at: assignment.endsAt,
-          type: assignment.type,
-          source: assignment.source,
-          set_number: assignment.setNumber,
-          is_class_wise: true,
-          created_by: payload.currentUserId,
-          is_deleted: false,
-        }));
-      }),
-    );
-
-    if (missingAssignmentTargets.size > 0) {
-      logger.warn(
-        'Skipping campaign assignments for school/grade pairs without classes:',
-        Array.from(missingAssignmentTargets).map((target) => {
-          const [schoolId, gradeId] = target.split(':');
-          return { schoolId, gradeId };
-        }),
-      );
-    }
-
-    if (assignmentRows.length === 0) {
-      throw new Error(
-        'No classes found for the selected campaign assignments.',
-      );
-    }
-
     const { error: assignmentCleanupError } = await this.supabase
       .from(TABLES.Assignment)
       .update({ is_deleted: true, updated_at: updatedAt })
@@ -9690,14 +9602,107 @@ export class SupabaseApi implements ServiceApi {
       throw assignmentCleanupError;
     }
 
-    for (const assignmentBatch of chunkArray(assignmentRows, 500)) {
-      const { error } = await this.supabase
-        .from(TABLES.Assignment)
-        .insert(assignmentBatch);
+    if (requiresAssignments) {
+      const schoolIds = Array.from(
+        new Set(
+          payload.assignments.flatMap((assignment) => assignment.schoolIds),
+        ),
+      );
+      const gradeIds = Array.from(
+        new Set(payload.assignments.map((assignment) => assignment.gradeId)),
+      );
 
-      if (error) {
-        logger.error('Error inserting campaign assignments:', error);
-        throw error;
+      if (schoolIds.length === 0 || gradeIds.length === 0) {
+        throw new Error('Campaign assignment schools and grades are required.');
+      }
+
+      const { data: classRowsData, error: classRowsError } = await this.supabase
+        .from(TABLES.Class)
+        .select('id, school_id, grade_id')
+        .in('school_id', schoolIds)
+        .in('grade_id', gradeIds)
+        .eq('is_deleted', false);
+
+      if (classRowsError) {
+        logger.error(
+          'Error resolving campaign assignment classes:',
+          classRowsError,
+        );
+        throw classRowsError;
+      }
+
+      const classRows = (classRowsData ?? []) as Array<{
+        id: string;
+        school_id: string;
+        grade_id: string;
+      }>;
+
+      const classesBySchoolAndGrade = new Map<
+        string,
+        Array<{ id: string; school_id: string; grade_id: string }>
+      >();
+      classRows.forEach((classRow) => {
+        const key = `${classRow.school_id}:${classRow.grade_id}`;
+        if (!classesBySchoolAndGrade.has(key)) {
+          classesBySchoolAndGrade.set(key, []);
+        }
+        classesBySchoolAndGrade.get(key)?.push(classRow);
+      });
+
+      const missingAssignmentTargets = new Set<string>();
+      const assignmentRows = payload.assignments.flatMap((assignment) =>
+        assignment.schoolIds.flatMap((schoolId) => {
+          const classes =
+            classesBySchoolAndGrade.get(`${schoolId}:${assignment.gradeId}`) ??
+            [];
+          if (classes.length === 0) {
+            missingAssignmentTargets.add(`${schoolId}:${assignment.gradeId}`);
+          }
+          return classes.map((classRow) => ({
+            campaign_id: payload.campaignId,
+            batch_id: payload.campaignId,
+            class_id: classRow.id,
+            school_id: classRow.school_id,
+            lesson_id: assignment.lessonId,
+            chapter_id: assignment.chapterId,
+            course_id: assignment.courseId,
+            starts_at: assignment.startsAt,
+            ends_at: assignment.endsAt,
+            type: assignment.type,
+            source: assignment.source,
+            set_number: assignment.setNumber,
+            is_class_wise: true,
+            created_by: payload.currentUserId,
+            is_deleted: false,
+          }));
+        }),
+      );
+
+      if (missingAssignmentTargets.size > 0) {
+        logger.warn(
+          'Skipping campaign assignments for school/grade pairs without classes:',
+          Array.from(missingAssignmentTargets).map((target) => {
+            const [schoolId, gradeId] = target.split(':');
+            return { schoolId, gradeId };
+          }),
+        );
+      }
+
+      if (assignmentRows.length === 0) {
+        throw new Error(
+          'No classes found for the selected campaign assignments.',
+        );
+      }
+
+      for (const assignmentBatch of chunkArray(assignmentRows, 500)) {
+        const { error } = await this.supabase
+          .from(TABLES.Assignment)
+          .insert(assignmentBatch);
+
+        if (error) {
+          logger.error('Error inserting campaign assignments:', error);
+          throw error;
+        }
       }
     }
 


### PR DESCRIPTION
Teach the app to handle campaigns with objective "homepage_learning_pathway_campaign":

- Communication timeline: buildCommunicationTimelineDates now accepts the form and will generate dates from campaign start/end for homepage learning pathway campaigns (new buildCampaignDurationTimelineDates). Tests updated to cover this behavior.
- UI/UX: CampaignSetupStepper is now configurable via a steps prop; CampaignSetupPage computes stepper steps and active index to hide the Assignments step for homepage learning pathway campaigns and passes the form into timeline generation. CampaignReviewStep hides the Assignments review card for that objective. Small copy change: "activities" → "Lessons" in ChapterSelection.
- API: Launch payload includes objective. SupabaseApi.launchCampaign no longer requires assignments for homepage learning pathway campaigns, clears previous assignments before inserting, and only resolves/inserts assignment rows when assignments are required. Error handling and logging adjusted accordingly.
- Tests: Campaign setup tests updated to assert stepper contents and launch payload objective, and additional interaction assertions added.

These changes allow campaigns that target learning pathways (without class assignments) to have proper timelines, stepper flow, review, and server-side validation.