### PR TITLE
fix: Sync same-framework assessment paths

### DIFF
--- a/src/hooks/useLearningPath.test.ts
+++ b/src/hooks/useLearningPath.test.ts
@@ -553,6 +553,109 @@ describe('useLearningPath features used by Home tab', () => {
     expect(mockApi.updateLearningPath).not.toHaveBeenCalled();
   });
 
+  test('initializes a newly added same-framework assessment course with synced active index', async () => {
+    const existingPath = {
+      courses: {
+        currentCourseIndex: 0,
+        courseList: [
+          {
+            path_id: 'grade-1-path',
+            course_id: 'grade-1-course',
+            subject_id: 'grade-1-subject',
+            framework_id: 'framework-1',
+            type: 'chapter',
+            path: [
+              {
+                lesson_id: 'grade-1-assessment-1',
+                is_assessment: true,
+                isPlayed: true,
+              },
+              {
+                lesson_id: 'grade-1-assessment-2',
+                is_assessment: true,
+                isPlayed: true,
+              },
+              {
+                lesson_id: 'grade-1-assessment-3',
+                is_assessment: true,
+                isPlayed: false,
+              },
+            ],
+            completedPath: 0,
+          },
+        ],
+      },
+      type: 'chapter',
+      pathMode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
+    };
+    (Util.getCurrentStudent as jest.Mock).mockReturnValue({
+      id: 'stu-1',
+      learning_path: JSON.stringify(existingPath),
+    });
+    mockApi.getSubjectLessonsBySubjectId.mockResolvedValue({
+      id: 'grade-2-assessment-doc-3',
+      lesson_id: 'grade-2-assessment-3',
+    });
+
+    const { result } = renderHook(() => useLearningPath());
+    await act(async () => {
+      await result.current.getPath({
+        courses: [
+          {
+            id: 'grade-1-course',
+            subject_id: 'grade-1-subject',
+            framework_id: 'framework-1',
+          },
+          {
+            id: 'grade-2-course',
+            subject_id: 'grade-2-subject',
+            framework_id: 'framework-1',
+          },
+        ],
+        mode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
+      });
+    });
+
+    const saved = mockApi.updateLearningPath.mock.calls[0][1];
+    const parsed = JSON.parse(saved) as {
+      courses: {
+        courseList: Array<{
+          course_id: string;
+          framework_id?: string | null;
+          path: Array<{
+            lesson_id: string;
+            is_assessment: boolean;
+            isPlayed: boolean;
+          }>;
+        }>;
+      };
+    };
+    const gradeTwoPath = parsed.courses.courseList.find(
+      (course) => course.course_id === 'grade-2-course',
+    );
+
+    expect(gradeTwoPath?.framework_id).toBe('framework-1');
+    expect(gradeTwoPath?.path).toEqual([
+      {
+        lesson_id: 'grade-1-assessment-1',
+        is_assessment: true,
+        isPlayed: true,
+      },
+      {
+        lesson_id: 'grade-1-assessment-2',
+        is_assessment: true,
+        isPlayed: true,
+      },
+      {
+        lesson_id: 'grade-2-assessment-3',
+        chapter_id: undefined,
+        source: SOURCE.INITIAL_ASSESSMENT,
+        is_assessment: true,
+        isPlayed: false,
+      },
+    ]);
+  });
+
   test('marks only PAL recommended lessons with PAL source', async () => {
     mockApi.isStudentPlayedPalLesson.mockResolvedValue(true);
     (palUtil.getPalLessonPathForCourse as jest.Mock).mockResolvedValue({

--- a/src/hooks/useLearningPath.ts
+++ b/src/hooks/useLearningPath.ts
@@ -29,6 +29,7 @@ export type CoursePath = {
   path_id: string;
   course_id: string;
   subject_id: string | null;
+  framework_id?: string | null;
   display_name?: string;
   is_pal_consolidated?: boolean;
   type: RECOMMENDATION_TYPE;
@@ -140,6 +141,30 @@ const mergeAssignedAssessmentIdsIntoPath = (
   return updated ? mergedPath : path;
 };
 
+const hasAssessmentProgress = (path: LessonNode[] = []) =>
+  path.some((node) => node.is_assessment === true);
+
+const buildSameFrameworkAssessmentPath = (
+  sourcePath: LessonNode[] = [],
+  activeLesson: LessonNode | null,
+) => {
+  if (!activeLesson?.is_assessment || !sourcePath.length) return null;
+
+  const assessmentPath = sourcePath.filter(
+    (node) => node.is_assessment === true,
+  );
+  if (!assessmentPath.length) return null;
+
+  const activeIndex = assessmentPath.findIndex(
+    (node) => node.isPlayed === false,
+  );
+  if (activeIndex === -1) return null;
+
+  return assessmentPath.map((node, index) =>
+    index === activeIndex ? { ...activeLesson } : { ...node },
+  );
+};
+
 const getAssignedAssessmentPath = async ({
   student,
   course,
@@ -249,6 +274,7 @@ export async function buildPath({
         path_id: uuidv4(),
         course_id: course.id,
         subject_id: course.subject_id ?? null,
+        framework_id: course.framework_id ?? null,
         display_name: course.pathway_display_name,
         is_pal_consolidated: course.is_pal_consolidated,
         type: course.framework_id
@@ -906,6 +932,30 @@ export const useLearningPath = (opts?: {
      * ----------------------------------- */
     const existingMap = new Map<string, StoredCoursePath>();
     oldCourseList.forEach((c) => existingMap.set(c.course_id, c));
+    const courseInputMap = new Map(
+      userCourses.map((course) => [course.id, course]),
+    );
+
+    const findSameFrameworkAssessmentPath = (
+      course: LearningPathCourseInput,
+    ) => {
+      const frameworkId = course.framework_id;
+      if (!frameworkId) return null;
+
+      return (
+        oldCourseList.find((coursePath) => {
+          const pathFrameworkId =
+            coursePath.framework_id ??
+            courseInputMap.get(coursePath.course_id)?.framework_id ??
+            null;
+
+          return (
+            pathFrameworkId === frameworkId &&
+            hasAssessmentProgress(coursePath.path)
+          );
+        }) ?? null
+      );
+    };
 
     const newCourseList: StoredCoursePath[] = [];
     for (const course of userCourses) {
@@ -915,6 +965,7 @@ export const useLearningPath = (opts?: {
         // ✅ Preserve entire course state
         newCourseList.push({
           ...existing,
+          framework_id: course.framework_id ?? existing.framework_id ?? null,
           display_name: course.pathway_display_name,
           is_pal_consolidated: course.is_pal_consolidated,
         });
@@ -926,17 +977,23 @@ export const useLearningPath = (opts?: {
           mode,
           classId,
         });
+        const sameFrameworkAssessmentPath = buildSameFrameworkAssessmentPath(
+          findSameFrameworkAssessmentPath(course)?.path,
+          activeLesson,
+        );
 
         newCourseList.push({
           path_id: uuidv4(),
           course_id: course.id,
           subject_id: course.subject_id ?? null,
+          framework_id: course.framework_id ?? null,
           display_name: course.pathway_display_name,
           is_pal_consolidated: course.is_pal_consolidated,
           type: course.framework_id
             ? RECOMMENDATION_TYPE.FRAMEWORK
             : RECOMMENDATION_TYPE.CHAPTER,
-          path: activeLesson ? [activeLesson] : [],
+          path:
+            sameFrameworkAssessmentPath ?? (activeLesson ? [activeLesson] : []),
           completedPath: 0,
           lastPlayedLesson: undefined,
         });
@@ -1004,6 +1061,7 @@ export const useLearningPath = (opts?: {
           coursePath.path = mergedPath;
           coursePath.display_name = course.pathway_display_name;
           coursePath.is_pal_consolidated = course.is_pal_consolidated;
+          coursePath.framework_id = course.framework_id ?? null;
           coursePath.type = course.framework_id
             ? RECOMMENDATION_TYPE.FRAMEWORK
             : RECOMMENDATION_TYPE.CHAPTER;
@@ -1046,6 +1104,7 @@ export const useLearningPath = (opts?: {
       coursePath.path = assessmentPath;
       coursePath.display_name = course.pathway_display_name;
       coursePath.is_pal_consolidated = course.is_pal_consolidated;
+      coursePath.framework_id = course.framework_id ?? null;
       coursePath.type = course.framework_id
         ? RECOMMENDATION_TYPE.FRAMEWORK
         : RECOMMENDATION_TYPE.CHAPTER;
@@ -1117,6 +1176,7 @@ export const useLearningPath = (opts?: {
       path_id: coursePath.path_id,
       course_id: coursePath.course_id,
       subject_id: coursePath.subject_id,
+      framework_id: coursePath.framework_id,
       display_name: coursePath.display_name,
       is_pal_consolidated: coursePath.is_pal_consolidated,
       type: coursePath.type as RECOMMENDATION_TYPE,

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -10264,8 +10264,48 @@ order by
 
     if (!latestBatchId) return [];
 
+    const latestBatchLessonQuery = `
+      SELECT a.lesson_id
+      FROM assignment a
+      LEFT JOIN assignment_user au
+        ON a.id = au.assignment_id
+        AND au.is_deleted = 0
+      WHERE a.class_id = ?
+        AND a.course_id = ?
+        AND a.type = 'assessment'
+        AND a.is_deleted = 0
+        AND a.batch_id = ?
+        AND (
+          a.starts_at IS NULL
+          OR a.starts_at = ''
+          OR datetime(a.starts_at) <= datetime(?)
+        )
+        AND (
+          a.ends_at IS NULL
+          OR a.ends_at = ''
+          OR datetime(a.ends_at) > datetime(?)
+        )
+        AND (
+          a.is_class_wise = 1
+          OR au.user_id = ?
+        );
+    `;
+    const latestBatchLessonRes = await this._db?.query(latestBatchLessonQuery, [
+      classId,
+      courseId,
+      latestBatchId,
+      nowIso,
+      nowIso,
+      studentId,
+    ]);
+    const latestBatchLessonIds = new Set(
+      ((latestBatchLessonRes?.values ?? []) as { lesson_id?: string | null }[])
+        .map((assignment) => assignment.lesson_id)
+        .filter((lessonId): lessonId is string => !!lessonId),
+    );
+
     const courseTerminationQuery = `
-      SELECT r.status
+      SELECT r.lesson_id, r.status
       FROM result r
       INNER JOIN assignment a
         ON a.id = r.assignment_id
@@ -10283,7 +10323,14 @@ order by
       classId,
       courseId,
     ]);
-    if (courseTerminationRes?.values?.length) {
+    const courseTerminationRows = (courseTerminationRes?.values ?? []) as {
+      lesson_id?: string | null;
+    }[];
+    const isLatestBatchReassignment = courseTerminationRows.some(
+      (result) =>
+        !!result.lesson_id && latestBatchLessonIds.has(result.lesson_id),
+    );
+    if (courseTerminationRows.length && !isLatestBatchReassignment) {
       return [];
     }
 
@@ -10379,13 +10426,6 @@ order by
 
         -- NOT completed
         AND r.assignment_id IS NULL
-        AND NOT EXISTS (
-          SELECT 1
-          FROM result lr
-          WHERE lr.student_id = '${studentId}'
-            AND lr.lesson_id = a.lesson_id
-            AND lr.is_deleted = 0
-        )
 
         -- subject_lesson validation (LANGUAGE ONLY)
         AND EXISTS (

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -215,6 +215,13 @@ type AssessmentAssignmentRow = TableTypes<'assignment'> & {
   assignment_user?: AssessmentAssignmentUserLink[] | null;
 };
 
+type AssessmentBatchLessonRow = Pick<
+  TableTypes<'assignment'>,
+  'lesson_id' | 'is_class_wise'
+> & {
+  assignment_user?: AssessmentAssignmentUserLink[] | null;
+};
+
 type AssessmentResultRow = Pick<
   TableTypes<'result'>,
   'assignment_id' | 'status' | 'created_at'
@@ -15017,7 +15024,10 @@ export class SupabaseApi implements ServiceApi {
     courseId = courseId ?? '';
 
     const isAssignedToStudent = (
-      assignment: AssessmentBatchRow | AssessmentAssignmentRow,
+      assignment:
+        | AssessmentBatchRow
+        | AssessmentAssignmentRow
+        | AssessmentBatchLessonRow,
     ) =>
       assignment.is_class_wise === true ||
       (assignment.assignment_user ?? []).some(
@@ -15057,11 +15067,45 @@ export class SupabaseApi implements ServiceApi {
     const latestBatchId = latestAssignedBatch?.batch_id;
     if (!latestBatchId) return [];
 
+    const { data: latestBatchLessons, error: latestBatchLessonsError } =
+      await this.supabase
+        .from(TABLES.Assignment)
+        .select(
+          `
+          lesson_id,
+          is_class_wise,
+          assignment_user:assignment_user!left(user_id, is_deleted)
+        `,
+        )
+        .eq('class_id', classId)
+        .eq('course_id', courseId)
+        .eq('type', 'assessment')
+        .eq('is_deleted', false)
+        .eq('batch_id', latestBatchId)
+        .or(`starts_at.is.null,starts_at.lte.${nowIso}`)
+        .or(`ends_at.is.null,ends_at.gt.${nowIso}`);
+
+    if (latestBatchLessonsError) {
+      logger.error(
+        'Latest assessment batch lesson query error:',
+        latestBatchLessonsError,
+      );
+      return [];
+    }
+
+    const latestBatchLessonIds = new Set(
+      ((latestBatchLessons ?? []) as unknown as AssessmentBatchLessonRow[])
+        .filter((assignment) => isAssignedToStudent(assignment))
+        .map((assignment) => assignment.lesson_id)
+        .filter((lessonId): lessonId is string => !!lessonId),
+    );
+
     const { data: courseTerminationResults, error: courseTerminationError } =
       await this.supabase
         .from(TABLES.Result)
         .select(
           `
+          lesson_id,
           status,
           assignment!inner(class_id, course_id, type)
         `,
@@ -15082,7 +15126,14 @@ export class SupabaseApi implements ServiceApi {
       return [];
     }
 
-    if (courseTerminationResults?.length) {
+    const isLatestBatchReassignment = (courseTerminationResults ?? []).some(
+      (result) => {
+        const lessonId = result.lesson_id;
+        return !!lessonId && latestBatchLessonIds.has(lessonId);
+      },
+    );
+
+    if (courseTerminationResults?.length && !isLatestBatchReassignment) {
       return [];
     }
 
@@ -15171,10 +15222,6 @@ export class SupabaseApi implements ServiceApi {
     if (!assignedAssessments.length) return [];
 
     const assignmentIds = assignedAssessments.map((a) => a.id);
-    const assignedLessonIds = assignedAssessments
-      .map((assignment) => assignment.lesson_id)
-      .filter((lessonId): lessonId is string => !!lessonId);
-
     const { data: assignmentResults } = await this.supabase
       .from(TABLES.Result)
       .select('assignment_id')
@@ -15186,23 +15233,8 @@ export class SupabaseApi implements ServiceApi {
       (assignmentResults ?? []).map((r) => r.assignment_id),
     );
 
-    const { data: lessonResults } = assignedLessonIds.length
-      ? await this.supabase
-          .from(TABLES.Result)
-          .select('lesson_id')
-          .in('lesson_id', assignedLessonIds)
-          .eq('student_id', studentId)
-          .eq('is_deleted', false)
-      : { data: [] };
-
-    const completedLessonIds = new Set(
-      (lessonResults ?? []).map((r) => r.lesson_id),
-    );
-
     const incompleteAssignments = assignedAssessments.filter(
-      (a) =>
-        !completedAssignmentIds.has(a.id) &&
-        !completedLessonIds.has(a.lesson_id),
+      (a) => !completedAssignmentIds.has(a.id),
     );
 
     if (!incompleteAssignments.length) return [];

--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -3038,16 +3038,21 @@ export class Util {
           storedPathwayMode !== LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY ||
           !activeLesson ||
           !activeLesson.is_assessment ||
-          !course.subject_id
+          (!course.subject_id && !course.framework_id)
         ) {
           return;
         }
 
         for (const peerCourse of courses.courseList) {
-          if (
-            peerCourse === course ||
-            peerCourse.subject_id !== course.subject_id
-          ) {
+          const isSameAssessmentGroup =
+            !!course.framework_id &&
+            !!peerCourse.framework_id &&
+            peerCourse.framework_id === course.framework_id
+              ? true
+              : !!course.subject_id &&
+                peerCourse.subject_id === course.subject_id;
+
+          if (peerCourse === course || !isSameAssessmentGroup) {
             continue;
           }
 


### PR DESCRIPTION
Add support for carrying assessment progress across courses that share the same framework. Key changes:

For Case 1:
Assigned assessment completion is now checked by assignment_id only, so a reassigned same assessment with new assignment IDs can start again from lesson 1.
The course-level termination guard still blocks unrelated new assessment batches after termination, but now allows reassignment when the latest batch overlaps the terminated assessment lesson IDs.
For Case 2:
CoursePath now stores framework_id.
When a new same-framework course is added, its assessment path is initialized from the existing framework assessment progress, so the active flower index stays synced.
Runtime assessment sync now matches peers by framework_id first, falling back to subject_id.

These changes ensure assessment-only pathways keep consistent progress across courses that belong to the same framework and improve detection of reassigned assessment batches in both SQLite and Supabase implementations.