### PR TITLE
Allow UNSPECIFIED gender in FileUpload

### DIFF
--- a/src/ops-console/components/FileUpload.tsx
+++ b/src/ops-console/components/FileUpload.tsx
@@ -1086,8 +1086,12 @@ const FileUpload: React.FC<{ onCancleClick?: () => void }> = ({
           if (!studentName) errors.push('Missing STUDENT NAME.');
           if (!gender) {
             errors.push('Missing GENDER.');
-          } else if (!['MALE', 'FEMALE'].includes(gender.toUpperCase())) {
-            errors.push('Invalid GENDER. Must be "MALE" or "FEMALE".');
+          } else if (
+            !['MALE', 'FEMALE', 'UNSPECIFIED'].includes(gender.toUpperCase())
+          ) {
+            errors.push(
+              'Invalid GENDER. Must be "MALE", "FEMALE", or "UNSPECIFIED".',
+            );
           }
           if (!/^\d+$/.test(age)) {
             errors.push('AGE must be a whole number.');


### PR DESCRIPTION
Update FileUpload.tsx gender validation to accept 'UNSPECIFIED' alongside 'MALE' and 'FEMALE', and update the validation error message to list all three allowed values. Prevents valid UNSPECIFIED entries from being treated as invalid.