### PR TITLE
Increase grid row/column gaps in SelectMode.css

### DIFF
--- a/src/pages/SelectMode.css
+++ b/src/pages/SelectMode.css
@@ -305,7 +305,7 @@
   margin-top: 0.2vh;
   display: grid;
   grid-template-columns: repeat(4, var(--display-students-card-width));
-  row-gap: clamp(12px, 0.8vw, 10px);
+  row-gap: clamp(12px, 0.8vw, 16px);
   column-gap: clamp(22px, 2.2vw, 24px);
 
   justify-content: center;

--- a/src/pages/SelectMode.css
+++ b/src/pages/SelectMode.css
@@ -305,8 +305,9 @@
   margin-top: 0.2vh;
   display: grid;
   grid-template-columns: repeat(4, var(--display-students-card-width));
-  row-gap: clamp(6px, 0.8vw, 10px);
-  column-gap: clamp(16px, 2.2vw, 24px);
+  row-gap: clamp(12px, 0.8vw, 10px);
+  column-gap: clamp(22px, 2.2vw, 24px);
+
   justify-content: center;
   align-content: start;
   /* max-height: calc(


### PR DESCRIPTION
Adjust grid spacing in SelectMode.css by increasing the minimum row-gap from 6px to 12px and the minimum column-gap from 16px to 22px (clamp() ranges otherwise unchanged). This improves spacing between student cards for better readability across viewports.