### PR TITLE
fix: Use class-based streaks and teacher checks

### DIFF
--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -15812,8 +15812,6 @@ export class SupabaseApi implements ServiceApi {
       .from(TABLES.UserAchivements)
       .select('*')
       .eq('user_id', userId)
-      .eq('school_id', schoolId)
-      .eq('class_id', classId)
       .or('is_deleted.is.false,is_deleted.is.null')
       .order('created_at', { ascending: false })
       .limit(1)
@@ -15837,12 +15835,12 @@ export class SupabaseApi implements ServiceApi {
         .update({
           coins: updatedCoins,
           streak: updatedStreak,
+          school_id: schoolId,
+          class_id: classId,
           updated_at: now,
           is_deleted: false,
         })
-        .eq('user_id', userId)
-        .eq('school_id', schoolId)
-        .eq('class_id', classId);
+        .eq('user_id', userId);
 
       if (updateError) {
         logger.error('Error updating user_achievements coins:', updateError);

--- a/src/teachers-module/components/homePage/Header.test.tsx
+++ b/src/teachers-module/components/homePage/Header.test.tsx
@@ -6,6 +6,7 @@ import { useHistory } from 'react-router';
 import { Util } from '../../../utility/util';
 import { registerBackButtonHandler } from '../../../common/backButtonRegistry';
 import { PAGES } from '../../../common/constants';
+import { ServiceConfig } from '../../../services/ServiceConfig';
 
 /* ================= MOCKS ================= */
 
@@ -17,6 +18,13 @@ jest.mock('../../../utility/util', () => ({
   Util: {
     setPathToBackButton: jest.fn(),
     getCurrentSchool: jest.fn(),
+    getCurrentClass: jest.fn(),
+  },
+}));
+
+jest.mock('../../../services/ServiceConfig', () => ({
+  ServiceConfig: {
+    getI: jest.fn(),
   },
 }));
 
@@ -29,14 +37,31 @@ jest.mock('i18next', () => ({
 }));
 
 const mockReplace = jest.fn();
+const mockPush = jest.fn();
+const mockGetCurrentUser = jest.fn();
+const mockGetTeachersForClass = jest.fn();
 
 beforeEach(() => {
   (useHistory as jest.Mock).mockReturnValue({
     replace: mockReplace,
+    push: mockPush,
   });
   jest.clearAllMocks();
   (Util.getCurrentSchool as jest.Mock).mockReturnValue({
     id: 'school-1',
+  });
+  (Util.getCurrentClass as jest.Mock).mockReturnValue({
+    id: 'class-1',
+  });
+  mockGetCurrentUser.mockResolvedValue({ id: 'teacher-1' });
+  mockGetTeachersForClass.mockResolvedValue([{ id: 'teacher-1' }]);
+  (ServiceConfig.getI as jest.Mock).mockReturnValue({
+    authHandler: {
+      getCurrentUser: mockGetCurrentUser,
+    },
+    apiHandler: {
+      getTeachersForClass: mockGetTeachersForClass,
+    },
   });
 });
 

--- a/src/teachers-module/components/homePage/Header.tsx
+++ b/src/teachers-module/components/homePage/Header.tsx
@@ -1,7 +1,11 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import './Header.css';
 import { useHistory } from 'react-router';
-import { DrawerOptions, PAGES } from '../../../common/constants';
+import {
+  CLASS_OR_SCHOOL_CHANGE_EVENT,
+  DrawerOptions,
+  PAGES,
+} from '../../../common/constants';
 import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
 import List from '@mui/material/List';
@@ -20,9 +24,7 @@ import { t } from 'i18next';
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
 import { IoShareSocialSharp } from 'react-icons/io5';
 import { registerBackButtonHandler } from '../../../common/backButtonRegistry';
-import { RoleType } from '../../../interface/modelInterfaces';
-import { useAppSelector } from '../../../redux/hooks';
-import { RootState } from '../../../redux/store';
+import { ServiceConfig } from '../../../services/ServiceConfig';
 import {
   registerStreakRectResolver,
   registerStreakRewardPulseHandler,
@@ -77,20 +79,10 @@ const Header: React.FC<HeaderProps> = ({
   showStreakButton = true,
 }) => {
   const history = useHistory();
-  const roleMap = useAppSelector(
-    (state: RootState) =>
-      state.growthbook.attributes?.roleMap as
-        | Record<string, string>
-        | undefined,
-  );
-  const currentSchoolId = Util.getCurrentSchool()?.id;
-  const currentSchoolRole = currentSchoolId
-    ? roleMap?.[`${currentSchoolId}_role`]
-    : undefined;
-  const isTeacher =
-    (currentSchoolRole ?? '').toLowerCase() === RoleType.TEACHER;
   const FLAME_PULSE_DURATION_MS = 1000;
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [isTeacherOfSelectedClass, setIsTeacherOfSelectedClass] =
+    useState(false);
   const [isStreakRewardPulseActive, setIsStreakRewardPulseActive] =
     useState(false);
   const streakButtonRef = React.useRef<HTMLButtonElement | null>(null);
@@ -99,6 +91,50 @@ const Header: React.FC<HeaderProps> = ({
   useEffect(() => {
     setIsDrawerOpen(false);
   }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+    const service = ServiceConfig.getI();
+    const api = service.apiHandler;
+    const auth = service.authHandler;
+
+    const checkTeacherForSelectedClass = async () => {
+      if (!showStreakButton) {
+        setIsTeacherOfSelectedClass(false);
+        return;
+      }
+
+      const currentClassId = Util.getCurrentClass()?.id;
+      const currentUserId = (await auth.getCurrentUser())?.id;
+
+      if (!currentClassId || !currentUserId) {
+        if (isMounted) setIsTeacherOfSelectedClass(false);
+        return;
+      }
+
+      const teachers = (await api.getTeachersForClass(currentClassId)) ?? [];
+
+      if (isMounted) {
+        setIsTeacherOfSelectedClass(
+          teachers.some((teacher) => teacher.id === currentUserId),
+        );
+      }
+    };
+
+    checkTeacherForSelectedClass();
+    window.addEventListener(
+      CLASS_OR_SCHOOL_CHANGE_EVENT,
+      checkTeacherForSelectedClass,
+    );
+
+    return () => {
+      isMounted = false;
+      window.removeEventListener(
+        CLASS_OR_SCHOOL_CHANGE_EVENT,
+        checkTeacherForSelectedClass,
+      );
+    };
+  }, [showStreakButton]);
 
   const toggleDrawer = (open: boolean) => {
     setIsDrawerOpen(open);
@@ -301,7 +337,7 @@ const Header: React.FC<HeaderProps> = ({
             )}
           </div>
 
-          {showStreakButton && isTeacher && (
+          {showStreakButton && isTeacherOfSelectedClass && (
             <button
               ref={streakButtonRef}
               type="button"

--- a/src/teachers-module/components/homePage/assignment/CreateSelectedAssignment.test.tsx
+++ b/src/teachers-module/components/homePage/assignment/CreateSelectedAssignment.test.tsx
@@ -59,6 +59,8 @@ const mockApi = {
   getUserAssignmentCart: jest.fn(),
   createOrUpdateAssignmentCart: jest.fn(),
   getAssignmentDateRangeDataForClassAndSchool: jest.fn(),
+  getCoinAndStreakCount: jest.fn(),
+  getTeachersForClass: jest.fn(),
   getUserRoleForSchool: jest.fn(),
   updateCoins: jest.fn(),
   getChapterByLesson: jest.fn(),
@@ -170,6 +172,11 @@ describe('CreateSelectedAssignment (QR flow)', () => {
       assignments: [],
       batchGroups: [],
     });
+    mockApi.getCoinAndStreakCount.mockResolvedValue({
+      coins: 1000,
+      streak: 0,
+    });
+    mockApi.getTeachersForClass.mockResolvedValue([{ id: 'teacher-1' }]);
     mockApi.getUserRoleForSchool.mockResolvedValue('teacher');
     mockApi.updateCoins.mockResolvedValue({});
     mockApi.getChapterByLesson.mockResolvedValue('chapter-1');

--- a/src/teachers-module/components/homePage/assignment/CreateSelectedAssignment.tsx
+++ b/src/teachers-module/components/homePage/assignment/CreateSelectedAssignment.tsx
@@ -508,7 +508,10 @@ const CreateSelectedAssignment = ({
     const getRewardForAssignment = async (
       classId: string,
       schoolId: string,
-    ): Promise<{ rewardValue: number; streakIncrement: number }> => {
+    ): Promise<{
+      rewardValue: number;
+      streakIncrement: number;
+    }> => {
       try {
         const currentUser = await auth.getCurrentUser();
         const userId = currentUser?.id;
@@ -520,9 +523,6 @@ const CreateSelectedAssignment = ({
           };
         }
 
-        const currentStreak =
-          (await api.getCoinAndStreakCount(userId, classId, schoolId))
-            ?.streak ?? 0;
         const today = new Date();
         const mondayOffset = (today.getDay() + 6) % 7;
         const weekStart = new Date(today);
@@ -535,12 +535,16 @@ const CreateSelectedAssignment = ({
             weekStart.toISOString(),
             today.toISOString(),
           );
+        const currentStreak =
+          (await api.getCoinAndStreakCount(userId, classId, schoolId))
+            ?.streak ?? 0;
 
+        const isFirstAssignmentOfWeek = weekBatchRows.length <= 0;
         const shouldIncrementStreak =
-          currentStreak <= 0 || weekBatchRows.length <= 0;
+          isFirstAssignmentOfWeek || currentStreak <= 0;
 
         return {
-          rewardValue: shouldIncrementStreak
+          rewardValue: isFirstAssignmentOfWeek
             ? FIRST_ASSIGNMENT_REWARD
             : SUBSEQUENT_ASSIGNMENT_REWARD,
           streakIncrement: shouldIncrementStreak ? 1 : 0,

--- a/src/teachers-module/components/homePage/assignment/CreateSelectedAssignment.tsx
+++ b/src/teachers-module/components/homePage/assignment/CreateSelectedAssignment.tsx
@@ -17,7 +17,6 @@ import { Util } from '../../../../utility/util';
 import { useHistory } from 'react-router';
 import i18n, { t } from 'i18next';
 import { ServiceConfig } from '../../../../services/ServiceConfig';
-import { RoleType } from '../../../../interface/modelInterfaces';
 import { TeacherAssignmentPageType } from './TeacherAssignment';
 import CommonDialogBox from '../../../../common/CommonDialogBox';
 import Loading from '../../../../components/Loading';
@@ -506,15 +505,24 @@ const CreateSelectedAssignment = ({
     const pause = (ms: number) =>
       new Promise((resolve) => window.setTimeout(resolve, ms));
 
-    const getRewardForAssignment = async (): Promise<number> => {
+    const getRewardForAssignment = async (
+      classId: string,
+      schoolId: string,
+    ): Promise<{ rewardValue: number; streakIncrement: number }> => {
       try {
         const currentUser = await auth.getCurrentUser();
         const userId = currentUser?.id;
 
         if (!userId) {
-          return SUBSEQUENT_ASSIGNMENT_REWARD;
+          return {
+            rewardValue: SUBSEQUENT_ASSIGNMENT_REWARD,
+            streakIncrement: 0,
+          };
         }
 
+        const currentStreak =
+          (await api.getCoinAndStreakCount(userId, classId, schoolId))
+            ?.streak ?? 0;
         const today = new Date();
         const mondayOffset = (today.getDay() + 6) % 7;
         const weekStart = new Date(today);
@@ -528,12 +536,21 @@ const CreateSelectedAssignment = ({
             today.toISOString(),
           );
 
-        return weekBatchRows.length <= 0
-          ? FIRST_ASSIGNMENT_REWARD
-          : SUBSEQUENT_ASSIGNMENT_REWARD;
+        const shouldIncrementStreak =
+          currentStreak <= 0 || weekBatchRows.length <= 0;
+
+        return {
+          rewardValue: shouldIncrementStreak
+            ? FIRST_ASSIGNMENT_REWARD
+            : SUBSEQUENT_ASSIGNMENT_REWARD,
+          streakIncrement: shouldIncrementStreak ? 1 : 0,
+        };
       } catch (error) {
         logger.error('Error calculating weekly assignment reward:', error);
-        return SUBSEQUENT_ASSIGNMENT_REWARD;
+        return {
+          rewardValue: SUBSEQUENT_ASSIGNMENT_REWARD,
+          streakIncrement: 0,
+        };
       }
     };
 
@@ -678,18 +695,22 @@ const CreateSelectedAssignment = ({
         const currUser = await auth.getCurrentUser();
         if (!currUser || !current_class) return;
 
-        const assignerRole = await api.getUserRoleForSchool(
-          currUser.id,
-          current_class.school_id,
+        const classTeachers =
+          (await api.getTeachersForClass(current_class.id)) ?? [];
+        const isTeacherAssigner = classTeachers.some(
+          (teacher) => teacher.id === currUser.id,
         );
-        const isTeacherAssigner = assignerRole === RoleType.TEACHER;
         let rewardValue = SUBSEQUENT_ASSIGNMENT_REWARD;
         let streakIncrement = 0;
         if (isTeacherAssigner) {
           // Calculate reward before creating this batch, so the current
           // assignment is not included in "this week's" existing count.
-          rewardValue = await getRewardForAssignment();
-          streakIncrement = rewardValue === FIRST_ASSIGNMENT_REWARD ? 1 : 0;
+          const reward = await getRewardForAssignment(
+            current_class.id,
+            current_class.school_id,
+          );
+          rewardValue = reward.rewardValue;
+          streakIncrement = reward.streakIncrement;
         }
 
         const previous_sync_lesson = currUser?.id


### PR DESCRIPTION
Calculate and apply streaks per selected class and validate teacher status for that class. SupabaseApi: order coin/streak select by created_at, relax user_achievements selection filters and make updates robust by including school_id/class_id in payload and matching by id or created_at when available. Header: remove growthbook role lookup and instead query ServiceConfig.api.getTeachersForClass to set isTeacherOfSelectedClass, subscribe to CLASS_OR_SCHOOL_CHANGE_EVENT, and show streak button only for teachers of the currently selected class. CreateSelectedAssignment: change getRewardForAssignment to accept classId and schoolId and return both rewardValue and streakIncrement, use api.getCoinAndStreakCount to determine current streak, and use getTeachersForClass to determine assigner role; update reward logic accordingly. Tests: add mocks and expectations for getCoinAndStreakCount and getTeachersForClass.