### PR TITLE
fix: prevent activation lesson banner from displaying after a student plays a lesson

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1361,6 +1361,7 @@ export const REWARD_MODAL_SHOWN_DATE = 'RewardModalShownDate';
 export const DAILY_USER_REWARD = 'DailyUserReward';
 export const IDLE_REWARD_ID = '5dfa8e34-14a3-42de-ae3a-977862712b1e';
 export const REWARD_LESSON = 'RewardLesson';
+export const STUDENT_RESULT = 'studentResult';
 export const REWARD_LEARNING_PATH = 'RewardLearningPath';
 export const ACTIVATION_REWARD_FLOW_KEY = 'ActivationRewardFlow';
 export enum RewardBoxState {

--- a/src/components/assignment/JoinClass.tsx
+++ b/src/components/assignment/JoinClass.tsx
@@ -12,6 +12,7 @@ import InputWithIcons from '../common/InputWithIcons';
 import Loading from '../Loading';
 import logger from '../../utility/logger';
 import { JoinClassInviteLookupResult } from '../../services/api/ServiceApi';
+import { STUDENT_RESULT } from '../../common/constants';
 const urlClassCode: any = {};
 
 const JoinClass: FC<{
@@ -293,6 +294,21 @@ const JoinClass: FC<{
         inviteCode: parsedInviteCode,
         studentId: student.id,
       });
+
+      try {
+        const studentResultStr = sessionStorage.getItem(STUDENT_RESULT);
+        const studentResultObj = studentResultStr
+          ? JSON.parse(studentResultStr)
+          : {};
+        studentResultObj[student.id] = false;
+        sessionStorage.setItem(
+          STUDENT_RESULT,
+          JSON.stringify(studentResultObj),
+        );
+      } catch (e) {
+        logger.error('Failed to reset studentResult in sessionStorage', e);
+      }
+
       const event = new CustomEvent('JoinClassListner', { detail: 'Joined' });
       window.dispatchEvent(event);
       // history.replace("/");

--- a/src/pages/Assignment.tsx
+++ b/src/pages/Assignment.tsx
@@ -12,6 +12,7 @@ import {
   SOURCE,
   TABLES,
   TableTypes,
+  STUDENT_RESULT,
 } from '../common/constants';
 import { useHistory } from 'react-router';
 import { App } from '@capacitor/app';
@@ -147,7 +148,21 @@ const AssignmentPage: React.FC<AssignmentPageProps> = ({
         typeof api.hasStudentResult === 'function'
           ? await api.hasStudentResult(student.id)
           : true;
-      setShowActivationLessonBanner(!hasStudentResult);
+
+      let playedNow = false;
+      try {
+        const studentResultStr = sessionStorage.getItem(STUDENT_RESULT);
+        if (studentResultStr) {
+          const studentResultObj = JSON.parse(studentResultStr);
+          if (studentResultObj && studentResultObj[student.id] === true) {
+            playedNow = true;
+          }
+        }
+      } catch (e) {
+        logger.error('Failed to parse studentResult from sessionStorage', e);
+      }
+
+      setShowActivationLessonBanner(!hasStudentResult && !playedNow);
       const linkedData = await api.getStudentClassesAndSchools(student.id);
       if (!linkedData?.classes.length) {
         setIsLinked(false);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,6 +16,7 @@ import {
   IS_REWARD_FEATURE_ON,
   GENERIC_POP_UP,
   SOURCE,
+  STUDENT_RESULT,
 } from '../common/constants';
 import './Home.css';
 import HomeHeader from '../components/HomeHeader';
@@ -238,7 +239,21 @@ const Home: FC = () => {
       typeof api.hasStudentResult === 'function'
         ? await api.hasStudentResult(student.id)
         : true;
-    setShowActivationLessonBanner(!hasStudentResult);
+
+    let playedNow = false;
+    try {
+      const studentResultStr = sessionStorage.getItem(STUDENT_RESULT);
+      if (studentResultStr) {
+        const studentResultObj = JSON.parse(studentResultStr);
+        if (studentResultObj && studentResultObj[student.id] === true) {
+          playedNow = true;
+        }
+      }
+    } catch (e) {
+      logger.error('Failed to parse studentResult from sessionStorage', e);
+    }
+
+    setShowActivationLessonBanner(!hasStudentResult && !playedNow);
     const studentResult = await api.getStudentResultInMap(student.id);
     if (!!studentResult) {
       setLessonResultMap(studentResult);

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -47,6 +47,7 @@ import {
   RESULT_STATUS,
   REWARD_LEARNING_PATH,
   REWARD_LESSON,
+  STUDENT_RESULT,
   RequestTypes,
   SCHOOL,
   STATUS,
@@ -3525,6 +3526,18 @@ export class SqliteApi implements ServiceApi {
       });
     }
     this.updatePushChanges(TABLES.User, MUTATE_TYPES.UPDATE, pushData);
+
+    try {
+      const studentResultStr = sessionStorage.getItem(STUDENT_RESULT);
+      const studentResultObj = studentResultStr
+        ? JSON.parse(studentResultStr)
+        : {};
+      studentResultObj[student.id] = true;
+      sessionStorage.setItem(STUDENT_RESULT, JSON.stringify(studentResultObj));
+    } catch (e) {
+      logger.error('Failed to set studentResult in sessionStorage', e);
+    }
+
     return newResult;
   }
 
@@ -5003,6 +5016,21 @@ export class SqliteApi implements ServiceApi {
         inviteCode,
         studentId,
       });
+
+      try {
+        const studentResultStr = sessionStorage.getItem(STUDENT_RESULT);
+        const studentResultObj = studentResultStr
+          ? JSON.parse(studentResultStr)
+          : {};
+        studentResultObj[studentId] = false;
+        sessionStorage.setItem(
+          STUDENT_RESULT,
+          JSON.stringify(studentResultObj),
+        );
+      } catch (e) {
+        logger.error('Failed to reset studentResult in sessionStorage', e);
+      }
+
       return linkData;
     } catch (error) {
       logger.warn('Join class link failed through SQLite API', {


### PR DESCRIPTION


- Add `STUDENT_RESULT` key to constants for session storage.
- Update `updateResult` in `SqliteApi.ts` to mark the student as having played a lesson in `sessionStorage`.
- Reset the session play status to false when joining a class in `SqliteApi.ts` and `JoinClass.tsx`.
- Update `Home.tsx` and `Assignment.tsx` to read the play status from `sessionStorage` and conditionally hide the activation lesson banner.