### PR TITLE
Improve Parent Section popup touch interaction

### DIFF
--- a/src/components/parent/TeacherAuthenticationPopup.css
+++ b/src/components/parent/TeacherAuthenticationPopup.css
@@ -1,11 +1,3 @@
-html:has(.teacher-authentication-popup-overlay),
-body:has(.teacher-authentication-popup-overlay),
-ion-app:has(.teacher-authentication-popup-overlay),
-ion-router-outlet:has(.teacher-authentication-popup-overlay) {
-  overflow: hidden;
-  overscroll-behavior: none;
-}
-
 .teacher-authentication-popup-overlay {
   position: fixed;
   inset: 0;
@@ -39,6 +31,7 @@ ion-router-outlet:has(.teacher-authentication-popup-overlay) {
   display: flex;
   align-items: center;
   justify-content: center;
+  -webkit-overflow-scrolling: touch;
 }
 
 .teacher-authentication-popup-inner {


### PR DESCRIPTION
Fixed the Parent Section popup touch interaction by optimizing popup scrolling behavior.

- Removed unnecessary global `:has(...)` scroll-lock selectors.
- Kept scroll behavior scoped to the popup overlay/container.
- Added `-webkit-overflow-scrolling: touch` for smoother touch scrolling.
- Updated touch handling to improve the smoothness of popup interaction while preserving existing behavior.