### PR TITLE
fix(CHIM-1109): show loading screen while updating DB from import.json after app upgrade

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,7 @@ import {
   SHOULD_SHOW_HOMEWORK_REMOTE_ASSETS,
   SHOULD_SHOW_REMOTE_ASSETS,
   SHOW_GENERIC_POPUP,
+  SHOW_GLOBAL_LOADING,
   GENERIC_POP_UP,
   SEARCH_LESSON_CACHE_KEY,
   SEARCH_LESSON_HISTORY,
@@ -98,6 +99,7 @@ import React from 'react';
 import './App.css';
 import { schoolUtil } from './utility/schoolUtil';
 import LidoPlayer from './pages/LidoPlayer';
+import Loading from './components/Loading';
 import UploadPage from './ops-console/pages/UploadPage';
 import SidebarPage from './ops-console/pages/SidebarPage';
 import { initializeClickListener } from './analytics/clickUtil';
@@ -226,6 +228,7 @@ const App: React.FC = () => {
   const [timeExceeded, setTimeExceeded] = useState<boolean>(false);
   const [showModal, setShowModal] = useState<boolean>(false);
   const [showToast, setShowToast] = useState<boolean>(false);
+  const [isGlobalLoading, setIsGlobalLoading] = useState<boolean>(false);
   const [isActive, setIsActive] = useState(true);
   const shouldShowRemoteAssets = useFeatureIsOn(CAN_ACCESS_REMOTE_ASSETS);
   const shouldShowHomeworkRemoteAssets = useFeatureIsOn(
@@ -396,6 +399,17 @@ const App: React.FC = () => {
 
     return () => {
       window.removeEventListener(SHOW_GENERIC_POPUP, handler);
+    };
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const customEvent = e as CustomEvent<boolean>;
+      setIsGlobalLoading(!!customEvent.detail);
+    };
+    window.addEventListener(SHOW_GLOBAL_LOADING, handler);
+    return () => {
+      window.removeEventListener(SHOW_GLOBAL_LOADING, handler);
     };
   }, []);
 
@@ -975,6 +989,7 @@ const App: React.FC = () => {
           }}
         />
       )}
+      <Loading isLoading={isGlobalLoading} />
     </IonApp>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,6 @@ import {
   SHOULD_SHOW_HOMEWORK_REMOTE_ASSETS,
   SHOULD_SHOW_REMOTE_ASSETS,
   SHOW_GENERIC_POPUP,
-  SHOW_GLOBAL_LOADING,
   GENERIC_POP_UP,
   SEARCH_LESSON_CACHE_KEY,
   SEARCH_LESSON_HISTORY,
@@ -145,6 +144,7 @@ import PopupManager from './components/GenericPopUp/GenericPopUpManager';
 import TermsGate from './components/termsandconditons/TermsGate';
 import { useGrowthBook } from '@growthbook/growthbook-react';
 import { setCachedGrowthBookFeatureValue } from './growthbook/Growthbook';
+import { useAppSelector } from './redux/hooks';
 import { HardwareBackButtonHandler } from './common/backButtonRegistry';
 import { logger } from './utility/logger';
 import {
@@ -228,7 +228,7 @@ const App: React.FC = () => {
   const [timeExceeded, setTimeExceeded] = useState<boolean>(false);
   const [showModal, setShowModal] = useState<boolean>(false);
   const [showToast, setShowToast] = useState<boolean>(false);
-  const [isGlobalLoading, setIsGlobalLoading] = useState<boolean>(false);
+  const isGlobalLoading = useAppSelector((state) => state.auth.globalLoading);
   const [isActive, setIsActive] = useState(true);
   const shouldShowRemoteAssets = useFeatureIsOn(CAN_ACCESS_REMOTE_ASSETS);
   const shouldShowHomeworkRemoteAssets = useFeatureIsOn(
@@ -399,17 +399,6 @@ const App: React.FC = () => {
 
     return () => {
       window.removeEventListener(SHOW_GENERIC_POPUP, handler);
-    };
-  }, []);
-
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const customEvent = e as CustomEvent<boolean>;
-      setIsGlobalLoading(!!customEvent.detail);
-    };
-    window.addEventListener(SHOW_GLOBAL_LOADING, handler);
-    return () => {
-      window.removeEventListener(SHOW_GLOBAL_LOADING, handler);
     };
   }, []);
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -739,6 +739,7 @@ export const IS_OPS_USER = 'isOpsUser';
 export const EDIT_STUDENTS_MAP = 'editStudentsMap';
 export const CURRENT_STUDENT_CHANGED_EVENT = 'currentStudentChanged';
 export const SHOW_GENERIC_POPUP = 'SHOW_GENERIC_POPUP';
+export const SHOW_GLOBAL_LOADING = 'SHOW_GLOBAL_LOADING';
 export const GENERIC_POPUP_INTERNAL_NAVIGATION = 'POPUP_INTERNAL_NAVIGATION';
 export const GENERIC_POP_UP = 'generic-pop-up';
 export const TC_HTML_URL = 'tc_html_url';

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -739,7 +739,6 @@ export const IS_OPS_USER = 'isOpsUser';
 export const EDIT_STUDENTS_MAP = 'editStudentsMap';
 export const CURRENT_STUDENT_CHANGED_EVENT = 'currentStudentChanged';
 export const SHOW_GENERIC_POPUP = 'SHOW_GENERIC_POPUP';
