### PR TITLE
fix: Stop audio playback on route changes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -189,6 +189,21 @@ const LAST_ACCESS_DATE_KEY = 'lastAccessDate';
 const IS_INITIALIZED = 'isInitialized';
 let timeoutId: NodeJS.Timeout;
 
+const RouteAudioCleanup = () => {
+  const location = useLocation();
+  const lastLocationRef = useRef(location.pathname + location.search);
+
+  useEffect(() => {
+    const currentLocation = location.pathname + location.search;
+    if (lastLocationRef.current !== currentLocation) {
+      void AudioUtil.stopAudioUrlOrTtsPlayback();
+      lastLocationRef.current = currentLocation;
+    }
+  }, [location.pathname, location.search]);
+
+  return null;
+};
+
 const App: React.FC = () => {
   const growthbook = useGrowthBook();
   const [online, setOnline] = useState(navigator.onLine);
@@ -258,21 +273,6 @@ const App: React.FC = () => {
         document.body.classList.remove('ops-console');
       };
     }, [location.pathname]);
-
-    return null;
-  };
-
-  const RouteAudioCleanup = () => {
-    const location = useLocation();
-    const lastLocationRef = useRef(location.pathname + location.search);
-
-    useEffect(() => {
-      const currentLocation = location.pathname + location.search;
-      if (lastLocationRef.current !== currentLocation) {
-        void AudioUtil.stopAudioUrlOrTtsPlayback();
-        lastLocationRef.current = currentLocation;
-      }
-    }, [location.pathname, location.search]);
 
     return null;
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,6 +164,7 @@ import TeacherRecommendedAssignments from './teachers-module/components/homePage
 import StreakPage from './teachers-module/components/streakComponent/streakPage';
 import StickerBook from './pages/StickerBook';
 import KidsAppLocation from './teachers-module/pages/KidsAppLocation';
+import { AudioUtil } from './utility/AudioUtil';
 
 setupIonicReact();
 interface ExtraData {
@@ -257,6 +258,21 @@ const App: React.FC = () => {
         document.body.classList.remove('ops-console');
       };
     }, [location.pathname]);
+
+    return null;
+  };
+
+  const RouteAudioCleanup = () => {
+    const location = useLocation();
+    const lastLocationRef = useRef(location.pathname + location.search);
+
+    useEffect(() => {
+      const currentLocation = location.pathname + location.search;
+      if (lastLocationRef.current !== currentLocation) {
+        void AudioUtil.stopAudioUrlOrTtsPlayback();
+        lastLocationRef.current = currentLocation;
+      }
+    }, [location.pathname, location.search]);
 
     return null;
   };
@@ -633,6 +649,7 @@ const App: React.FC = () => {
     <IonApp>
       <IonReactRouter basename={BASE_NAME}>
         <OpsConsoleRouteWatcher />
+        <RouteAudioCleanup />
         <TermsGate />
         <HardwareBackButtonHandler
           popupDataRef={popupDataRef}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -602,6 +602,7 @@ const App: React.FC = () => {
       }
       startTimeout();
     } else {
+      void AudioUtil.stopAudioUrlOrTtsPlayback();
       saveUsedTime();
       localStorage.removeItem(START_TIME_KEY);
       clearExistingTimeout();

--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -96,7 +96,6 @@ import {
   REMOTE_CONFIG_KEYS,
 } from '../services/RemoteConfig';
 import { schoolUtil } from './schoolUtil';
-import { TextToSpeech } from '@capacitor-community/text-to-speech';
 import { URLOpenListenerEvent } from '@capacitor/app';
 import { t } from 'i18next';
 import { FirebaseCrashlytics } from '@capacitor-firebase/crashlytics';
@@ -122,6 +121,7 @@ import {
 } from '../redux/slices/auth/authSlice';
 import logger from './logger';
 import type { StickerBookModalData } from '../components/learningPathway/StickerBookPreviewModal';
+import { AudioUtil } from './AudioUtil';
 
 type LessonBundleDownloadOptions = {
   lessonId: string;
@@ -1136,9 +1136,8 @@ export class Util {
   }
 
   public static onAppStateChange = ({ isActive }: { isActive: boolean }) => {
-    // Existing logic for stopping TextToSpeech when app is inactive
     if (!isActive) {
-      TextToSpeech.stop();
+      void AudioUtil.stopAudioUrlOrTtsPlayback();
     }
     logger.info('[Lifecycle] App state changed', { isActive });
 


### PR DESCRIPTION
- Add RouteAudioCleanup component to stop ongoing audio/TTs when navigation occurs. 

- Imports AudioUtil and mounts RouteAudioCleanup inside the router; the component tracks the last location with a ref and calls AudioUtil.stopAudioUrlOrTtsPlayback() in an effect when pathname or search changes to prevent audio persisting across pages.