### PR TITLE
fix: Add language-based filtering for assessments

### DIFF
--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -190,7 +190,10 @@ const LidoPlayer: FC = () => {
 
   const getAssessmentProgressKey = () => {
     if (isAssessmentLesson && courseDetail?.subject_id) {
-      return `subject:${courseDetail.subject_id}`;
+      const courseCode = courseDetail.code?.trim().toLowerCase();
+      return courseCode
+        ? `subject:${courseDetail.subject_id}:course:${courseCode}`
+        : `subject:${courseDetail.subject_id}:course:${courseDetail.id}`;
     }
     return courseDetail?.id ?? courseDocId ?? '';
   };

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -9943,9 +9943,22 @@ order by
       const setNumber = candidateSets[randomIndex];
       const useStrictLanguageTrack =
         !!langId && preferredSets.includes(setNumber);
+      const assessmentTrackRows = useStrictLanguageTrack
+        ? setRows.filter((row) =>
+            localeId
+              ? row.language_id === langId &&
+                (row.locale_id === localeId || row.locale_id == null)
+              : row.language_id === langId,
+          )
+        : setRows.filter((row) =>
+            localeId
+              ? row.language_id == null &&
+                (row.locale_id === localeId || row.locale_id == null)
+              : row.language_id == null,
+          );
       const assessmentLessonIds = Array.from(
         new Set(
-          setRows
+          assessmentTrackRows
             .map((row) => row.lesson_id)
             .filter((lessonId): lessonId is string => !!lessonId),
         ),
@@ -10131,9 +10144,33 @@ order by
       const course = await this.getCourse(courseId);
       if (!course?.subject_id) return false;
       const subjectId = course.subject_id;
+      let langId: string | null = null;
+      const courseCode = course.code?.trim().toLowerCase();
+      const courseLanguageCode =
+        courseCode === COURSES.MATHS
+          ? COURSES.ENGLISH
+          : courseCode?.includes('-')
+            ? courseCode.split('-').pop()
+            : courseCode;
+
+      if (courseLanguageCode) {
+        const languageRes = await this.executeQuery(
+          `
+            SELECT id
+            FROM language
+            WHERE LOWER(code) = ?
+              AND is_deleted = 0
+            LIMIT 1;
+          `,
+          [courseLanguageCode],
+        );
+        langId =
+          (((languageRes as DBSQLiteValues | undefined)?.values ?? [])[0]
+            ?.id as string | undefined) ?? null;
+      }
 
       const assessmentLessonsQuery = `
-        SELECT DISTINCT lesson_id
+        SELECT DISTINCT lesson_id, language_id
         FROM subject_lesson
         WHERE subject_id = ?
           AND COALESCE(is_deleted, 0) = 0
@@ -10145,11 +10182,28 @@ order by
       );
       const assessmentLessonIds = Array.from(
         new Set(
+          (langId &&
           (
             ((assessmentLessonsRes as DBSQLiteValues | undefined)?.values ??
               []) as {
               lesson_id?: string | null;
+              language_id?: string | null;
             }[]
+          ).some((lesson) => lesson.language_id === langId)
+            ? (
+                ((assessmentLessonsRes as DBSQLiteValues | undefined)?.values ??
+                  []) as {
+                  lesson_id?: string | null;
+                  language_id?: string | null;
+                }[]
+              ).filter((lesson) => lesson.language_id === langId)
+            : (
+                ((assessmentLessonsRes as DBSQLiteValues | undefined)?.values ??
+                  []) as {
+                  lesson_id?: string | null;
+                  language_id?: string | null;
+                }[]
+              ).filter((lesson) => lesson.language_id == null)
           )
             .map((lesson) => lesson.lesson_id)
             .filter((lessonId): lessonId is string => !!lessonId),
@@ -10222,10 +10276,34 @@ order by
       if (!subjectId) {
         return false;
       }
+      let langId: string | null = null;
+      const courseCode = course.code?.trim().toLowerCase();
+      const courseLanguageCode =
+        courseCode === COURSES.MATHS
+          ? COURSES.ENGLISH
+          : courseCode?.includes('-')
+            ? courseCode.split('-').pop()
+            : courseCode;
+
+      if (courseLanguageCode) {
+        const languageRes = await this.executeQuery(
+          `
+            SELECT id
+            FROM language
+            WHERE LOWER(code) = ?
+              AND is_deleted = 0
+            LIMIT 1;
+          `,
+          [courseLanguageCode],
+        );
+        langId =
+          (((languageRes as DBSQLiteValues | undefined)?.values ?? [])[0]
+            ?.id as string | undefined) ?? null;
+      }
 
       const assessmentLessonsRes = await this.executeQuery(
         `
-          SELECT lesson_id
+          SELECT lesson_id, language_id
           FROM subject_lesson
           WHERE subject_id = ?
             AND COALESCE(is_deleted, 0) = 0
@@ -10235,9 +10313,16 @@ order by
 
       const assessmentLessonRows =
         (assessmentLessonsRes as DBSQLiteValues | undefined)?.values ?? [];
+      const languageTrackLessons =
+        langId &&
+        assessmentLessonRows.some((lesson) => lesson.language_id === langId)
+          ? assessmentLessonRows.filter(
+              (lesson) => lesson.language_id === langId,
+            )
+          : assessmentLessonRows.filter((lesson) => lesson.language_id == null);
       const assessmentLessonIds: string[] = [];
       const placeholderParts: string[] = [];
-      for (const row of assessmentLessonRows) {
+      for (const row of languageTrackLessons) {
         const lessonId = row.lesson_id;
         if (!lessonId) continue;
         assessmentLessonIds.push(lessonId);

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -14612,9 +14612,22 @@ export class SupabaseApi implements ServiceApi {
       const setNumber = candidateSets[randomIndex];
       const useStrictLanguageTrack =
         !!langId && preferredSets.includes(setNumber);
+      const assessmentTrackRows = useStrictLanguageTrack
+        ? (setRows ?? []).filter((row) =>
+            localeId
+              ? row.language_id === langId &&
+                (row.locale_id === localeId || row.locale_id == null)
+              : row.language_id === langId,
+          )
+        : (setRows ?? []).filter((row) =>
+            localeId
+              ? row.language_id == null &&
+                (row.locale_id === localeId || row.locale_id == null)
+              : row.language_id == null,
+          );
       const assessmentLessonIds = Array.from(
         new Set(
-          (setRows ?? [])
+          assessmentTrackRows
             .map((row) => row.lesson_id)
             .filter((lessonId): lessonId is string => !!lessonId),
         ),
@@ -14645,16 +14658,12 @@ export class SupabaseApi implements ServiceApi {
         return {} as TableTypes<'subject_lesson'>;
       }
 
-      if (!data || data.length === 0) {
-        return {} as TableTypes<'subject_lesson'>;
-      }
-
       /* -----------------------------------------
         Keep latest result per unique lesson
       ------------------------------------------ */
       const uniqueMap = new Map<string, ResultStatusRow>();
 
-      for (const row of data as ResultStatusRow[]) {
+      for (const row of (data ?? []) as ResultStatusRow[]) {
         if (!row.lesson_id) continue;
         if (!uniqueMap.has(row.lesson_id)) {
           uniqueMap.set(row.lesson_id, row);
@@ -14669,7 +14678,7 @@ export class SupabaseApi implements ServiceApi {
       /* -----------------------------------------
         Abort check
       ------------------------------------------ */
-      const isAssessmentTerminated = (data as ResultStatusRow[]).some(
+      const isAssessmentTerminated = ((data ?? []) as ResultStatusRow[]).some(
         (r) => r.status === 'assessment_terminated',
       );
       const isAborted =
@@ -14888,11 +14897,37 @@ export class SupabaseApi implements ServiceApi {
       const course = await this.getCourse(courseId);
       if (!course?.subject_id) return false;
       const subjectId = course.subject_id;
+      let langId: string | null = null;
+      const courseCode = course.code?.trim().toLowerCase();
+      const courseLanguageCode =
+        courseCode === COURSES.MATHS
+          ? COURSES.ENGLISH
+          : courseCode?.includes('-')
+            ? courseCode.split('-').pop()
+            : courseCode;
+
+      if (courseLanguageCode) {
+        const { data: languageRows, error: languageError } = await this.supabase
+          .from('language')
+          .select('id')
+          .ilike('code', courseLanguageCode)
+          .eq('is_deleted', false)
+          .limit(1);
+
+        if (languageError) {
+          logger.error(
+            'Error fetching PAL assessment history language:',
+            languageError,
+          );
+        } else {
+          langId = languageRows?.[0]?.id ?? null;
+        }
+      }
 
       const { data: assessmentLessons, error: assessmentLessonsError } =
         await this.supabase
           .from('subject_lesson')
-          .select('lesson_id')
+          .select('lesson_id, language_id')
           .eq('subject_id', subjectId)
           .or('is_deleted.eq.false,is_deleted.is.null');
 
@@ -14906,7 +14941,17 @@ export class SupabaseApi implements ServiceApi {
 
       const assessmentLessonIds = Array.from(
         new Set(
-          (assessmentLessons ?? [])
+          (langId &&
+          (assessmentLessons ?? []).some(
+            (lesson) => lesson.language_id === langId,
+          )
+            ? (assessmentLessons ?? []).filter(
+                (lesson) => lesson.language_id === langId,
+              )
+            : (assessmentLessons ?? []).filter(
+                (lesson) => lesson.language_id == null,
+              )
+          )
             .map((lesson) => lesson.lesson_id)
             .filter((lessonId): lessonId is string => !!lessonId),
         ),
@@ -14986,11 +15031,37 @@ export class SupabaseApi implements ServiceApi {
       if (!course?.subject_id) {
         return false;
       }
+      let langId: string | null = null;
+      const courseCode = course.code?.trim().toLowerCase();
+      const courseLanguageCode =
+        courseCode === COURSES.MATHS
+          ? COURSES.ENGLISH
+          : courseCode?.includes('-')
+            ? courseCode.split('-').pop()
+            : courseCode;
+
+      if (courseLanguageCode) {
+        const { data: languageRows, error: languageError } = await this.supabase
+          .from('language')
+          .select('id')
+          .ilike('code', courseLanguageCode)
+          .eq('is_deleted', false)
+          .limit(1);
+
+        if (languageError) {
+          logger.error(
+            'Error fetching pending abort assessment language:',
+            languageError,
+          );
+        } else {
+          langId = languageRows?.[0]?.id ?? null;
+        }
+      }
 
       const { data: assessmentLessons, error: assessmentLessonsError } =
         await this.supabase
           .from('subject_lesson')
-          .select('lesson_id')
+          .select('lesson_id, language_id')
           .eq('subject_id', course.subject_id)
           .or('is_deleted.eq.false,is_deleted.is.null');
 
@@ -15002,9 +15073,21 @@ export class SupabaseApi implements ServiceApi {
         return false;
       }
 
+      const languageTrackLessons =
+        langId &&
+        (assessmentLessons ?? []).some(
+          (lesson) => lesson.language_id === langId,
+        )
+          ? (assessmentLessons ?? []).filter(
+              (lesson) => lesson.language_id === langId,
+            )
+          : (assessmentLessons ?? []).filter(
+              (lesson) => lesson.language_id == null,
+            );
+
       const seenLessonIds = new Set<string>();
       const assessmentLessonIds: string[] = [];
-      for (const lesson of assessmentLessons ?? []) {
+      for (const lesson of languageTrackLessons) {
         const lessonId = lesson.lesson_id;
         if (!lessonId || seenLessonIds.has(lessonId)) continue;
         seenLessonIds.add(lessonId);

--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -2901,6 +2901,31 @@ export class Util {
       if (courseIndex === -1) return;
 
       let course = courses.courseList[courseIndex];
+      const courseCodeById = new Map<string, string | null>();
+      const getCourseCode = async (coursePath: CoursePath) => {
+        const storedCode = coursePath.course_code?.trim().toLowerCase();
+        if (storedCode) return storedCode;
+
+        const courseId = coursePath.course_id;
+        if (courseCodeById.has(courseId)) {
+          return courseCodeById.get(courseId) ?? null;
+        }
+
+        try {
+          const courseMeta =
+            await ServiceConfig.getI().apiHandler.getCourse(courseId);
+          const code = courseMeta?.code?.trim().toLowerCase() || null;
+          courseCodeById.set(courseId, code);
+          return code;
+        } catch (error) {
+          logger.warn('[LearningPath] Unable to resolve course code', {
+            courseId,
+            error,
+          });
+          courseCodeById.set(courseId, null);
+          return null;
+        }
+      };
       course.path.length = 0;
       const nextQueuedLesson = course.path.find(
         (lesson: LessonNode) => lesson.isPlayed === false,
@@ -2930,10 +2955,14 @@ export class Util {
         storedPathwayMode === LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY &&
         course.subject_id
       ) {
+        const activeCourseCode = await getCourseCode(course);
         for (const peerCourse of courses.courseList) {
+          const peerCourseCode = await getCourseCode(peerCourse);
           if (
             peerCourse === course ||
-            peerCourse.subject_id !== course.subject_id
+            peerCourse.subject_id !== course.subject_id ||
+            !activeCourseCode ||
+            peerCourseCode !== activeCourseCode
           ) {
             continue;
           }


### PR DESCRIPTION
Filter assessment lessons and courses by language to properly track progress for multi-language subjects. This extracts the language code from course identifiers and ensures assessment lessons are grouped by language track instead of just subject ID.

Changes:
- Update assessment progress key to include course code
- Filter assessment lessons by language_id matching course language
- Group assessment-only courses by both subject and language
- Apply language filtering in both SQLite and Supabase APIs