-export const SHOW_GLOBAL_LOADING = 'SHOW_GLOBAL_LOADING';
 export const GENERIC_POPUP_INTERNAL_NAVIGATION = 'POPUP_INTERNAL_NAVIGATION';
 export const GENERIC_POP_UP = 'generic-pop-up';
 export const TC_HTML_URL = 'tc_html_url';

--- a/src/components/termsandconditons/TermsGate.test.tsx
+++ b/src/components/termsandconditons/TermsGate.test.tsx
@@ -82,6 +82,7 @@ describe('TermsGate', () => {
           isOpsUser: false,
           roles: [],
           loading: false,
+          globalLoading: false,
           error: {
             phone: null,
             student: null,

--- a/src/redux/slices/auth/authSlice.ts
+++ b/src/redux/slices/auth/authSlice.ts
@@ -18,6 +18,7 @@ export interface AuthState {
   isOpsUser: boolean;
   roles: string[];
   loading: boolean;
+  globalLoading: boolean;
   error: AuthErrors;
 }
 
@@ -36,6 +37,7 @@ const initialState: AuthState = {
   isOpsUser: false,
   roles: [],
   loading: false,
+  globalLoading: false,
   error: initialErrorState,
 };
 
@@ -45,6 +47,9 @@ export const authSlice = createSlice({
   reducers: {
     setAuthLoading: (state, action: PayloadAction<boolean>) => {
       state.loading = action.payload;
+    },
+    setGlobalLoading: (state, action: PayloadAction<boolean>) => {
+      state.globalLoading = action.payload;
     },
 
     // Allows setting a specific error by key
@@ -113,12 +118,14 @@ export const authTransform = createTransform(
       general: null,
     },
     loading: false,
+    globalLoading: false,
   }),
   { whitelist: ['auth'] },
 );
 
 export const {
   setAuthLoading,
+  setGlobalLoading,
   setAuthError,
   setAuthUser,
   setUser,

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -21,6 +21,7 @@ import {
   CLASS,
   COURSES,
   CURRENT_SQLITE_VERSION,
+  SHOW_GLOBAL_LOADING,
   CoordinatorAPIResponse,
   CoordinatorInfo,
   DEFAULT_LOCALE_ID,
@@ -475,7 +476,20 @@ export class SqliteApi implements ServiceApi {
         logger.info('🚀 ~ SqliteApi ~ setUpDatabase ~ error:', error);
       }
     } else {
-      await this.importBundledDataAfterUpgrade();
+      try {
+        window.dispatchEvent(
+          new CustomEvent(SHOW_GLOBAL_LOADING, { detail: true }),
+        );
+        logger.warn(
+          '🚀 ~ SqliteApi ~ Updaing Local Dabatase from import.json after app update',
+        );
+        await this.importBundledDataAfterUpgrade();
+      } finally {
+        window.dispatchEvent(
+          new CustomEvent(SHOW_GLOBAL_LOADING, { detail: false }),
+        );
+        logger.warn('🚀 ~ SqliteApi ~ Local Dabatase update complete');
+      }
     }
     if (this._syncTableData) {
       const tableNames = Object.keys(this._syncTableData) ?? [];

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -21,7 +21,6 @@ import {
   CLASS,
   COURSES,
   CURRENT_SQLITE_VERSION,
-  SHOW_GLOBAL_LOADING,
   CoordinatorAPIResponse,
   CoordinatorInfo,
   DEFAULT_LOCALE_ID,
@@ -83,6 +82,7 @@ import {
 } from '../../ops-console/pages/NewUserPageOps';
 import { FCSchoolStats } from '../../ops-console/pages/SchoolDetailsPage';
 import { store } from '../../redux/store';
+import { setGlobalLoading } from '../../redux/slices/auth/authSlice';
 import {
   readAssignmentCartFromStorage,
   writeAssignmentCartToStorage,
@@ -477,18 +477,14 @@ export class SqliteApi implements ServiceApi {
       }
     } else {
       try {
-        window.dispatchEvent(
-          new CustomEvent(SHOW_GLOBAL_LOADING, { detail: true }),
-        );
+        store.dispatch(setGlobalLoading(true));
         logger.warn(
-          '🚀 ~ SqliteApi ~ Updaing Local Dabatase from import.json after app update',
+          '🚀 ~ SqliteApi ~ Updating Local Database from import.json after app update',
         );
         await this.importBundledDataAfterUpgrade();
       } finally {
-        window.dispatchEvent(
-          new CustomEvent(SHOW_GLOBAL_LOADING, { detail: false }),
-        );
-        logger.warn('🚀 ~ SqliteApi ~ Local Dabatase update complete');
+        store.dispatch(setGlobalLoading(false));
+        logger.warn('🚀 ~ SqliteApi ~ Local Database update complete');
       }
     }
     if (this._syncTableData) {

--- a/src/teachers-module/hooks/useKidsAppLocationAccess.test.ts
+++ b/src/teachers-module/hooks/useKidsAppLocationAccess.test.ts
@@ -22,6 +22,7 @@ const createAuthState = (roles: string[]): AuthState => ({
   isOpsUser: false,
   roles,
   loading: false,
+  globalLoading: false,
   error: {
     phone: null,
     student: null,


### PR DESCRIPTION
- Added `SHOW_GLOBAL_LOADING` event constant to constants.ts.
- Integrated the global `Loading` spinner component at the root level of App.tsx, listening to show/hide events.
- Dispatched the loading events in SqliteApi.ts before and after running `importBundledDataAfterUpgrade()`.