### PR TITLE
fix: sync pathway by course_code and match paths by code

### DIFF
--- a/src/hooks/useLearningPath.test.ts
+++ b/src/hooks/useLearningPath.test.ts
@@ -561,7 +561,7 @@ describe('useLearningPath features used by Home tab', () => {
           {
             path_id: 'grade-1-path',
             course_id: 'grade-1-course',
-            subject_id: 'grade-1-subject',
+            subject_id: 'math-subject',
             framework_id: 'framework-1',
             type: 'chapter',
             path: [
@@ -603,12 +603,12 @@ describe('useLearningPath features used by Home tab', () => {
         courses: [
           {
             id: 'grade-1-course',
-            subject_id: 'grade-1-subject',
+            subject_id: 'math-subject',
             framework_id: 'framework-1',
           },
           {
             id: 'grade-2-course',
-            subject_id: 'grade-2-subject',
+            subject_id: 'math-subject',
             framework_id: 'framework-1',
           },
         ],

--- a/src/hooks/useLearningPath.ts
+++ b/src/hooks/useLearningPath.ts
@@ -30,6 +30,7 @@ export type CoursePath = {
   course_id: string;
   subject_id: string | null;
   framework_id?: string | null;
+  course_code?: string | null;
   display_name?: string;
   is_pal_consolidated?: boolean;
   type: RECOMMENDATION_TYPE;
@@ -275,6 +276,7 @@ export async function buildPath({
         course_id: course.id,
         subject_id: course.subject_id ?? null,
         framework_id: course.framework_id ?? null,
+        course_code: course.code ?? null,
         display_name: course.pathway_display_name,
         is_pal_consolidated: course.is_pal_consolidated,
         type: course.framework_id
@@ -948,9 +950,16 @@ export const useLearningPath = (opts?: {
             coursePath.framework_id ??
             courseInputMap.get(coursePath.course_id)?.framework_id ??
             null;
+          const pathCourseCode = normalizeCourseToken(
+            coursePath.course_code ??
+              courseInputMap.get(coursePath.course_id)?.code,
+          );
+          const courseCode = normalizeCourseToken(course.code);
 
           return (
             pathFrameworkId === frameworkId &&
+            coursePath.subject_id === (course.subject_id ?? null) &&
+            (!pathCourseCode || !courseCode || pathCourseCode === courseCode) &&
             hasAssessmentProgress(coursePath.path)
           );
         }) ?? null
@@ -966,6 +975,7 @@ export const useLearningPath = (opts?: {
         newCourseList.push({
           ...existing,
           framework_id: course.framework_id ?? existing.framework_id ?? null,
+          course_code: course.code ?? existing.course_code ?? null,
           display_name: course.pathway_display_name,
           is_pal_consolidated: course.is_pal_consolidated,
         });
@@ -987,6 +997,7 @@ export const useLearningPath = (opts?: {
           course_id: course.id,
           subject_id: course.subject_id ?? null,
           framework_id: course.framework_id ?? null,
+          course_code: course.code ?? null,
           display_name: course.pathway_display_name,
           is_pal_consolidated: course.is_pal_consolidated,
           type: course.framework_id
@@ -1062,6 +1073,8 @@ export const useLearningPath = (opts?: {
           coursePath.display_name = course.pathway_display_name;
           coursePath.is_pal_consolidated = course.is_pal_consolidated;
           coursePath.framework_id = course.framework_id ?? null;
+          coursePath.course_code =
+            course.code ?? coursePath.course_code ?? null;
           coursePath.type = course.framework_id
             ? RECOMMENDATION_TYPE.FRAMEWORK
             : RECOMMENDATION_TYPE.CHAPTER;
@@ -1105,6 +1118,7 @@ export const useLearningPath = (opts?: {
       coursePath.display_name = course.pathway_display_name;
       coursePath.is_pal_consolidated = course.is_pal_consolidated;
       coursePath.framework_id = course.framework_id ?? null;
+      coursePath.course_code = course.code ?? coursePath.course_code ?? null;
       coursePath.type = course.framework_id
         ? RECOMMENDATION_TYPE.FRAMEWORK
         : RECOMMENDATION_TYPE.CHAPTER;
@@ -1177,6 +1191,7 @@ export const useLearningPath = (opts?: {
       course_id: coursePath.course_id,
       subject_id: coursePath.subject_id,
       framework_id: coursePath.framework_id,
+      course_code: coursePath.course_code,
       display_name: coursePath.display_name,
       is_pal_consolidated: coursePath.is_pal_consolidated,
       type: coursePath.type as RECOMMENDATION_TYPE,

--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -2989,6 +2989,30 @@ export class Util {
       let courseIndex = courses.currentCourseIndex;
       let course = courses.courseList[courseIndex];
       if (!course) return;
+      const courseCodeById = new Map<string, string | null>();
+      const getCourseCode = async (coursePath: CoursePath) => {
+        const storedCode = coursePath.course_code?.trim().toLowerCase();
+        if (storedCode) return storedCode;
+
+        const courseId = coursePath.course_id;
+        if (courseCodeById.has(courseId)) {
+          return courseCodeById.get(courseId) ?? null;
+        }
+
+        try {
+          const courseMeta = await api.getCourse(courseId);
+          const code = courseMeta?.code?.trim().toLowerCase() || null;
+          courseCodeById.set(courseId, code);
+          return code;
+        } catch (error) {
+          logger.warn('[LearningPath] Unable to resolve course code', {
+            courseId,
+            error,
+          });
+          courseCodeById.set(courseId, null);
+          return null;
+        }
+      };
 
       /* 1️⃣ Identify active lesson */
       const activeLessonIndex = course.path.findIndex(
@@ -3031,7 +3055,7 @@ export class Util {
             !!lesson.assignment_id,
         );
 
-      const syncSameSubjectAssessmentPaths = (
+      const syncSameSubjectAssessmentPaths = async (
         nextAssessmentLesson: LessonNode | null,
       ) => {
         if (
@@ -3043,6 +3067,9 @@ export class Util {
           return;
         }
 
+        const activeCourseCode = await getCourseCode(course);
+        if (!activeCourseCode) return;
+
         for (const peerCourse of courses.courseList) {
           const isSameAssessmentGroup =
             !!course.framework_id &&
@@ -3053,6 +3080,11 @@ export class Util {
                 peerCourse.subject_id === course.subject_id;
 
           if (peerCourse === course || !isSameAssessmentGroup) {
+            continue;
+          }
+
+          const peerCourseCode = await getCourseCode(peerCourse);
+          if (!peerCourseCode || peerCourseCode !== activeCourseCode) {
             continue;
           }
 
@@ -3111,7 +3143,7 @@ export class Util {
       }
 
       /* 4️⃣ Check path overflow */
-      syncSameSubjectAssessmentPaths(nextLesson);
+      await syncSameSubjectAssessmentPaths(nextLesson);
 
       let pathCompleted = false;
 


### PR DESCRIPTION
- Introduce course_code into CoursePath and propagate course.code throughout useLearningPath to uniquely identify courses.
-  Compare normalized course tokens (with subject_id) when selecting matching paths to avoid cross-course/subject matches. 
-  In Util, add async getCourseCode with caching to resolve codes via api.getCourse, make syncSameSubjectAssessmentPaths async and filter peers by course_code, and await its completion. 
-  Update tests to use the new math-subject course IDs. 
-  These changes prevent incorrect assessment syncing between different courses that share frameworks but are not the same course.