### PR TITLE
Fix login screen flicker after successful Student ID login

### DIFF
--- a/src/pages/LoginScreen.tsx
+++ b/src/pages/LoginScreen.tsx
@@ -680,8 +680,6 @@ const LoginScreen: React.FC = () => {
         );
         return;
       }
-      setAnimatedLoading(false);
-      dispatch(setAuthLoading(false));
       dispatch(setAuthUser(authUser));
       dispatch(setUser(userData));
       dispatch(setIsOpsUser(isOps));

--- a/src/pages/LoginScreen.tsx
+++ b/src/pages/LoginScreen.tsx
@@ -680,6 +680,7 @@ const LoginScreen: React.FC = () => {
         );
         return;
       }
+      dispatch(setAuthLoading(false));
       dispatch(setAuthUser(authUser));
       dispatch(setUser(userData));
       dispatch(setIsOpsUser(isOps));


### PR DESCRIPTION
Fixed the login screen flicker that occurred after a successful Student ID login.

Root Cause

The loading state was being cleared before the post-login navigation completed, causing the login screen to briefly reappear before redirecting to the destination page.

Changes
Removed the early setAnimatedLoading(false) and dispatch(setAuthLoading(false)) calls from the successful Student ID login flow.
Kept the existing authentication and navigation logic unchanged.