### PR TITLE
Fix: Delayed lesson loading in teacher chapter view

### DIFF
--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -161,10 +161,12 @@ export class SqliteApi implements ServiceApi {
   private async resolveCourseLanguageId(
     courseId: string,
   ): Promise<string | null> {
+    // Reuse successful course-language resolution across chapter lesson fetches.
     if (this.courseLanguageIdCache.has(courseId)) {
       return this.courseLanguageIdCache.get(courseId) ?? null;
     }
 
+    // Deduplicate concurrent lookups for the same course while one query is in flight.
     const inFlightPromise = this.courseLanguageIdPromiseCache.get(courseId);
     if (inFlightPromise) {
       return inFlightPromise;
@@ -181,6 +183,11 @@ export class SqliteApi implements ServiceApi {
         `,
         [courseId],
       );
+      if (!courseRes) {
+        throw new Error(
+          `Failed to fetch course code while resolving language for course ${courseId}`,
+        );
+      }
 
       const courseCode = (
         ((courseRes as DBSQLiteValues | undefined)?.values?.[0] ?? {}) as {
@@ -210,6 +217,11 @@ export class SqliteApi implements ServiceApi {
         `,
         [courseLanguageCode],
       );
+      if (!languageRes) {
+        throw new Error(
+          `Failed to fetch language id while resolving language for course ${courseId}`,
+        );
+      }
 
       const courseLanguageId = (
         ((languageRes as DBSQLiteValues | undefined)?.values?.[0] ?? {}) as {
@@ -220,7 +232,10 @@ export class SqliteApi implements ServiceApi {
       return courseLanguageId ?? null;
     })()
       .then((languageId) => {
-        this.courseLanguageIdCache.set(courseId, languageId);
+        // Cache only confirmed language ids so transient query failures can retry later.
+        if (languageId) {
+          this.courseLanguageIdCache.set(courseId, languageId);
+        }
         return languageId;
       })
       .finally(() => {
@@ -251,6 +266,11 @@ export class SqliteApi implements ServiceApi {
       `,
       [chapterId],
     );
+    if (!courseRes) {
+      throw new Error(
+        `Failed to fetch chapter course while resolving language for chapter ${chapterId}`,
+      );
+    }
 
     const courseId = (
       ((courseRes as DBSQLiteValues | undefined)?.values?.[0] ?? {}) as {
@@ -258,7 +278,10 @@ export class SqliteApi implements ServiceApi {
       }
     ).course_id;
 
-    this.chapterCourseIdCache.set(chapterId, courseId ?? null);
+    // Keep the chapter -> course mapping only when we resolved a real course id.
+    if (courseId) {
+      this.chapterCourseIdCache.set(chapterId, courseId);
+    }
     return courseId ? this.resolveCourseLanguageId(courseId) : null;
   }
   public static async getInstance(): Promise<SqliteApi> {

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -128,6 +128,12 @@ export class SqliteApi implements ServiceApi {
   private _currentStudent: TableTypes<'user'> | undefined;
   private _currentClass: TableTypes<'class'> | undefined;
   private _currentSchool: TableTypes<'school'> | undefined;
+  private chapterCourseIdCache = new Map<string, string | null>();
+  private courseLanguageIdCache = new Map<string, string | null>();
+  private courseLanguageIdPromiseCache = new Map<
+    string,
+    Promise<string | null>
+  >();
   private _currentCourse:
     | Map<string, TableTypes<'course'> | undefined>
     | undefined;
@@ -150,6 +156,110 @@ export class SqliteApi implements ServiceApi {
       SqliteApi.i._serverApi = SupabaseApi.getInstance();
     }
     return SqliteApi.i;
+  }
+
+  private async resolveCourseLanguageId(
+    courseId: string,
+  ): Promise<string | null> {
+    if (this.courseLanguageIdCache.has(courseId)) {
+      return this.courseLanguageIdCache.get(courseId) ?? null;
+    }
+
+    const inFlightPromise = this.courseLanguageIdPromiseCache.get(courseId);
+    if (inFlightPromise) {
+      return inFlightPromise;
+    }
+
+    const languagePromise = (async () => {
+      const courseRes = await this.executeQuery(
+        `
+          SELECT code
+          FROM ${TABLES.Course}
+          WHERE id = ?
+            AND is_deleted = 0
+          LIMIT 1;
+        `,
+        [courseId],
+      );
+
+      const courseCode = (
+        ((courseRes as DBSQLiteValues | undefined)?.values?.[0] ?? {}) as {
+          code?: string | null;
+        }
+      ).code
+        ?.trim()
+        .toLowerCase();
+      const courseLanguageCode =
+        courseCode === COURSES.MATHS
+          ? COURSES.ENGLISH
+          : courseCode?.includes('-')
+            ? courseCode.split('-').pop()
+            : courseCode;
+
+      if (!courseLanguageCode) {
+        return null;
+      }
+
+      const languageRes = await this.executeQuery(
+        `
+          SELECT id
+          FROM ${TABLES.Language}
+          WHERE LOWER(code) = ?
+            AND is_deleted = 0
+          LIMIT 1;
+        `,
+        [courseLanguageCode],
+      );
+
+      const courseLanguageId = (
+        ((languageRes as DBSQLiteValues | undefined)?.values?.[0] ?? {}) as {
+          id?: string | null;
+        }
+      ).id;
+
+      return courseLanguageId ?? null;
+    })()
+      .then((languageId) => {
+        this.courseLanguageIdCache.set(courseId, languageId);
+        return languageId;
+      })
+      .finally(() => {
+        this.courseLanguageIdPromiseCache.delete(courseId);
+      });
+
+    this.courseLanguageIdPromiseCache.set(courseId, languagePromise);
+    return languagePromise;
+  }
+
+  private async resolveCourseLanguageIdForChapter(
+    chapterId: string,
+  ): Promise<string | null> {
+    const cachedCourseId = this.chapterCourseIdCache.get(chapterId);
+    if (cachedCourseId !== undefined) {
+      return cachedCourseId
+        ? this.resolveCourseLanguageId(cachedCourseId)
+        : Promise.resolve(null);
+    }
+
+    const courseRes = await this.executeQuery(
+      `
+        SELECT course_id
+        FROM ${TABLES.Chapter}
+        WHERE id = ?
+          AND is_deleted = 0
+        LIMIT 1;
+      `,
+      [chapterId],
+    );
+
+    const courseId = (
+      ((courseRes as DBSQLiteValues | undefined)?.values?.[0] ?? {}) as {
+        course_id?: string | null;
+      }
+    ).course_id;
+
+    this.chapterCourseIdCache.set(chapterId, courseId ?? null);
+    return courseId ? this.resolveCourseLanguageId(courseId) : null;
   }
   public static async getInstance(): Promise<SqliteApi> {
     if (!SqliteApi.i) {
@@ -2515,52 +2625,10 @@ export class SqliteApi implements ServiceApi {
     const localeId = student?.locale_id;
 
     try {
-      const courseRes = await this.executeQuery(
-        `
-          SELECT course.code
-          FROM ${TABLES.Chapter} AS chapter
-          JOIN ${TABLES.Course} AS course ON chapter.course_id = course.id
-          WHERE chapter.id = ?
-            AND chapter.is_deleted = 0
-            AND course.is_deleted = 0
-          LIMIT 1;
-        `,
-        [chapterId],
-      );
-      const courseCode = (
-        ((courseRes as DBSQLiteValues | undefined)?.values?.[0] ?? {}) as {
-          code?: string | null;
-        }
-      ).code
-        ?.trim()
-        .toLowerCase();
-      const courseLanguageCode =
-        courseCode === COURSES.MATHS
-          ? COURSES.ENGLISH
-          : courseCode?.includes('-')
-            ? courseCode.split('-').pop()
-            : courseCode;
-
-      if (courseLanguageCode) {
-        const languageRes = await this.executeQuery(
-          `
-            SELECT id
-            FROM ${TABLES.Language}
-            WHERE LOWER(code) = ?
-              AND is_deleted = 0
-            LIMIT 1;
-          `,
-          [courseLanguageCode],
-        );
-        const courseLanguageId = (
-          ((languageRes as DBSQLiteValues | undefined)?.values?.[0] ?? {}) as {
-            id?: string | null;
-          }
-        ).id;
-
-        if (courseLanguageId) {
-          langId = courseLanguageId;
-        }
+      const courseLanguageId =
+        await this.resolveCourseLanguageIdForChapter(chapterId);
+      if (courseLanguageId) {
+        langId = courseLanguageId;
       }
     } catch (error) {
       logger.error('Error resolving chapter course language:', error);
@@ -5120,6 +5188,9 @@ export class SqliteApi implements ServiceApi {
     ORDER BY sort_index ASC;
     `;
     const res = await this._db?.query(query);
+    (res?.values ?? []).forEach((chapter) => {
+      this.chapterCourseIdCache.set(chapter.id, chapter.course_id ?? courseId);
+    });
     return res?.values ?? [];
   }
   async getPendingAssignmentForLesson(

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -292,6 +292,113 @@ export class SupabaseApi implements ServiceApi {
   private _liveQuizRealTime?: RealtimeChannel;
   private _currentMode: MODES;
   private searchStudentsTimer: any = null;
+  private chapterCourseIdCache = new Map<string, string | null>();
+  private courseLanguageIdCache = new Map<string, string | null>();
+  private courseLanguageIdPromiseCache = new Map<
+    string,
+    Promise<string | null>
+  >();
+
+  private async resolveCourseLanguageId(
+    courseId: string,
+  ): Promise<string | null> {
+    if (this.courseLanguageIdCache.has(courseId)) {
+      return this.courseLanguageIdCache.get(courseId) ?? null;
+    }
+
+    const inFlightPromise = this.courseLanguageIdPromiseCache.get(courseId);
+    if (inFlightPromise) {
+      return inFlightPromise;
+    }
+
+    const languagePromise = (async () => {
+      if (!this.supabase) return null;
+
+      const { data: courseRows, error: courseError } = await this.supabase
+        .from(TABLES.Course)
+        .select('code')
+        .eq('id', courseId)
+        .eq('is_deleted', false)
+        .limit(1);
+
+      if (courseError) {
+        logger.error(
+          'Error fetching course code for lesson language:',
+          courseError,
+        );
+        return null;
+      }
+
+      const courseCode = (courseRows?.[0]?.code ?? '').trim().toLowerCase();
+      const courseLanguageCode =
+        courseCode === COURSES.MATHS
+          ? COURSES.ENGLISH
+          : courseCode.includes('-')
+            ? courseCode.split('-').pop()
+            : courseCode;
+
+      if (!courseLanguageCode) {
+        return null;
+      }
+
+      const { data: languageRows, error: languageError } = await this.supabase
+        .from(TABLES.Language)
+        .select('id')
+        .ilike('code', courseLanguageCode)
+        .eq('is_deleted', false)
+        .limit(1);
+
+      if (languageError) {
+        logger.error('Error fetching course language:', languageError);
+        return null;
+      }
+
+      return languageRows?.[0]?.id ?? null;
+    })()
+      .then((languageId) => {
+        this.courseLanguageIdCache.set(courseId, languageId);
+        return languageId;
+      })
+      .finally(() => {
+        this.courseLanguageIdPromiseCache.delete(courseId);
+      });
+
+    this.courseLanguageIdPromiseCache.set(courseId, languagePromise);
+    return languagePromise;
+  }
+
+  private async resolveCourseLanguageIdForChapter(
+    chapterId: string,
+  ): Promise<string | null> {
+    const cachedCourseId = this.chapterCourseIdCache.get(chapterId);
+    if (cachedCourseId !== undefined) {
+      return cachedCourseId
+        ? this.resolveCourseLanguageId(cachedCourseId)
+        : Promise.resolve(null);
+    }
+
+    if (!this.supabase) return null;
+
+    const { data: chapterRows, error: chapterError } = await this.supabase
+      .from(TABLES.Chapter)
+      .select('course_id')
+      .eq('id', chapterId)
+      .eq('is_deleted', false)
+      .limit(1);
+
+    if (chapterError) {
+      logger.error(
+        'Error fetching chapter course for lesson language:',
+        chapterError,
+      );
+      return null;
+    }
+
+    const courseId = chapterRows?.[0]?.course_id ?? null;
+    this.chapterCourseIdCache.set(chapterId, courseId);
+    return courseId ? this.resolveCourseLanguageId(courseId) : null;
+  }
+
   async getChaptersForCourse(courseId: string): Promise<
     {
       course_id: string | null;
@@ -317,6 +424,10 @@ export class SupabaseApi implements ServiceApi {
       logger.error('Error fetching chapters for course:', error);
       return [];
     }
+
+    (data ?? []).forEach((chapter) => {
+      this.chapterCourseIdCache.set(chapter.id, chapter.course_id ?? courseId);
+    });
 
     return data ?? [];
   }
@@ -2309,42 +2420,10 @@ export class SupabaseApi implements ServiceApi {
     let langId = student?.language_id;
     const localeId = student?.locale_id;
 
-    const { data: chapterRows, error: chapterError } = await this.supabase
-      .from(TABLES.Chapter)
-      .select('course:course_id(code)')
-      .eq('id', chapterId)
-      .eq('is_deleted', false)
-      .limit(1);
-
-    if (chapterError) {
-      logger.error('Error fetching chapter course:', chapterError);
-    } else {
-      const courseCode = (
-        chapterRows?.[0]?.course as { code?: string | null } | null | undefined
-      )?.code
-        ?.trim()
-        .toLowerCase();
-      const courseLanguageCode =
-        courseCode === COURSES.MATHS
-          ? COURSES.ENGLISH
-          : courseCode?.includes('-')
-            ? courseCode.split('-').pop()
-            : courseCode;
-
-      if (courseLanguageCode) {
-        const { data: languageRows, error: languageError } = await this.supabase
-          .from(TABLES.Language)
-          .select('id')
-          .ilike('code', courseLanguageCode)
-          .eq('is_deleted', false)
-          .limit(1);
-
-        if (languageError) {
-          logger.error('Error fetching course language:', languageError);
-        } else if (languageRows?.[0]?.id) {
-          langId = languageRows[0].id;
-        }
-      }
+    const courseLanguageId =
+      await this.resolveCourseLanguageIdForChapter(chapterId);
+    if (courseLanguageId) {
+      langId = courseLanguageId;
     }
 
     const orFilters: string[] = [];

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -292,135 +292,6 @@ export class SupabaseApi implements ServiceApi {
   private _liveQuizRealTime?: RealtimeChannel;
   private _currentMode: MODES;
   private searchStudentsTimer: any = null;
-  private chapterCourseIdCache = new Map<string, string | null>();
-  private courseLanguageIdCache = new Map<string, string | null>();
-  private courseLanguageIdPromiseCache = new Map<
-    string,
-    Promise<string | null>
-  >();
-
-  private async resolveCourseLanguageId(
-    courseId: string,
-  ): Promise<string | null> {
-    // Reuse successful course-language resolution across chapter lesson fetches.
-    if (this.courseLanguageIdCache.has(courseId)) {
-      return this.courseLanguageIdCache.get(courseId) ?? null;
-    }
-
-    // Deduplicate concurrent lookups for the same course while one request is in flight.
-    const inFlightPromise = this.courseLanguageIdPromiseCache.get(courseId);
-    if (inFlightPromise) {
-      return inFlightPromise;
-    }
-
-    const languagePromise = (async () => {
-      if (!this.supabase) {
-        throw new Error(
-          `Supabase is not initialized while resolving language for course ${courseId}`,
-        );
-      }
-
-      const { data: courseRows, error: courseError } = await this.supabase
-        .from(TABLES.Course)
-        .select('code')
-        .eq('id', courseId)
-        .eq('is_deleted', false)
-        .limit(1);
-
-      if (courseError) {
-        logger.error(
-          'Error fetching course code for lesson language:',
-          courseError,
-        );
-        throw new Error(
-          `Failed to fetch course code while resolving language for course ${courseId}`,
-        );
-      }
-
-      const courseCode = (courseRows?.[0]?.code ?? '').trim().toLowerCase();
-      const courseLanguageCode =
-        courseCode === COURSES.MATHS
-          ? COURSES.ENGLISH
-          : courseCode.includes('-')
-            ? courseCode.split('-').pop()
-            : courseCode;
-
-      if (!courseLanguageCode) {
-        return null;
-      }
-
-      const { data: languageRows, error: languageError } = await this.supabase
-        .from(TABLES.Language)
-        .select('id')
-        .ilike('code', courseLanguageCode)
-        .eq('is_deleted', false)
-        .limit(1);
-
-      if (languageError) {
-        logger.error('Error fetching course language:', languageError);
-        throw new Error(
-          `Failed to fetch language while resolving language for course ${courseId}`,
-        );
-      }
-
-      return languageRows?.[0]?.id ?? null;
-    })()
-      .then((languageId) => {
-        // Cache only confirmed language ids so transient client/query failures can retry.
-        if (languageId) {
-          this.courseLanguageIdCache.set(courseId, languageId);
-        }
-        return languageId;
-      })
-      .finally(() => {
-        this.courseLanguageIdPromiseCache.delete(courseId);
-      });
-
-    this.courseLanguageIdPromiseCache.set(courseId, languagePromise);
-    return languagePromise;
-  }
-
-  private async resolveCourseLanguageIdForChapter(
-    chapterId: string,
-  ): Promise<string | null> {
-    const cachedCourseId = this.chapterCourseIdCache.get(chapterId);
-    if (cachedCourseId !== undefined) {
-      return cachedCourseId
-        ? this.resolveCourseLanguageId(cachedCourseId)
-        : Promise.resolve(null);
-    }
-
-    if (!this.supabase) {
-      throw new Error(
-        `Supabase is not initialized while resolving language for chapter ${chapterId}`,
-      );
-    }
-
-    const { data: chapterRows, error: chapterError } = await this.supabase
-      .from(TABLES.Chapter)
-      .select('course_id')
-      .eq('id', chapterId)
-      .eq('is_deleted', false)
-      .limit(1);
-
-    if (chapterError) {
-      logger.error(
-        'Error fetching chapter course for lesson language:',
-        chapterError,
-      );
-      throw new Error(
-        `Failed to fetch chapter course while resolving language for chapter ${chapterId}`,
-      );
-    }
-
-    const courseId = chapterRows?.[0]?.course_id ?? null;
-    // Keep the chapter -> course mapping only when we resolved a real course id.
-    if (courseId) {
-      this.chapterCourseIdCache.set(chapterId, courseId);
-    }
-    return courseId ? this.resolveCourseLanguageId(courseId) : null;
-  }
-
   async getChaptersForCourse(courseId: string): Promise<
     {
       course_id: string | null;
@@ -446,10 +317,6 @@ export class SupabaseApi implements ServiceApi {
       logger.error('Error fetching chapters for course:', error);
       return [];
     }
-
-    (data ?? []).forEach((chapter) => {
-      this.chapterCourseIdCache.set(chapter.id, chapter.course_id ?? courseId);
-    });
 
     return data ?? [];
   }
@@ -2442,10 +2309,42 @@ export class SupabaseApi implements ServiceApi {
     let langId = student?.language_id;
     const localeId = student?.locale_id;
 
-    const courseLanguageId =
-      await this.resolveCourseLanguageIdForChapter(chapterId);
-    if (courseLanguageId) {
-      langId = courseLanguageId;
+    const { data: chapterRows, error: chapterError } = await this.supabase
+      .from(TABLES.Chapter)
+      .select('course:course_id(code)')
+      .eq('id', chapterId)
+      .eq('is_deleted', false)
+      .limit(1);
+
+    if (chapterError) {
+      logger.error('Error fetching chapter course:', chapterError);
+    } else {
+      const courseCode = (
+        chapterRows?.[0]?.course as { code?: string | null } | null | undefined
+      )?.code
+        ?.trim()
+        .toLowerCase();
+      const courseLanguageCode =
+        courseCode === COURSES.MATHS
+          ? COURSES.ENGLISH
+          : courseCode?.includes('-')
+            ? courseCode.split('-').pop()
+            : courseCode;
+
+      if (courseLanguageCode) {
+        const { data: languageRows, error: languageError } = await this.supabase
+          .from(TABLES.Language)
+          .select('id')
+          .ilike('code', courseLanguageCode)
+          .eq('is_deleted', false)
+          .limit(1);
+
+        if (languageError) {
+          logger.error('Error fetching course language:', languageError);
+        } else if (languageRows?.[0]?.id) {
+          langId = languageRows[0].id;
+        }
+      }
     }
 
     const orFilters: string[] = [];

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -302,17 +302,23 @@ export class SupabaseApi implements ServiceApi {
   private async resolveCourseLanguageId(
     courseId: string,
   ): Promise<string | null> {
+    // Reuse successful course-language resolution across chapter lesson fetches.
     if (this.courseLanguageIdCache.has(courseId)) {
       return this.courseLanguageIdCache.get(courseId) ?? null;
     }
 
+    // Deduplicate concurrent lookups for the same course while one request is in flight.
     const inFlightPromise = this.courseLanguageIdPromiseCache.get(courseId);
     if (inFlightPromise) {
       return inFlightPromise;
     }
 
     const languagePromise = (async () => {
-      if (!this.supabase) return null;
+      if (!this.supabase) {
+        throw new Error(
+          `Supabase is not initialized while resolving language for course ${courseId}`,
+        );
+      }
 
       const { data: courseRows, error: courseError } = await this.supabase
         .from(TABLES.Course)
@@ -326,7 +332,9 @@ export class SupabaseApi implements ServiceApi {
           'Error fetching course code for lesson language:',
           courseError,
         );
-        return null;
+        throw new Error(
+          `Failed to fetch course code while resolving language for course ${courseId}`,
+        );
       }
 
       const courseCode = (courseRows?.[0]?.code ?? '').trim().toLowerCase();
@@ -350,13 +358,18 @@ export class SupabaseApi implements ServiceApi {
 
       if (languageError) {
         logger.error('Error fetching course language:', languageError);
-        return null;
+        throw new Error(
+          `Failed to fetch language while resolving language for course ${courseId}`,
+        );
       }
 
       return languageRows?.[0]?.id ?? null;
     })()
       .then((languageId) => {
-        this.courseLanguageIdCache.set(courseId, languageId);
+        // Cache only confirmed language ids so transient client/query failures can retry.
+        if (languageId) {
+          this.courseLanguageIdCache.set(courseId, languageId);
+        }
         return languageId;
       })
       .finally(() => {
@@ -377,7 +390,11 @@ export class SupabaseApi implements ServiceApi {
         : Promise.resolve(null);
     }
 
-    if (!this.supabase) return null;
+    if (!this.supabase) {
+      throw new Error(
+        `Supabase is not initialized while resolving language for chapter ${chapterId}`,
+      );
+    }
 
     const { data: chapterRows, error: chapterError } = await this.supabase
       .from(TABLES.Chapter)
@@ -391,11 +408,16 @@ export class SupabaseApi implements ServiceApi {
         'Error fetching chapter course for lesson language:',
         chapterError,
       );
-      return null;
+      throw new Error(
+        `Failed to fetch chapter course while resolving language for chapter ${chapterId}`,
+      );
     }
 
     const courseId = chapterRows?.[0]?.course_id ?? null;
-    this.chapterCourseIdCache.set(chapterId, courseId);
+    // Keep the chapter -> course mapping only when we resolved a real course id.
+    if (courseId) {
+      this.chapterCourseIdCache.set(chapterId, courseId);
+    }
     return courseId ? this.resolveCourseLanguageId(courseId) : null;
   }
 

--- a/src/teachers-module/components/library/ChapterContainer.tsx
+++ b/src/teachers-module/components/library/ChapterContainer.tsx
@@ -39,10 +39,6 @@ const ChapterContainer: React.FC<ChapterContainerProps> = ({
         (lesson) => !lesson.id || !assignedLessonIds?.has(lesson.id),
       );
 
-  if (lessons.length === 0) {
-    return null;
-  }
-
   const visibleLessonIds = visibleLessons
     .map((lesson) => lesson.id)
     .filter((lessonId): lessonId is string => Boolean(lessonId));
@@ -162,26 +158,30 @@ const ChapterContainer: React.FC<ChapterContainerProps> = ({
                 }
               }}
             >
-              <span
-                id="chaptercontainer-chapter-select-all-text"
-                className="chaptercontainer-chapter-select-all-text"
-              >
-                {t('Select All')}
-              </span>
-              <span
-                id="chaptercontainer-chapter-select-all-icon"
-                className="chaptercontainer-chapter-select-all-icon"
-                aria-hidden="true"
-              >
-                {isAllSelected ? (
-                  <img
-                    src="/assets/icons/checkbox.png"
-                    alt=""
-                    id="chaptercontainer-chapter-select-all-icon-image"
-                    className="chaptercontainer-chapter-select-all-icon-image"
-                  />
-                ) : null}
-              </span>
+              {visibleLessons.length > 0 ? (
+                <>
+                  <span
+                    id="chaptercontainer-chapter-select-all-text"
+                    className="chaptercontainer-chapter-select-all-text"
+                  >
+                    {t('Select All')}
+                  </span>
+                  <span
+                    id="chaptercontainer-chapter-select-all-icon"
+                    className="chaptercontainer-chapter-select-all-icon"
+                    aria-hidden="true"
+                  >
+                    {isAllSelected ? (
+                      <img
+                        src="/assets/icons/checkbox.png"
+                        alt=""
+                        id="chaptercontainer-chapter-select-all-icon-image"
+                        className="chaptercontainer-chapter-select-all-icon-image"
+                      />
+                    ) : null}
+                  </span>
+                </>
+              ) : null}
             </div>
             <span
               id="chaptercontainer-expand-arrow"
@@ -193,7 +193,7 @@ const ChapterContainer: React.FC<ChapterContainerProps> = ({
           </div>
         </div>
       </div>
-      {isExpanded ? (
+      {isExpanded && visibleLessons.length > 0 ? (
         <div
           id="chaptercontainer-grid-container"
           className="chaptercontainer-grid-container"


### PR DESCRIPTION
- Moved the course-language resolution logic out of getLessonsForChapter into reusable helper methods.
- Added caching for chapter -> course lookup to avoid repeated chapter queries.
- Added caching for course -> language lookup to avoid repeated language resolution for the same course.
- Updated both SQLite and Supabase implementations so the optimization works in both data paths.
- Kept the final lesson filtering behavior unchanged, so no existing language-based lesson selection logic is lost.
- Updated the chapter UI to avoid rendering an empty expanded lesson grid before lessons are available.