### PR TITLE
fix(CHIM-1079): Restrict initial assessment to framework specific

### DIFF
--- a/src/hooks/useLearningPath.test.ts
+++ b/src/hooks/useLearningPath.test.ts
@@ -16,7 +16,6 @@ import {
   LEARNING_PATHWAY_MODE,
   SOURCE,
   TableTypes,
-  grade1,
 } from '../common/constants';
 
 jest.mock('../utility/util');
@@ -213,7 +212,7 @@ describe('useLearningPath features used by Home tab', () => {
 
     const next = await recommendNextLesson({
       student: { id: 'stu-1' },
-      course: { id: 'c1', subject_id: 's1', grade_id: grade1 },
+      course: { id: 'c1', subject_id: 's1', framework_id: 'framework-1' },
       mode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
     });
 
@@ -240,7 +239,7 @@ describe('useLearningPath features used by Home tab', () => {
 
     const next = await recommendNextLesson({
       student: { id: 'stu-1' },
-      course: { id: 'c1', subject_id: 's1', grade_id: grade1 },
+      course: { id: 'c1', subject_id: 's1', framework_id: 'framework-1' },
       mode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
     });
 
@@ -637,8 +636,7 @@ describe('useLearningPath features used by Home tab', () => {
           {
             id: 'c1',
             subject_id: 's1',
-            framework_id: null,
-            grade_id: grade1,
+            framework_id: 'framework-1',
           },
         ],
         mode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,

--- a/src/hooks/useLearningPath.test.ts
+++ b/src/hooks/useLearningPath.test.ts
@@ -16,6 +16,7 @@ import {
   LEARNING_PATHWAY_MODE,
   SOURCE,
   TableTypes,
+  grade1,
 } from '../common/constants';
 
 jest.mock('../utility/util');
@@ -212,7 +213,7 @@ describe('useLearningPath features used by Home tab', () => {
 
     const next = await recommendNextLesson({
       student: { id: 'stu-1' },
-      course: { id: 'c1', subject_id: 's1' },
+      course: { id: 'c1', subject_id: 's1', grade_id: grade1 },
       mode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
     });
 
@@ -239,7 +240,7 @@ describe('useLearningPath features used by Home tab', () => {
 
     const next = await recommendNextLesson({
       student: { id: 'stu-1' },
-      course: { id: 'c1', subject_id: 's1' },
+      course: { id: 'c1', subject_id: 's1', grade_id: grade1 },
       mode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
     });
 
@@ -632,7 +633,14 @@ describe('useLearningPath features used by Home tab', () => {
     const { result } = renderHook(() => useLearningPath());
     await act(async () => {
       await result.current.getPath({
-        courses: [{ id: 'c1', subject_id: 's1', framework_id: null }],
+        courses: [
+          {
+            id: 'c1',
+            subject_id: 's1',
+            framework_id: null,
+            grade_id: grade1,
+          },
+        ],
         mode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
       });
     });

--- a/src/hooks/useLearningPath.ts
+++ b/src/hooks/useLearningPath.ts
@@ -11,8 +11,6 @@ import {
   LANGUAGE,
   COURSES,
   SOURCE,
-  grade1,
-  grade2,
 } from '../common/constants';
 import { updateLocalAttributes, useGbContext } from '../growthbook/Growthbook';
 import logger from '../utility/logger';
@@ -333,7 +331,7 @@ export async function recommendNextLesson({
     !skipAssessment &&
     !hasCompletedInitialAssessment &&
     course.subject_id &&
-    [grade1, grade2].includes(course.grade_id ?? '')
+    course.framework_id != null
   ) {
     const res = await api.getSubjectLessonsBySubjectId(
       course.subject_id,

--- a/src/hooks/useLearningPath.ts
+++ b/src/hooks/useLearningPath.ts
@@ -11,6 +11,8 @@ import {
   LANGUAGE,
   COURSES,
   SOURCE,
+  grade1,
+  grade2,
 } from '../common/constants';
 import { updateLocalAttributes, useGbContext } from '../growthbook/Growthbook';
 import logger from '../utility/logger';
@@ -330,7 +332,8 @@ export async function recommendNextLesson({
     shouldUseAssessment(mode) &&
     !skipAssessment &&
     !hasCompletedInitialAssessment &&
-    course.subject_id
+    course.subject_id &&
+    [grade1, grade2].includes(course.grade_id ?? '')
   ) {
     const res = await api.getSubjectLessonsBySubjectId(
       course.subject_id,


### PR DESCRIPTION
Limit the initial assessment trigger in `recommendNextLesson` to apply only to courses designated as `grade1` or `grade2`.