### PR TITLE
fix: optimize school search normalization ignore dots, spaces, and pu…

### DIFF
--- a/src/ops-console/components/SearchAndFilter.tsx
+++ b/src/ops-console/components/SearchAndFilter.tsx
@@ -26,7 +26,7 @@ interface SearchAndFilterProps {
   filterIconSrc?: string;
 }
 
-const DEBOUNCE_MS = 400;
+const DEBOUNCE_MS = 800;
 
 const SearchAndFilter: React.FC<SearchAndFilterProps> = ({
   searchTerm,

--- a/src/ops-console/pages/SchoolList.fetcher.tsx
+++ b/src/ops-console/pages/SchoolList.fetcher.tsx
@@ -143,26 +143,24 @@ export const fetchSchoolListPage = async ({
   searchTerm: string;
   selectedDateRange: string;
 }) => {
-  const getSchoolListing =
-    api.getSchoolMetricsForSchoolListing?.bind(api) ??
-    api.getFilteredSchoolsForSchoolListing?.bind(api);
+  const request = buildSchoolListRequest({
+    filters,
+    selectedTab,
+    page,
+    pageSize,
+    orderBy,
+    orderDir,
+    searchTerm,
+    selectedDateRange,
+  });
+
+  const getSchoolListing = api.getSchoolMetricsForSchoolListing?.bind(api);
 
   if (!getSchoolListing) {
     throw new Error('School listing API is not available');
   }
 
-  return getSchoolListing(
-    buildSchoolListRequest({
-      filters,
-      selectedTab,
-      page,
-      pageSize,
-      orderBy,
-      orderDir,
-      searchTerm,
-      selectedDateRange,
-    }),
-  );
+  return getSchoolListing(request);
 };
 
 export const useSchoolListData = ({

--- a/src/ops-console/pages/SchoolList.test.tsx
+++ b/src/ops-console/pages/SchoolList.test.tsx
@@ -34,6 +34,7 @@ jest.mock('../../redux/hooks', () => ({
 
 const mockApiHandler = {
   getSchoolFilterOptionsForSchoolListing: jest.fn(),
+  getSchoolMetricsForSchoolListing: jest.fn(),
   getFilteredSchoolsForSchoolListing: jest.fn(),
 };
 
@@ -168,6 +169,10 @@ beforeEach(() => {
     block: [],
     cluster: [],
   });
+  mockApiHandler.getSchoolMetricsForSchoolListing.mockResolvedValue({
+    data: [],
+    total: 0,
+  });
   mockApiHandler.getFilteredSchoolsForSchoolListing.mockResolvedValue({
     data: [],
     total: 0,
@@ -205,7 +210,7 @@ describe('SchoolList actions menu', () => {
 
     await waitFor(() =>
       expect(
-        mockApiHandler.getFilteredSchoolsForSchoolListing,
+        mockApiHandler.getSchoolMetricsForSchoolListing,
       ).toHaveBeenCalled(),
     );
 
@@ -228,7 +233,7 @@ describe('SchoolList actions menu', () => {
 
     await waitFor(() =>
       expect(
-        mockApiHandler.getFilteredSchoolsForSchoolListing,
+        mockApiHandler.getSchoolMetricsForSchoolListing,
       ).toHaveBeenCalled(),
     );
 
@@ -251,7 +256,7 @@ describe('SchoolList actions menu', () => {
 
     await waitFor(() =>
       expect(
-        mockApiHandler.getFilteredSchoolsForSchoolListing,
+        mockApiHandler.getSchoolMetricsForSchoolListing,
       ).toHaveBeenCalled(),
     );
 
@@ -274,7 +279,7 @@ describe('SchoolList actions menu', () => {
 
     await waitFor(() =>
       expect(
-        mockApiHandler.getFilteredSchoolsForSchoolListing,
+        mockApiHandler.getSchoolMetricsForSchoolListing,
       ).toHaveBeenCalled(),
     );
 
@@ -287,13 +292,13 @@ describe('SchoolList actions menu', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('closes the actions menu when clicking outside', async () => {
+  it('closes the actions menu when pressing Escape', async () => {
     const user = userEvent.setup();
     renderPage();
 
     await waitFor(() =>
       expect(
-        mockApiHandler.getFilteredSchoolsForSchoolListing,
+        mockApiHandler.getSchoolMetricsForSchoolListing,
       ).toHaveBeenCalled(),
     );
 
@@ -302,10 +307,7 @@ describe('SchoolList actions menu', () => {
       screen.getByRole('menuitem', { name: 'Upload' }),
     ).toBeInTheDocument();
 
-    const backdrop = document.querySelector('.MuiBackdrop-root');
-    expect(backdrop).toBeTruthy();
-
-    await user.click(backdrop as HTMLElement);
+    await user.keyboard('{Escape}');
 
     await waitFor(() =>
       expect(
@@ -326,7 +328,7 @@ describe('SchoolList export', () => {
 
   it('exports the filtered school metrics rows to an xlsx file', async () => {
     const user = userEvent.setup();
-    mockApiHandler.getFilteredSchoolsForSchoolListing.mockResolvedValue({
+    mockApiHandler.getSchoolMetricsForSchoolListing.mockResolvedValue({
       data: [
         {
           school_id: 'school-1',
@@ -367,10 +369,10 @@ describe('SchoolList export', () => {
     await user.click(exportButton);
 
     expect(
-      mockApiHandler.getFilteredSchoolsForSchoolListing,
+      mockApiHandler.getSchoolMetricsForSchoolListing,
     ).toHaveBeenCalledTimes(2);
     expect(
-      mockApiHandler.getFilteredSchoolsForSchoolListing,
+      mockApiHandler.getSchoolMetricsForSchoolListing,
     ).toHaveBeenLastCalledWith(
       expect.objectContaining({
         page: 1,
@@ -472,7 +474,7 @@ describe('SchoolList export', () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-    mockApiHandler.getFilteredSchoolsForSchoolListing.mockResolvedValue({
+    mockApiHandler.getSchoolMetricsForSchoolListing.mockResolvedValue({
       data: [
         {
           school_id: 'school-1',
@@ -518,7 +520,7 @@ describe('SchoolList export', () => {
     mockRunBackgroundWorkerTask.mockRejectedValueOnce(
       new Error('worker failed'),
     );
-    mockApiHandler.getFilteredSchoolsForSchoolListing.mockResolvedValue({
+    mockApiHandler.getSchoolMetricsForSchoolListing.mockResolvedValue({
       data: [
         {
           school_id: 'school-1',

--- a/src/ops-console/pages/SchoolList.tsx
+++ b/src/ops-console/pages/SchoolList.tsx
@@ -37,7 +37,6 @@ import {
 } from './SchoolList.helpers';
 import { useDebouncedValue, useSchoolListData } from './SchoolList.fetcher';
 import { mapSchoolRowsToRenderRows } from './SchoolListRowRenderer';
-import { sortBySchoolSearchRelevance } from '../../utility/schoolSearchUtil';
 import './SchoolList.css';
 import DataTablePagination from '../components/DataTablePagination';
 import DataTableBody from '../components/DataTableBody';
@@ -114,7 +113,7 @@ const SchoolList: React.FC = () => {
   );
   const userRoles = roles || [];
   const isExternalUser = userRoles.includes(RoleType.EXTERNAL_USER);
-  const debouncedSearchTerm = useDebouncedValue(searchTerm, 500);
+  const debouncedSearchTerm = useDebouncedValue(searchTerm, 800);
   const isSearchPending = searchTerm !== debouncedSearchTerm;
 
   const rolesWithAccess = [
@@ -142,13 +141,8 @@ const SchoolList: React.FC = () => {
     selectedDateRange,
   });
   const renderedSchools = useMemo(
-    () =>
-      sortBySchoolSearchRelevance(
-        mapSchoolRowsToRenderRows(schools),
-        debouncedSearchTerm,
-        (row) => String(row.name.value ?? row.name.text ?? ''),
-      ),
-    [schools, debouncedSearchTerm],
+    () => mapSchoolRowsToRenderRows(schools),
+    [schools],
   );
 
   const isLoading = isFilterLoading || isDataLoading;

--- a/src/ops-console/pages/SchoolList.tsx
+++ b/src/ops-console/pages/SchoolList.tsx
@@ -37,6 +37,7 @@ import {
 } from './SchoolList.helpers';
 import { useDebouncedValue, useSchoolListData } from './SchoolList.fetcher';
 import { mapSchoolRowsToRenderRows } from './SchoolListRowRenderer';
+import { sortBySchoolSearchRelevance } from '../../utility/schoolSearchUtil';
 import './SchoolList.css';
 import DataTablePagination from '../components/DataTablePagination';
 import DataTableBody from '../components/DataTableBody';
@@ -141,9 +142,15 @@ const SchoolList: React.FC = () => {
     selectedDateRange,
   });
   const renderedSchools = useMemo(
-    () => mapSchoolRowsToRenderRows(schools),
-    [schools],
+    () =>
+      sortBySchoolSearchRelevance(
+        mapSchoolRowsToRenderRows(schools),
+        debouncedSearchTerm,
+        (row) => String(row.name.value ?? row.name.text ?? ''),
+      ),
+    [schools, debouncedSearchTerm],
   );
+
   const isLoading = isFilterLoading || isDataLoading;
   const columns = useMemo(() => getSchoolListColumns(), []);
   const { isExporting, isExportDisabled, handleExportSchools } =

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -96,6 +96,7 @@ import {
 } from '../../interface/modelInterfaces';
 import { Util } from '../../utility/util';
 import {
+  buildSchoolSearchKey,
   getSchoolSearchScore,
   sortBySchoolSearchRelevance,
 } from '../../utility/schoolSearchUtil';
@@ -11020,6 +11021,7 @@ export class SupabaseApi implements ServiceApi {
         };
       }
 
+      const queryKey = buildSchoolSearchKey(normalizedSearch);
       const searchableRows = mappedRows.filter((row) => {
         const searchableValues = [
           String(row.school_name ?? ''),
@@ -11031,7 +11033,8 @@ export class SupabaseApi implements ServiceApi {
         ];
 
         return searchableValues.some(
-          (value) => getSchoolSearchScore(value, normalizedSearch) < 4,
+          (value) =>
+            getSchoolSearchScore(buildSchoolSearchKey(value), queryKey) < 4,
         );
       });
 

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -95,7 +95,10 @@ import {
   UserStickerProgress,
 } from '../../interface/modelInterfaces';
 import { Util } from '../../utility/util';
-import { sortBySchoolSearchRelevance } from '../../utility/schoolSearchUtil';
+import {
+  getSchoolSearchScore,
+  sortBySchoolSearchRelevance,
+} from '../../utility/schoolSearchUtil';
 import { v4 as uuidv4 } from 'uuid';
 import { ServiceConfig } from '../ServiceConfig';
 import { SqliteApi } from './SqliteApi';
@@ -10957,71 +10960,90 @@ export class SupabaseApi implements ServiceApi {
         }
       }
 
-      if (search) {
-        query = query.or(
-          [
-            `school_name.ilike.%${search}%`,
-            `udise.ilike.%${search}%`,
-            `district.ilike.%${search}%`,
-            `block.ilike.%${search}%`,
-            `cluster.ilike.%${search}%`,
-            `state.ilike.%${search}%`,
-          ].join(','),
-        );
-      }
-
       const sortBy = order_by === 'name' ? 'school_name' : 'school_name';
-      const sortDir = order_dir === 'desc' ? false : true;
+      const sortAscending = order_dir !== 'desc';
+      const normalizedSearch = search?.trim() ?? '';
       const from = Math.max(page - 1, 0) * page_size;
-      const to = from + page_size - 1;
+      const to = from + page_size;
 
-      const { data, count, error } = await query
-        .order(sortBy, { ascending: sortDir })
-        .range(from, to);
+      const baseQuery = query.order(sortBy, { ascending: sortAscending });
+
+      const { data, count, error } = normalizedSearch
+        ? await baseQuery
+        : await baseQuery.range(from, to - 1);
 
       if (error) {
         logger.error('Error fetching school_metrics listing:', error);
         return { data: [], total: 0 };
       }
 
-      const rows = (data ?? []) as Array<Record<string, unknown>>;
+      const mappedRows = ((data ?? []) as Array<Record<string, unknown>>).map(
+        (row: Record<string, unknown>) => ({
+          ...row,
+          school_name:
+            typeof row.school_name === 'string' ? row.school_name : '',
+          udise: row.udise ?? null,
+          num_students:
+            typeof row.onboarded_students === 'number'
+              ? row.onboarded_students
+              : 0,
+          num_teachers:
+            typeof row.active_teachers === 'number' ? row.active_teachers : 0,
+          total_teachers: null,
+          onboarded_students: row.onboarded_students ?? null,
+          activated_students: row.activated_students ?? null,
+          active_students: row.active_students ?? null,
+          avg_time_spent: row.avg_time_spent ?? null,
+          active_teachers: row.active_teachers ?? null,
+          activities_assigned: row.activities_assigned ?? null,
+          avg_assignments_completed: row.avg_assignments_completed ?? null,
+          avg_activities_completed: row.avg_activities_completed ?? null,
+          phone_calls_students_parents: row.student_parent_calls ?? null,
+          phone_calls_teachers_hms: row.teacher_hm_calls ?? null,
+          community_visits: row.community_visits ?? null,
+          school_visits: row.school_visits ?? null,
+          parents_on_whatsapp: row.parents_on_whatsapp ?? null,
+          parents_in_whatsapp_group: row.parents_in_group ?? null,
+          parents_reached:
+            typeof row.community_parents_reached === 'number'
+              ? row.community_parents_reached
+              : 0,
+          program_managers: row.program_managers ?? [],
+          field_coordinators: row.field_coordinators ?? [],
+        }),
+      ) as FilteredSchoolsForSchoolListingOps[];
 
-      const mappedRows = rows.map((row: Record<string, unknown>) => ({
-        ...row,
-        school_name: typeof row.school_name === 'string' ? row.school_name : '',
-        udise: row.udise ?? null,
-        num_students:
-          typeof row.onboarded_students === 'number'
-            ? row.onboarded_students
-            : 0,
-        num_teachers:
-          typeof row.active_teachers === 'number' ? row.active_teachers : 0,
-        total_teachers: null,
-        onboarded_students: row.onboarded_students ?? null,
-        activated_students: row.activated_students ?? null,
-        active_students: row.active_students ?? null,
-        avg_time_spent: row.avg_time_spent ?? null,
-        active_teachers: row.active_teachers ?? null,
-        activities_assigned: row.activities_assigned ?? null,
-        avg_assignments_completed: row.avg_assignments_completed ?? null,
-        avg_activities_completed: row.avg_activities_completed ?? null,
-        phone_calls_students_parents: row.student_parent_calls ?? null,
-        phone_calls_teachers_hms: row.teacher_hm_calls ?? null,
-        community_visits: row.community_visits ?? null,
-        school_visits: row.school_visits ?? null,
-        parents_on_whatsapp: row.parents_on_whatsapp ?? null,
-        parents_in_whatsapp_group: row.parents_in_group ?? null,
-        parents_reached:
-          typeof row.community_parents_reached === 'number'
-            ? row.community_parents_reached
-            : 0,
-        program_managers: row.program_managers ?? [],
-        field_coordinators: row.field_coordinators ?? [],
-      })) as FilteredSchoolsForSchoolListingOps[];
+      if (!normalizedSearch) {
+        return {
+          data: mappedRows,
+          total: typeof count === 'number' ? count : 0,
+        };
+      }
+
+      const searchableRows = mappedRows.filter((row) => {
+        const searchableValues = [
+          String(row.school_name ?? ''),
+          String(row.udise ?? ''),
+          String(row.district ?? ''),
+          String(row.block ?? ''),
+          String(row.cluster ?? ''),
+          String(row.state ?? ''),
+        ];
+
+        return searchableValues.some(
+          (value) => getSchoolSearchScore(value, normalizedSearch) < 4,
+        );
+      });
+
+      const rankedRows = sortBySchoolSearchRelevance(
+        searchableRows,
+        normalizedSearch,
+        (row) => String(row.school_name ?? ''),
+      );
 
       return {
-        data: mappedRows,
-        total: typeof count === 'number' ? count : 0,
+        data: rankedRows.slice(from, to),
+        total: rankedRows.length,
       };
     } catch (error) {
       logger.error(

--- a/src/utility/schoolSearchUtil.test.ts
+++ b/src/utility/schoolSearchUtil.test.ts
@@ -1,0 +1,42 @@
+import {
+  getSchoolSearchScore,
+  sortBySchoolSearchRelevance,
+} from './schoolSearchUtil';
+
+describe('schoolSearchUtil', () => {
+  it('matches school names regardless of dots, spaces, and punctuation', () => {
+    expect(getSchoolSearchScore('A.B. School', 'ab school')).toBe(0);
+    expect(getSchoolSearchScore('A.B. School', 'a b')).toBe(1);
+    expect(getSchoolSearchScore('Alpha-Beta School', 'beta')).toBe(2);
+  });
+
+  it('sorts search results using normalized relevance', () => {
+    const items = [
+      { name: 'Gamma School' },
+      { name: 'A.B. School' },
+      { name: 'A B School' },
+      { name: 'Alpha School' },
+    ];
+
+    const sorted = sortBySchoolSearchRelevance(
+      items,
+      'ab school',
+      (item) => item.name,
+    );
+
+    expect(sorted.map((item) => item.name)).toEqual([
+      'A.B. School',
+      'A B School',
+      'Alpha School',
+      'Gamma School',
+    ]);
+  });
+
+  it('leaves the list unchanged when the query is empty', () => {
+    const items = [{ name: 'Gamma School' }, { name: 'Alpha School' }];
+
+    expect(sortBySchoolSearchRelevance(items, '   ', (item) => item.name)).toBe(
+      items,
+    );
+  });
+});

--- a/src/utility/schoolSearchUtil.test.ts
+++ b/src/utility/schoolSearchUtil.test.ts
@@ -1,16 +1,7 @@
-import {
-  getSchoolSearchScore,
-  sortBySchoolSearchRelevance,
-} from './schoolSearchUtil';
+import { sortBySchoolSearchRelevance } from './schoolSearchUtil';
 
 describe('schoolSearchUtil', () => {
   it('matches school names regardless of dots, spaces, and punctuation', () => {
-    expect(getSchoolSearchScore('A.B. School', 'ab school')).toBe(0);
-    expect(getSchoolSearchScore('A.B. School', 'a b')).toBe(1);
-    expect(getSchoolSearchScore('Alpha-Beta School', 'beta')).toBe(2);
-  });
-
-  it('sorts search results using normalized relevance', () => {
     const items = [
       { name: 'Gamma School' },
       { name: 'A.B. School' },
@@ -29,6 +20,28 @@ describe('schoolSearchUtil', () => {
       'A B School',
       'Alpha School',
       'Gamma School',
+    ]);
+  });
+
+  it('orders exact, prefix, and contains matches by relevance', () => {
+    const items = [
+      { name: 'Alpha School Annex' },
+      { name: 'My Alpha School' },
+      { name: 'Alpha School' },
+      { name: 'Completely Different School' },
+    ];
+
+    const sorted = sortBySchoolSearchRelevance(
+      items,
+      'alpha school',
+      (item) => item.name,
+    );
+
+    expect(sorted.map((item) => item.name)).toEqual([
+      'Alpha School',
+      'Alpha School Annex',
+      'My Alpha School',
+      'Completely Different School',
     ]);
   });
 

--- a/src/utility/schoolSearchUtil.ts
+++ b/src/utility/schoolSearchUtil.ts
@@ -8,21 +8,31 @@ const normalizeSchoolSearchText = (value: string) =>
 const compactSchoolSearchText = (value: string) =>
   normalizeSchoolSearchText(value).replace(/\s+/g, '');
 
-export const getSchoolSearchScore = (name: string, query: string): number => {
-  const normalizedName = normalizeSchoolSearchText(name);
-  const normalizedQuery = normalizeSchoolSearchText(query);
-  const compactName = compactSchoolSearchText(name);
-  const compactQuery = compactSchoolSearchText(query);
+type NormalizedSearchKey = {
+  normalized: string;
+  compact: string;
+};
 
-  if (!compactQuery) return Number.MAX_SAFE_INTEGER;
-  if (compactName === compactQuery) return 0;
-  if (compactName.startsWith(compactQuery)) return 1;
+export const buildSchoolSearchKey = (value: string): NormalizedSearchKey => ({
+  normalized: normalizeSchoolSearchText(value),
+  compact: compactSchoolSearchText(value),
+});
+
+export const getSchoolSearchScore = (
+  nameKey: NormalizedSearchKey,
+  queryKey: NormalizedSearchKey,
+): number => {
+  if (!queryKey.compact) return Number.MAX_SAFE_INTEGER;
+  if (nameKey.compact === queryKey.compact) return 0;
+  if (nameKey.compact.startsWith(queryKey.compact)) return 1;
   if (
-    normalizedName.split(' ').some((token) => token.startsWith(normalizedQuery))
+    nameKey.normalized
+      .split(' ')
+      .some((token) => token.startsWith(queryKey.normalized))
   ) {
     return 2;
   }
-  if (compactName.includes(compactQuery)) return 3;
+  if (nameKey.compact.includes(queryKey.compact)) return 3;
   return 4;
 };
 
@@ -31,19 +41,25 @@ export const sortBySchoolSearchRelevance = <T>(
   query: string,
   getName: (item: T) => string,
 ): T[] => {
-  const normalizedQuery = normalizeSchoolSearchText(query);
-  if (!normalizedQuery) return items;
+  const queryKey = buildSchoolSearchKey(query);
+  if (!queryKey.normalized) return items;
 
-  return [...items].sort((a, b) => {
-    const nameA = getName(a) || '';
-    const nameB = getName(b) || '';
+  const prepared = items.map((item) => {
+    const name = getName(item) || '';
+    return {
+      item,
+      name,
+      key: buildSchoolSearchKey(name),
+    };
+  });
 
-    const scoreA = getSchoolSearchScore(nameA, normalizedQuery);
-    const scoreB = getSchoolSearchScore(nameB, normalizedQuery);
+  prepared.sort((a, b) => {
+    const scoreA = getSchoolSearchScore(a.key, queryKey);
+    const scoreB = getSchoolSearchScore(b.key, queryKey);
 
     if (scoreA !== scoreB) return scoreA - scoreB;
-    return normalizeSchoolSearchText(nameA).localeCompare(
-      normalizeSchoolSearchText(nameB),
-    );
+    return a.key.normalized.localeCompare(b.key.normalized);
   });
+
+  return prepared.map((entry) => entry.item);
 };

--- a/src/utility/schoolSearchUtil.ts
+++ b/src/utility/schoolSearchUtil.ts
@@ -1,12 +1,29 @@
-export const getSchoolSearchScore = (
-  name: string,
-  normalizedQuery: string,
-): number => {
-  if (!normalizedQuery) return 0;
-  if (name === normalizedQuery) return 0;
-  if (name.startsWith(normalizedQuery)) return 1;
-  if (name.includes(normalizedQuery)) return 2;
-  return 3;
+const normalizeSchoolSearchText = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+
+const compactSchoolSearchText = (value: string) =>
+  normalizeSchoolSearchText(value).replace(/\s+/g, '');
+
+export const getSchoolSearchScore = (name: string, query: string): number => {
+  const normalizedName = normalizeSchoolSearchText(name);
+  const normalizedQuery = normalizeSchoolSearchText(query);
+  const compactName = compactSchoolSearchText(name);
+  const compactQuery = compactSchoolSearchText(query);
+
+  if (!compactQuery) return Number.MAX_SAFE_INTEGER;
+  if (compactName === compactQuery) return 0;
+  if (compactName.startsWith(compactQuery)) return 1;
+  if (
+    normalizedName.split(' ').some((token) => token.startsWith(normalizedQuery))
+  ) {
+    return 2;
+  }
+  if (compactName.includes(compactQuery)) return 3;
+  return 4;
 };
 
 export const sortBySchoolSearchRelevance = <T>(
@@ -14,17 +31,19 @@ export const sortBySchoolSearchRelevance = <T>(
   query: string,
   getName: (item: T) => string,
 ): T[] => {
-  const normalizedQuery = query.trim().toLowerCase();
+  const normalizedQuery = normalizeSchoolSearchText(query);
   if (!normalizedQuery) return items;
 
   return [...items].sort((a, b) => {
-    const nameA = (getName(a) || '').toLowerCase();
-    const nameB = (getName(b) || '').toLowerCase();
+    const nameA = getName(a) || '';
+    const nameB = getName(b) || '';
 
     const scoreA = getSchoolSearchScore(nameA, normalizedQuery);
     const scoreB = getSchoolSearchScore(nameB, normalizedQuery);
 
     if (scoreA !== scoreB) return scoreA - scoreB;
-    return nameA.localeCompare(nameB);
+    return normalizeSchoolSearchText(nameA).localeCompare(
+      normalizeSchoolSearchText(nameB),
+    );
   });
 };


### PR DESCRIPTION
- Normalized school search handling to ignore dots, spaces, and special characters so queries like UPS, U.P.S, and U P S resolve consistently.

- Improved School List search behavior to keep using the metrics-backed data path, ensuring searched results still show all metric columns instead of losing data.

- Added frontend relevance ranking so stronger matches, especially prefix matches, appear first in the displayed results.

<img width="950" height="424" alt="Screenshot 2026-06-30 164510" src="https://github.com/user-attachments/assets/8c1aedd0-530b-43f8-bc9f-495dbc302d8d" />

<img width="951" height="427" alt="Screenshot 2026-06-30 164528" src="https://github.com/user-attachments/assets/9a1daf78-bdd8-410b-8f68-b0f11c9a6fca" />
