### PR TITLE
Fix student profile creation and back navigation

### DIFF
--- a/src/components/parent/ProfileCard.test.tsx
+++ b/src/components/parent/ProfileCard.test.tsx
@@ -4,7 +4,7 @@ import { EVENTS, MODES, PAGES } from '../../common/constants';
 import ProfileCard from './ProfileCard';
 import { Util } from '../../utility/util';
 
-const mockHistoryReplace = jest.fn();
+const mockHistoryPush = jest.fn();
 const mockPresentToast = jest.fn();
 
 jest.mock('@ionic/react', () => ({
@@ -15,8 +15,8 @@ jest.mock('@ionic/react', () => ({
 
 jest.mock('react-router-dom', () => ({
   useHistory: () => ({
-    replace: mockHistoryReplace,
-    location: { pathname: '/parent' },
+    push: mockHistoryPush,
+    location: { pathname: '/parent', search: '' },
   }),
 }));
 
@@ -86,8 +86,9 @@ describe('ProfileCard', () => {
         {},
       ),
     );
-    expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.CREATE_STUDENT, {
-      showBackButton: false,
+    expect(mockHistoryPush).toHaveBeenCalledWith(PAGES.CREATE_STUDENT, {
+      isEdit: false,
+      from: '/parent',
     });
   });
 });

--- a/src/components/parent/ProfileCard.tsx
+++ b/src/components/parent/ProfileCard.tsx
@@ -196,8 +196,9 @@ const ProfileCard: React.FC<{
                 return;
               }
               void Util.logEvent(EVENTS.PROFILE_CREATION_CLICKED, {});
-              history.replace(PAGES.CREATE_STUDENT, {
-                showBackButton: !areProfilesAvailable,
+              history.push(PAGES.CREATE_STUDENT, {
+                isEdit: false,
+                from: `${history.location.pathname}${history.location.search}`,
               });
             }}
           >

--- a/src/components/profileDetails/ProfileDetails.tsx
+++ b/src/components/profileDetails/ProfileDetails.tsx
@@ -268,32 +268,20 @@ const ProfileDetails = () => {
 
       // CREATE MODE Logic
       const state = history.location.state as any;
-      if (state?.from) {
-        const targetPath = withContinueIfNeeded(state.from);
-        if (targetPath.startsWith(PAGES.DISPLAY_STUDENT)) {
-          // Reinitialize hardware back handling only for create -> display students path.
-          reinitializeHardwareBackButton();
-          const separator = targetPath.includes('?') ? '&' : '?';
-          history.replace(`${targetPath}${separator}forceReload=1`);
-        } else {
-          history.replace(targetPath);
-        }
-      } else {
-        const createFallbackPath = parentHasStudentRef.current
-          ? PAGES.DISPLAY_STUDENT
-          : PAGES.SELECT_MODE;
-        const targetPath = withContinueIfNeeded(
-          state?.from ?? createFallbackPath,
-        );
+      const createFallbackPath = parentHasStudentRef.current
+        ? PAGES.DISPLAY_STUDENT
+        : PAGES.SELECT_MODE;
+      const targetPath = withContinueIfNeeded(
+        state?.from ?? createFallbackPath,
+      );
 
-        if (targetPath.startsWith(PAGES.DISPLAY_STUDENT)) {
-          // Reinitialize hardware back handling only for create -> display students path.
-          reinitializeHardwareBackButton();
-          const separator = targetPath.includes('?') ? '&' : '?';
-          history.replace(`${targetPath}${separator}forceReload=1`);
-        } else {
-          history.replace(targetPath);
-        }
+      if (targetPath.startsWith(PAGES.DISPLAY_STUDENT)) {
+        // Reinitialize hardware back handling only for create -> display students path.
+        reinitializeHardwareBackButton();
+        const separator = targetPath.includes('?') ? '&' : '?';
+        history.replace(`${targetPath}${separator}forceReload=1`);
+      } else {
+        history.replace(targetPath);
       }
       return;
     } catch (e) {

--- a/src/components/profileDetails/ProfileDetails.tsx
+++ b/src/components/profileDetails/ProfileDetails.tsx
@@ -282,7 +282,9 @@ const ProfileDetails = () => {
         const createFallbackPath = parentHasStudentRef.current
           ? PAGES.DISPLAY_STUDENT
           : PAGES.SELECT_MODE;
-        const targetPath = withContinueIfNeeded(createFallbackPath);
+        const targetPath = withContinueIfNeeded(
+          state?.from ?? createFallbackPath,
+        );
 
         if (targetPath.startsWith(PAGES.DISPLAY_STUDENT)) {
           // Reinitialize hardware back handling only for create -> display students path.

--- a/src/components/profileDetails/ProfileDetails.tsx
+++ b/src/components/profileDetails/ProfileDetails.tsx
@@ -268,20 +268,22 @@ const ProfileDetails = () => {
 
       // CREATE MODE Logic
       const state = history.location.state as any;
-      const createFallbackPath = parentHasStudentRef.current
-        ? PAGES.DISPLAY_STUDENT
-        : PAGES.SELECT_MODE;
-      const targetPath = withContinueIfNeeded(
-        state?.from ?? createFallbackPath,
-      );
-
-      if (targetPath.startsWith(PAGES.DISPLAY_STUDENT)) {
-        // Reinitialize hardware back handling only for create -> display students path.
-        reinitializeHardwareBackButton();
-        const separator = targetPath.includes('?') ? '&' : '?';
-        history.replace(`${targetPath}${separator}forceReload=1`);
+      if (state?.from) {
+        const targetPath = withContinueIfNeeded(state.from);
+        if (targetPath.startsWith(PAGES.DISPLAY_STUDENT)) {
+          // Reinitialize hardware back handling only for create -> display students path.
+          reinitializeHardwareBackButton();
+          const separator = targetPath.includes('?') ? '&' : '?';
+          history.replace(`${targetPath}${separator}forceReload=1`);
+        } else {
+          history.replace(targetPath);
+        }
+      } else if (history.length > 1) {
+        history.goBack();
+      } else if (parentHasStudentRef.current) {
+        history.replace(PAGES.DISPLAY_STUDENT);
       } else {
-        history.replace(targetPath);
+        history.replace(PAGES.SELECT_MODE);
       }
       return;
     } catch (e) {
@@ -547,7 +549,7 @@ const ProfileDetails = () => {
 
         <div className="profiledetails-form-fields">
           {/* Header Info: Class Name | School Name */}
-          {(className || schoolName) && (
+          {isEdit && (className || schoolName) && (
             <div className="profiledetails-header-info">
               {className && (
                 <div className="pd-info-item">

--- a/src/components/profileDetails/ProfileDetails.tsx
+++ b/src/components/profileDetails/ProfileDetails.tsx
@@ -278,12 +278,20 @@ const ProfileDetails = () => {
         } else {
           history.replace(targetPath);
         }
-      } else if (history.length > 1) {
-        history.goBack();
-      } else if (parentHasStudentRef.current) {
-        history.replace(PAGES.DISPLAY_STUDENT);
       } else {
-        history.replace(PAGES.SELECT_MODE);
+        const createFallbackPath = parentHasStudentRef.current
+          ? PAGES.DISPLAY_STUDENT
+          : PAGES.SELECT_MODE;
+        const targetPath = withContinueIfNeeded(createFallbackPath);
+
+        if (targetPath.startsWith(PAGES.DISPLAY_STUDENT)) {
+          // Reinitialize hardware back handling only for create -> display students path.
+          reinitializeHardwareBackButton();
+          const separator = targetPath.includes('?') ? '&' : '?';
+          history.replace(`${targetPath}${separator}forceReload=1`);
+        } else {
+          history.replace(targetPath);
+        }
       }
       return;
     } catch (e) {


### PR DESCRIPTION
Issue 1:
- Removed school name and class name during student profile creation.
- Display them only in edit mode.

Issue 2:
- Fix back navigation from create student profile.
- Pass previous route using `from` and use `history.push` instead of `history.replace`.
- Back now returns to the correct previous screen instead of navigating to an incorrect page.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/61d86d50-8230-41ec-ae9f-cbec8ed852f4" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d4eb2808-9505-4643-873f-c484e9fc8cab" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b59a72d5-8ba8-4987-8a3f-4081f87c5965" />
