### PR TITLE
fix: Skip rebuilding assessments pathway when same assessment assigned as assignment

### DIFF
--- a/src/hooks/useLearningPath.test.ts
+++ b/src/hooks/useLearningPath.test.ts
@@ -255,6 +255,31 @@ describe('useLearningPath features used by Home tab', () => {
     expect(palUtil.getPalLessonPathForCourse).not.toHaveBeenCalled();
   });
 
+  test('skips assessment recommendation when rebuilding after assessment termination', async () => {
+    mockApi.getSubjectLessonsBySubjectId.mockResolvedValue({
+      id: 'asmt-doc-1',
+      lesson_id: 'assessment-lesson-1',
+    });
+    mockApi.getChaptersForCourse.mockResolvedValue([{ id: 'chapter-1' }]);
+    mockApi.getLessonsForChapter.mockResolvedValue([{ id: 'normal-lesson-1' }]);
+
+    const next = await recommendNextLesson({
+      student: { id: 'stu-1' },
+      course: { id: 'c1', subject_id: 's1' },
+      mode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
+      skipAssessment: true,
+    });
+
+    expect(mockApi.getSubjectLessonsBySubjectId).not.toHaveBeenCalled();
+    expect(next).toEqual({
+      lesson_id: 'normal-lesson-1',
+      chapter_id: 'chapter-1',
+      source: SOURCE.LEARNING_PATHWAY_HOME_NO_PAL,
+      is_assessment: false,
+      isPlayed: false,
+    });
+  });
+
   test('resumes same teacher-assigned assessment after exit', async () => {
     mockApi.getLatestAssessmentGroup.mockResolvedValue([
       { id: 'assignment-11', lesson_id: 'teacher-asmt-11' },
@@ -374,6 +399,158 @@ describe('useLearningPath features used by Home tab', () => {
         isPlayed: false,
       },
     ]);
+  });
+
+  test('does not rebuild an in-progress assessment path when matching assessments are assigned', async () => {
+    const existingPath = {
+      courses: {
+        currentCourseIndex: 0,
+        courseList: [
+          {
+            path_id: 'assessment-path',
+            course_id: 'c1',
+            subject_id: 's1',
+            type: 'chapter',
+            path: [
+              {
+                lesson_id: 'assessment-lesson-1',
+                is_assessment: true,
+                isPlayed: true,
+              },
+              {
+                lesson_id: 'assessment-lesson-2',
+                is_assessment: true,
+                isPlayed: false,
+              },
+              {
+                lesson_id: 'assessment-lesson-3',
+                is_assessment: true,
+                isPlayed: false,
+              },
+            ],
+            completedPath: 0,
+          },
+        ],
+      },
+      type: 'chapter',
+      pathMode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
+    };
+    (Util.getCurrentStudent as jest.Mock).mockReturnValue({
+      id: 'stu-1',
+      learning_path: JSON.stringify(existingPath),
+    });
+    mockApi.getLatestAssessmentGroup.mockResolvedValue([
+      { id: 'assignment-1', lesson_id: 'assessment-lesson-1' },
+      { id: 'assignment-2', lesson_id: 'assessment-lesson-2' },
+      { id: 'assignment-3', lesson_id: 'assessment-lesson-3' },
+    ]);
+
+    const { result } = renderHook(() => useLearningPath());
+    await act(async () => {
+      await result.current.getPath({
+        courses: [{ id: 'c1', subject_id: 's1', framework_id: null }],
+        mode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
+        classId: 'class-1',
+      });
+    });
+
+    const saved = mockApi.updateLearningPath.mock.calls[0][1];
+    const parsed = JSON.parse(saved) as {
+      courses: {
+        courseList: Array<{
+          path_id: string;
+          path: Array<{
+            lesson_id: string;
+            assignment_id?: string;
+            isPlayed: boolean;
+          }>;
+        }>;
+      };
+    };
+    const coursePath = parsed.courses.courseList[0];
+
+    expect(coursePath.path_id).toBe('assessment-path');
+    expect(coursePath.path).toEqual([
+      {
+        lesson_id: 'assessment-lesson-1',
+        assignment_id: 'assignment-1',
+        source: SOURCE.INITIAL_ASSESSMENT,
+        is_assessment: true,
+        isPlayed: true,
+      },
+      {
+        lesson_id: 'assessment-lesson-2',
+        assignment_id: 'assignment-2',
+        source: SOURCE.INITIAL_ASSESSMENT,
+        is_assessment: true,
+        isPlayed: false,
+      },
+      {
+        lesson_id: 'assessment-lesson-3',
+        assignment_id: 'assignment-3',
+        source: SOURCE.INITIAL_ASSESSMENT,
+        is_assessment: true,
+        isPlayed: false,
+      },
+    ]);
+  });
+
+  test('does not reset an already assigned assessment path when a new batch arrives mid-assessment', async () => {
+    const existingPath = {
+      courses: {
+        currentCourseIndex: 0,
+        courseList: [
+          {
+            path_id: 'assigned-assessment-path',
+            course_id: 'math-course',
+            subject_id: 'math-subject',
+            type: 'chapter',
+            path: [
+              {
+                lesson_id: 'math-assessment-1',
+                assignment_id: 'old-assignment-1',
+                is_assessment: true,
+                isPlayed: true,
+              },
+              {
+                lesson_id: 'math-assessment-2',
+                assignment_id: 'old-assignment-2',
+                is_assessment: true,
+                isPlayed: false,
+              },
+            ],
+            completedPath: 0,
+          },
+        ],
+      },
+      type: 'chapter',
+      pathMode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
+    };
+    (Util.getCurrentStudent as jest.Mock).mockReturnValue({
+      id: 'stu-1',
+      learning_path: JSON.stringify(existingPath),
+    });
+    mockApi.getLatestAssessmentGroup.mockResolvedValue([
+      { id: 'new-assignment-1', lesson_id: 'new-math-assessment-1' },
+      { id: 'new-assignment-2', lesson_id: 'new-math-assessment-2' },
+    ]);
+
+    const { result } = renderHook(() => useLearningPath());
+    await act(async () => {
+      await result.current.getPath({
+        courses: [
+          {
+            id: 'math-course',
+            subject_id: 'math-subject',
+            framework_id: null,
+          },
+        ],
+        mode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
+        classId: 'class-1',
+      });
+    });
+
+    expect(mockApi.updateLearningPath).not.toHaveBeenCalled();
   });
 
   test('marks only PAL recommended lessons with PAL source', async () => {

--- a/src/hooks/useLearningPath.ts
+++ b/src/hooks/useLearningPath.ts
@@ -105,6 +105,41 @@ const toAssignedAssessmentPath = (assignments: TableTypes<'assignment'>[]) =>
     .slice(0, ASSIGNED_ASSESSMENT_PATH_SIZE)
     .map(toAssignedAssessmentNode);
 
+const getAssignedAssessmentNodeKey = (node: LessonNode) =>
+  node.assignment_id ?? node.lesson_id;
+
+const hasInProgressAssessmentPath = (path: LessonNode[] = []) =>
+  path.some((node) => node.is_assessment === true && node.isPlayed === false);
+
+const mergeAssignedAssessmentIdsIntoPath = (
+  path: LessonNode[] = [],
+  assessmentPath: LessonNode[],
+) => {
+  const assignmentByLessonId = new Map(
+    assessmentPath.map((node) => [node.lesson_id, node.assignment_id]),
+  );
+  let updated = false;
+
+  const mergedPath = path.map((node) => {
+    if (
+      node.is_assessment !== true ||
+      node.assignment_id ||
+      !assignmentByLessonId.has(node.lesson_id)
+    ) {
+      return node;
+    }
+
+    updated = true;
+    return {
+      ...node,
+      assignment_id: assignmentByLessonId.get(node.lesson_id),
+      source: SOURCE.INITIAL_ASSESSMENT,
+    };
+  });
+
+  return updated ? mergedPath : path;
+};
+
 const getAssignedAssessmentPath = async ({
   student,
   course,
@@ -252,12 +287,14 @@ export async function recommendNextLesson({
   mode,
   classId,
   coursePath,
+  skipAssessment = false,
 }: {
   student: LearningPathStudent;
   course: LearningPathCourseInput;
   mode: string;
   classId?: string;
   coursePath?: Pick<CoursePath, 'path'> | null;
+  skipAssessment?: boolean;
 }): Promise<LessonNode | null> {
   const api = ServiceConfig.getI().apiHandler;
 
@@ -267,7 +304,7 @@ export async function recommendNextLesson({
   const hasCompletedInitialAssessment = shouldUsePAL(mode)
     ? await api.isStudentPlayedPalLesson(student.id, course.id)
     : false;
-  if (classId) {
+  if (!skipAssessment && classId) {
     const assessments = await api.getLatestAssessmentGroup(
       classId,
       student as TableTypes<'user'>,
@@ -291,6 +328,7 @@ export async function recommendNextLesson({
    * ------------------------------------------------------------------------------------------ */
   if (
     shouldUseAssessment(mode) &&
+    !skipAssessment &&
     !hasCompletedInitialAssessment &&
     course.subject_id
   ) {
@@ -955,6 +993,27 @@ export const useLearningPath = (opts?: {
       const assessmentPath = toAssignedAssessmentPath(assignments);
 
       const coursePath = oldCourseList[courseIndex];
+      if (hasInProgressAssessmentPath(coursePath.path)) {
+        const mergedPath = mergeAssignedAssessmentIdsIntoPath(
+          coursePath.path,
+          assessmentPath,
+        );
+
+        if (mergedPath !== coursePath.path) {
+          coursePath.path = mergedPath;
+          coursePath.display_name = course.pathway_display_name;
+          coursePath.is_pal_consolidated = course.is_pal_consolidated;
+          coursePath.type = course.framework_id
+            ? RECOMMENDATION_TYPE.FRAMEWORK
+            : RECOMMENDATION_TYPE.CHAPTER;
+          coursePath.subject_id = course.subject_id ?? null;
+
+          return { updated: true, currentCourseIndex: courseIndex };
+        }
+
+        continue;
+      }
+
       const activeAssessment = coursePath.path?.find(
         (node: LessonNode) =>
           node.isPlayed === false && node.is_assessment === true,
@@ -964,9 +1023,9 @@ export const useLearningPath = (opts?: {
           (node: LessonNode) =>
             node.isPlayed === false && node.is_assessment === true,
         )
-        .map((node: LessonNode) => node.assignment_id);
+        .map(getAssignedAssessmentNodeKey);
       const assignedAssessmentIds = assessmentPath.map(
-        (node) => node.assignment_id,
+        getAssignedAssessmentNodeKey,
       );
       const hasSamePendingAssessmentSequence =
         currentPendingAssessmentIds.length === assignedAssessmentIds.length &&

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -10241,16 +10241,20 @@ order by
       FROM result r
       INNER JOIN assignment a
         ON a.id = r.assignment_id
-      WHERE r.student_id = '${studentId}'
+      WHERE r.student_id = ?
         AND r.status = 'assessment_terminated'
-        AND r.is_deleted = false
-        AND a.class_id = '${classId}'
-        AND a.course_id = '${courseId}'
+        AND r.is_deleted = 0
+        AND a.class_id = ?
+        AND a.course_id = ?
         AND a.type = 'assessment'
       LIMIT 1;
     `;
 
-    const courseTerminationRes = await this._db?.query(courseTerminationQuery);
+    const courseTerminationRes = await this._db?.query(courseTerminationQuery, [
+      studentId,
+      classId,
+      courseId,
+    ]);
     if (courseTerminationRes?.values?.length) {
       return [];
     }
@@ -10352,7 +10356,7 @@ order by
           FROM result lr
           WHERE lr.student_id = '${studentId}'
             AND lr.lesson_id = a.lesson_id
-            AND lr.is_deleted = false
+            AND lr.is_deleted = 0
         )
 
         -- subject_lesson validation (LANGUAGE ONLY)

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -9947,7 +9947,6 @@ order by
         FROM result
         WHERE student_id = ?
           AND subject_id = ?
-          AND assignment_id IS NULL
           AND is_deleted = 0
           AND lesson_id IN (${resultPlaceholders});
       `;
@@ -10237,6 +10236,25 @@ order by
 
     if (!latestBatchId) return [];
 
+    const courseTerminationQuery = `
+      SELECT r.status
+      FROM result r
+      INNER JOIN assignment a
+        ON a.id = r.assignment_id
+      WHERE r.student_id = '${studentId}'
+        AND r.status = 'assessment_terminated'
+        AND r.is_deleted = false
+        AND a.class_id = '${classId}'
+        AND a.course_id = '${courseId}'
+        AND a.type = 'assessment'
+      LIMIT 1;
+    `;
+
+    const courseTerminationRes = await this._db?.query(courseTerminationQuery);
+    if (courseTerminationRes?.values?.length) {
+      return [];
+    }
+
     /* ==========================================
      * Check if batch is closed by termination or abort
      * ========================================== */
@@ -10329,6 +10347,13 @@ order by
 
         -- NOT completed
         AND r.assignment_id IS NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM result lr
+          WHERE lr.student_id = '${studentId}'
+            AND lr.lesson_id = a.lesson_id
+            AND lr.is_deleted = false
+        )
 
         -- subject_lesson validation (LANGUAGE ONLY)
         AND EXISTS (

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -14657,7 +14657,6 @@ export class SupabaseApi implements ServiceApi {
         .select('lesson_id')
         .in('lesson_id', lessonIds)
         .eq('student_id', studentId)
-        .is('assignment_id', null)
         .eq('is_deleted', false);
 
       const { data: results } = await resultsQuery;
@@ -14993,6 +14992,35 @@ export class SupabaseApi implements ServiceApi {
     const latestBatchId = latestAssignedBatch?.batch_id;
     if (!latestBatchId) return [];
 
+    const { data: courseTerminationResults, error: courseTerminationError } =
+      await this.supabase
+        .from(TABLES.Result)
+        .select(
+          `
+          status,
+          assignment!inner(class_id, course_id, type)
+        `,
+        )
+        .eq('student_id', studentId)
+        .eq('status', 'assessment_terminated')
+        .eq('is_deleted', false)
+        .eq('assignment.class_id', classId)
+        .eq('assignment.course_id', courseId)
+        .eq('assignment.type', 'assessment')
+        .limit(1);
+
+    if (courseTerminationError) {
+      logger.error(
+        'Course assessment termination query error:',
+        courseTerminationError,
+      );
+      return [];
+    }
+
+    if (courseTerminationResults?.length) {
+      return [];
+    }
+
     /* ==========================================
      * STEP 2️⃣  Abort check
      * ========================================== */
@@ -15078,19 +15106,38 @@ export class SupabaseApi implements ServiceApi {
     if (!assignedAssessments.length) return [];
 
     const assignmentIds = assignedAssessments.map((a) => a.id);
+    const assignedLessonIds = assignedAssessments
+      .map((assignment) => assignment.lesson_id)
+      .filter((lessonId): lessonId is string => !!lessonId);
 
-    // fetch completed results
-    const { data: results } = await this.supabase
+    const { data: assignmentResults } = await this.supabase
       .from(TABLES.Result)
       .select('assignment_id')
       .in('assignment_id', assignmentIds)
       .eq('student_id', studentId)
       .eq('is_deleted', false);
 
-    const completedSet = new Set((results ?? []).map((r) => r.assignment_id));
+    const completedAssignmentIds = new Set(
+      (assignmentResults ?? []).map((r) => r.assignment_id),
+    );
+
+    const { data: lessonResults } = assignedLessonIds.length
+      ? await this.supabase
+          .from(TABLES.Result)
+          .select('lesson_id')
+          .in('lesson_id', assignedLessonIds)
+          .eq('student_id', studentId)
+          .eq('is_deleted', false)
+      : { data: [] };
+
+    const completedLessonIds = new Set(
+      (lessonResults ?? []).map((r) => r.lesson_id),
+    );
 
     const incompleteAssignments = assignedAssessments.filter(
-      (a) => !completedSet.has(a.id),
+      (a) =>
+        !completedAssignmentIds.has(a.id) &&
+        !completedLessonIds.has(a.lesson_id),
     );
 
     if (!incompleteAssignments.length) return [];

--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -2915,6 +2915,7 @@ export class Util {
           },
           mode: storedPathwayMode || LEARNING_PATHWAY_MODE.DISABLED,
           coursePath: course,
+          skipAssessment: true,
         }));
 
       if (nextLesson && !nextQueuedLesson) {
@@ -2946,6 +2947,7 @@ export class Util {
             },
             mode: storedPathwayMode,
             coursePath: peerCourse,
+            skipAssessment: true,
           });
 
           if (peerNextLesson) {


### PR DESCRIPTION
- Prevent rebuilding or resetting assessment learning paths when same assessments are assigned and assessment has not played or is in-progress. 
- Add skipAssessment flag to recommendNextLesson and propagate it where appropriate to avoid recommending assessments after termination. 
- Introduce helpers (getAssignedAssessmentNodeKey, hasInProgressAssessmentPath, mergeAssignedAssessmentIdsIntoPath) to merge new assignment IDs into an existing in-progress assessment path instead of replacing it. 
- Update useLearningPath to merge assignment IDs for in-progress paths and only update the saved path when changes occur. 
- Add checks in SqliteApi and SupabaseApi to detect course-level assessment termination and return no assigned assessments when termination is present.
- Update util to pass skipAssessment in rebuild scenarios. 
- Add tests covering skipping assessment recommendation after termination and preserving in-progress/assigned assessment paths when new batches arrive.