### PR TITLE
Respect pending assessments in recommendNextLesson

### DIFF
--- a/src/hooks/useLearningPath.test.ts
+++ b/src/hooks/useLearningPath.test.ts
@@ -165,6 +165,87 @@ describe('useLearningPath features used by Home tab', () => {
     expect(parsed.courses.currentCourseIndex).toBe(1);
   });
 
+  test('continues pending assessment after class join in full adaptive mode', async () => {
+    const existingPath = {
+      courses: {
+        currentCourseIndex: 0,
+        courseList: [
+          {
+            path_id: 'old-math-path',
+            course_id: 'old-math-course',
+            subject_id: 'math-subject',
+            framework_id: 'framework-1',
+            course_code: 'maths',
+            type: 'framework',
+            path: [
+              {
+                lesson_id: 'assessment-lesson-1',
+                is_assessment: true,
+                isPlayed: true,
+              },
+              {
+                lesson_id: 'assessment-lesson-2',
+                is_assessment: true,
+                isPlayed: false,
+              },
+            ],
+            completedPath: 0,
+          },
+        ],
+      },
+      type: 'framework',
+      pathMode: LEARNING_PATHWAY_MODE.FULL_ADAPTIVE,
+    };
+    (Util.getCurrentStudent as jest.Mock).mockReturnValue({
+      id: 'stu-1',
+      learning_path: JSON.stringify(existingPath),
+    });
+    mockApi.isStudentPlayedPalLesson.mockResolvedValue(true);
+    mockApi.getSubjectLessonsBySubjectId.mockResolvedValue({
+      id: 'asmt-doc-2',
+      lesson_id: 'assessment-lesson-2',
+    });
+    (palUtil.getPalLessonPathForCourse as jest.Mock).mockResolvedValue({
+      lesson_id: 'normal-pal-lesson',
+      chapter_id: 'pal-chapter',
+      skill_id: 'pal-skill',
+    });
+
+    const { result } = renderHook(() => useLearningPath());
+    await act(async () => {
+      await result.current.getPath({
+        courses: [
+          {
+            id: 'new-math-course',
+            subject_id: 'math-subject',
+            framework_id: 'framework-1',
+            code: 'maths',
+          },
+        ],
+        mode: LEARNING_PATHWAY_MODE.FULL_ADAPTIVE,
+        classId: 'class-1',
+      });
+    });
+
+    const saved = mockApi.updateLearningPath.mock.calls[0][1];
+    const parsed = JSON.parse(saved);
+    expect(parsed.courses.courseList[0].path).toEqual([
+      {
+        lesson_id: 'assessment-lesson-1',
+        is_assessment: true,
+        isPlayed: true,
+      },
+      {
+        lesson_id: 'assessment-lesson-2',
+        chapter_id: undefined,
+        source: SOURCE.INITIAL_ASSESSMENT,
+        is_assessment: true,
+        isPlayed: false,
+      },
+    ]);
+    expect(palUtil.getPalLessonPathForCourse).not.toHaveBeenCalled();
+  });
+
   test('restores lesson index correctly from old pathway structure (migration)', () => {
     const { result } = renderHook(() => useLearningPath());
     const migrated = result.current.migrate({
@@ -252,6 +333,43 @@ describe('useLearningPath features used by Home tab', () => {
       { id: 'stu-1' },
       'c1',
     );
+    expect(palUtil.getPalLessonPathForCourse).not.toHaveBeenCalled();
+  });
+
+  test('continues assessment sequence in full adaptive mode after first assessment is played', async () => {
+    mockApi.isStudentPlayedPalLesson.mockResolvedValue(true);
+    mockApi.getSubjectLessonsBySubjectId.mockResolvedValue({
+      id: 'asmt-doc-2',
+      lesson_id: 'assessment-lesson-2',
+    });
+    (palUtil.getPalLessonPathForCourse as jest.Mock).mockResolvedValue({
+      lesson_id: 'normal-pal-lesson',
+      chapter_id: 'pal-chapter',
+      skill_id: 'pal-skill',
+    });
+
+    const next = await recommendNextLesson({
+      student: { id: 'stu-1' },
+      course: { id: 'c1', subject_id: 's1', framework_id: 'framework-1' },
+      mode: LEARNING_PATHWAY_MODE.FULL_ADAPTIVE,
+      coursePath: {
+        path: [
+          {
+            lesson_id: 'assessment-lesson-1',
+            is_assessment: true,
+            isPlayed: true,
+          },
+        ],
+      },
+    });
+
+    expect(next).toEqual({
+      lesson_id: 'assessment-lesson-2',
+      chapter_id: undefined,
+      source: SOURCE.INITIAL_ASSESSMENT,
+      is_assessment: true,
+      isPlayed: false,
+    });
     expect(palUtil.getPalLessonPathForCourse).not.toHaveBeenCalled();
   });
 

--- a/src/hooks/useLearningPath.test.ts
+++ b/src/hooks/useLearningPath.test.ts
@@ -373,6 +373,44 @@ describe('useLearningPath features used by Home tab', () => {
     expect(palUtil.getPalLessonPathForCourse).not.toHaveBeenCalled();
   });
 
+  test('skips assessment lookup in full adaptive mode after PAL phase starts', async () => {
+    (palUtil.getPalLessonPathForCourse as jest.Mock).mockResolvedValue({
+      lesson_id: 'normal-pal-lesson-2',
+      chapter_id: 'pal-chapter-2',
+      skill_id: 'pal-skill-2',
+    });
+
+    const next = await recommendNextLesson({
+      student: { id: 'stu-1' },
+      course: { id: 'c1', subject_id: 's1', framework_id: 'framework-1' },
+      mode: LEARNING_PATHWAY_MODE.FULL_ADAPTIVE,
+      coursePath: {
+        path: [
+          {
+            lesson_id: 'assessment-lesson-1',
+            is_assessment: true,
+            isPlayed: true,
+          },
+          {
+            lesson_id: 'normal-pal-lesson-1',
+            is_assessment: false,
+            isPlayed: true,
+          },
+        ],
+      },
+    });
+
+    expect(mockApi.getSubjectLessonsBySubjectId).not.toHaveBeenCalled();
+    expect(next).toEqual({
+      lesson_id: 'normal-pal-lesson-2',
+      chapter_id: 'pal-chapter-2',
+      skill_id: 'pal-skill-2',
+      source: SOURCE.LEARNING_PATHWAY_HOME_PAL,
+      is_assessment: false,
+      isPlayed: false,
+    });
+  });
+
   test('skips assessment recommendation when rebuilding after assessment termination', async () => {
     mockApi.getSubjectLessonsBySubjectId.mockResolvedValue({
       id: 'asmt-doc-1',

--- a/src/hooks/useLearningPath.ts
+++ b/src/hooks/useLearningPath.ts
@@ -331,14 +331,19 @@ export async function recommendNextLesson({
     coursePath?.path?.some(
       (node) => node.is_assessment === true && node.isPlayed === false,
     ) ?? false;
+  const hasPlayedNormalLessonInPath =
+    coursePath?.path?.some(
+      (node) => node.is_assessment === false && node.isPlayed === true,
+    ) ?? false;
 
   /* -------------------------------
    * 1️⃣ TEACHER ASSIGNED ASSESSMENT
    * ------------------------------- */
   const hasCompletedInitialAssessment = shouldUsePAL(mode)
-    ? !hasAssessmentProgressInPath &&
-      !hasPendingAssessmentInPath &&
-      (await api.isStudentPlayedPalLesson(student.id, course.id))
+    ? hasPlayedNormalLessonInPath ||
+      (!hasAssessmentProgressInPath &&
+        !hasPendingAssessmentInPath &&
+        (await api.isStudentPlayedPalLesson(student.id, course.id)))
     : false;
   if (!skipAssessment && classId) {
     const assessments = await api.getLatestAssessmentGroup(

--- a/src/hooks/useLearningPath.ts
+++ b/src/hooks/useLearningPath.ts
@@ -325,12 +325,20 @@ export async function recommendNextLesson({
   skipAssessment?: boolean;
 }): Promise<LessonNode | null> {
   const api = ServiceConfig.getI().apiHandler;
+  const hasAssessmentProgressInPath =
+    coursePath?.path?.some((node) => node.is_assessment === true) ?? false;
+  const hasPendingAssessmentInPath =
+    coursePath?.path?.some(
+      (node) => node.is_assessment === true && node.isPlayed === false,
+    ) ?? false;
 
   /* -------------------------------
    * 1️⃣ TEACHER ASSIGNED ASSESSMENT
    * ------------------------------- */
   const hasCompletedInitialAssessment = shouldUsePAL(mode)
-    ? await api.isStudentPlayedPalLesson(student.id, course.id)
+    ? !hasAssessmentProgressInPath &&
+      !hasPendingAssessmentInPath &&
+      (await api.isStudentPlayedPalLesson(student.id, course.id))
     : false;
   if (!skipAssessment && classId) {
     const assessments = await api.getLatestAssessmentGroup(
@@ -981,14 +989,17 @@ export const useLearningPath = (opts?: {
         });
       } else {
         // ➕ New course → build fresh
+        const sameFrameworkAssessmentSource =
+          findSameFrameworkAssessmentPath(course);
         const activeLesson = await recommendNextLesson({
           student,
           course,
           mode,
           classId,
+          coursePath: sameFrameworkAssessmentSource,
         });
         const sameFrameworkAssessmentPath = buildSameFrameworkAssessmentPath(
-          findSameFrameworkAssessmentPath(course)?.path,
+          sameFrameworkAssessmentSource?.path,
           activeLesson,
         );
 


### PR DESCRIPTION
Detect existing assessment progress and pending assessment nodes in coursePath and avoid treating them as completed. recommendNextLesson now checks hasAssessmentProgressInPath and hasPendingAssessmentInPath and only calls api.isStudentPlayedPalLesson when there is no prior assessment progress or pending assessment. When initializing a new course path, the same-framework assessment source is passed through to recommendNextLesson and buildSameFrameworkAssessmentPath. Added tests to verify continuing pending assessments and continuing assessment sequence in full-adaptive mode (src/hooks/useLearningPath.test.ts).