### PR TITLE
style(CHIM-1098): enhance scorecard layout responsiveness and fix lesson name overflow

### DIFF
--- a/src/components/scorecards/ScoreCard.css
+++ b/src/components/scorecards/ScoreCard.css
@@ -17,17 +17,17 @@
   max-width: 100vw !important;
   border-radius: 24px !important;
   box-shadow: none !important;
-  margin: 2vh auto !important;
-  max-height: 96vh !important;
+  margin: 0 auto !important;
+  max-height: 100vh !important;
   overflow: hidden !important;
-  padding-top: 24px !important;
-  padding-bottom: 32px !important;
+  padding-top: 16px !important;
+  padding-bottom: 16px !important;
   box-sizing: border-box !important;
   display: flex !important;
   flex-direction: column !important;
   align-items: center !important;
   justify-content: flex-start !important;
-  gap: 5vh;
+  gap: 20px;
 }
 
 .score-card-dialog__paper--progress:has(.score-card-progress-count-1) {
@@ -104,6 +104,14 @@
   font-size: 14px;
   font-weight: 500;
   color: red;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  word-break: break-word;
+  max-width: 100%;
 }
 
 .image-icon {
@@ -292,8 +300,8 @@
 
 .score-card-dialog--progress .score-card-goal-progress-content-box {
   position: relative;
-  width: calc(70vw - 48px);
-  max-width: 370px;
+  width: fit-content;
+  max-width: 700px;
   height: auto;
   margin: 0 auto;
   padding: 20px 24px 16px;
@@ -376,6 +384,8 @@
   align-items: center !important;
   justify-content: center !important;
   gap: 8px !important;
+  flex: 1 !important;
+  min-width: 0 !important;
 }
 
 .score-card-dialog--progress .title-scoreCard {
@@ -411,6 +421,7 @@
   text-align: center;
   margin-left: 0;
   gap: 2px;
+  width: 100%;
 }
 
 .score-card-dialog--progress .score-card-content-message {
@@ -424,7 +435,14 @@
   font-size: 14px;
   font-weight: 700;
   color: red;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  word-break: break-word;
+  max-width: 100%;
 }
 
 .score-card-dialog--progress .score-card-goal-progress-list {


### PR DESCRIPTION

<img width="1152" height="677" alt="image" src="https://github.com/user-attachments/assets/9f7bd942-f829-4dfa-9729-55de0d4ad4f0" />


- Truncate long lesson names to a single line with text-overflow ellipsis.
- Prevent lesson name text from pushing the mascot icon and stars out of the container.
- Reduce margins, paddings, and gap on the progress dialog paper to prevent vertical clipping on short viewports.