### PR TITLE
fix: Preserve assessment nodes; robust assessment path logic

### DIFF
--- a/src/hooks/useLearningPath.test.ts
+++ b/src/hooks/useLearningPath.test.ts
@@ -812,6 +812,96 @@ describe('useLearningPath features used by Home tab', () => {
     ]);
   });
 
+  test('preserves played assessment nodes when syncing an assessment-only course without a pending node', async () => {
+    const existingPath = {
+      courses: {
+        currentCourseIndex: 0,
+        courseList: [
+          {
+            path_id: 'pre-class-math-path',
+            course_id: 'pre-class-math-course',
+            subject_id: 'math-subject',
+            framework_id: null,
+            course_code: 'maths',
+            type: 'chapter',
+            path: [
+              {
+                lesson_id: 'math-assessment-1',
+                is_assessment: true,
+                isPlayed: true,
+              },
+            ],
+            completedPath: 0,
+          },
+        ],
+      },
+      type: 'chapter',
+      pathMode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
+    };
+    (Util.getCurrentStudent as jest.Mock).mockReturnValue({
+      id: 'stu-1',
+      learning_path: JSON.stringify(existingPath),
+    });
+    mockApi.getSubjectLessonsBySubjectId.mockResolvedValue({
+      id: 'math-assessment-doc-2',
+      lesson_id: 'math-assessment-2',
+    });
+
+    const { result } = renderHook(() => useLearningPath());
+    await act(async () => {
+      await result.current.getPath({
+        courses: [
+          {
+            id: 'pre-class-math-course',
+            subject_id: 'math-subject',
+            framework_id: null,
+            code: 'maths',
+          },
+          {
+            id: 'class-math-course',
+            subject_id: 'math-subject',
+            framework_id: null,
+            code: 'maths',
+          },
+        ],
+        mode: LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY,
+        classId: 'class-1',
+      });
+    });
+
+    const saved = mockApi.updateLearningPath.mock.calls[0][1];
+    const parsed = JSON.parse(saved) as {
+      courses: {
+        courseList: Array<{
+          course_id: string;
+          path: Array<{
+            lesson_id: string;
+            is_assessment: boolean;
+            isPlayed: boolean;
+          }>;
+        }>;
+      };
+    };
+    const classMathPath = parsed.courses.courseList.find(
+      (course) => course.course_id === 'class-math-course',
+    );
+
+    expect(classMathPath?.path).toEqual([
+      {
+        lesson_id: 'math-assessment-1',
+        is_assessment: true,
+        isPlayed: true,
+      },
+      {
+        lesson_id: 'math-assessment-2',
+        chapter_id: undefined,
+        source: SOURCE.INITIAL_ASSESSMENT,
+        is_assessment: true,
+        isPlayed: false,
+      },
+    ]);
+  });
+
   test('marks only PAL recommended lessons with PAL source', async () => {
     mockApi.isStudentPlayedPalLesson.mockResolvedValue(true);
     (palUtil.getPalLessonPathForCourse as jest.Mock).mockResolvedValue({

--- a/src/hooks/useLearningPath.ts
+++ b/src/hooks/useLearningPath.ts
@@ -159,7 +159,14 @@ const buildSameFrameworkAssessmentPath = (
   const activeIndex = assessmentPath.findIndex(
     (node) => node.isPlayed === false,
   );
-  if (activeIndex === -1) return null;
+  if (activeIndex === -1) {
+    const alreadyExists = assessmentPath.some(
+      (node) => node.lesson_id === activeLesson.lesson_id,
+    );
+    return alreadyExists
+      ? assessmentPath
+      : [...assessmentPath, { ...activeLesson }];
+  }
 
   return assessmentPath.map((node, index) =>
     index === activeIndex ? { ...activeLesson } : { ...node },
@@ -950,11 +957,10 @@ export const useLearningPath = (opts?: {
       userCourses.map((course) => [course.id, course]),
     );
 
-    const findSameFrameworkAssessmentPath = (
-      course: LearningPathCourseInput,
-    ) => {
+    const findSameAssessmentPath = (course: LearningPathCourseInput) => {
       const frameworkId = course.framework_id;
-      if (!frameworkId) return null;
+      const courseCode = normalizeCourseToken(course.code);
+      if (!frameworkId && (!course.subject_id || !courseCode)) return null;
 
       return (
         oldCourseList.find((coursePath) => {
@@ -966,14 +972,19 @@ export const useLearningPath = (opts?: {
             coursePath.course_code ??
               courseInputMap.get(coursePath.course_id)?.code,
           );
-          const courseCode = normalizeCourseToken(course.code);
 
-          return (
-            pathFrameworkId === frameworkId &&
-            coursePath.subject_id === (course.subject_id ?? null) &&
-            (!pathCourseCode || !courseCode || pathCourseCode === courseCode) &&
-            hasAssessmentProgress(coursePath.path)
-          );
+          if (!hasAssessmentProgress(coursePath.path)) return false;
+          if (coursePath.subject_id !== (course.subject_id ?? null)) {
+            return false;
+          }
+          if (pathCourseCode && courseCode && pathCourseCode !== courseCode) {
+            return false;
+          }
+          if (!frameworkId && (!pathCourseCode || !courseCode)) {
+            return false;
+          }
+
+          return frameworkId ? pathFrameworkId === frameworkId : true;
         }) ?? null
       );
     };
@@ -993,8 +1004,7 @@ export const useLearningPath = (opts?: {
         });
       } else {
         // ➕ New course → build fresh
-        const sameFrameworkAssessmentSource =
-          findSameFrameworkAssessmentPath(course);
+        const sameFrameworkAssessmentSource = findSameAssessmentPath(course);
         const activeLesson = await recommendNextLesson({
           student,
           course,

--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -166,6 +166,12 @@ const LidoPlayer: FC = () => {
   const courseDetail: TableTypes<'course'> = state?.course
     ? JSON.parse(state.course)
     : undefined;
+  const courseDetailWithPathFields = courseDetail as
+    | (Partial<TableTypes<'course'>> & {
+        course_id?: string | null;
+        course_code?: string | null;
+      })
+    | undefined;
   const chapterDetail: TableTypes<'chapter'> = state?.chapter
     ? JSON.parse(state.chapter)
     : undefined;
@@ -189,13 +195,27 @@ const LidoPlayer: FC = () => {
   const isExitingRef = useRef(false);
 
   const getAssessmentProgressKey = () => {
-    if (isAssessmentLesson && courseDetail?.subject_id) {
-      const courseCode = courseDetail.code?.trim().toLowerCase();
+    if (isAssessmentLesson && courseDetailWithPathFields?.subject_id) {
+      const courseCode = (
+        courseDetailWithPathFields.code ??
+        courseDetailWithPathFields.course_code
+      )
+        ?.trim()
+        .toLowerCase();
+      const courseId =
+        courseDetailWithPathFields.id ??
+        courseDetailWithPathFields.course_id ??
+        courseDocId;
       return courseCode
-        ? `subject:${courseDetail.subject_id}:course:${courseCode}`
-        : `subject:${courseDetail.subject_id}:course:${courseDetail.id}`;
+        ? `subject:${courseDetailWithPathFields.subject_id}:course:${courseCode}`
+        : `subject:${courseDetailWithPathFields.subject_id}:course:${courseId}`;
     }
-    return courseDetail?.id ?? courseDocId ?? '';
+    return (
+      courseDetailWithPathFields?.id ??
+      courseDetailWithPathFields?.course_id ??
+      courseDocId ??
+      ''
+    );
   };
 
   const resolveStudentContext = async (): Promise<{

--- a/src/pages/LidoPlayer.tsx
+++ b/src/pages/LidoPlayer.tsx
@@ -201,7 +201,7 @@ const LidoPlayer: FC = () => {
         courseDetailWithPathFields.course_code
       )
         ?.trim()
-        .toLowerCase();
+        ?.toLowerCase();
       const courseId =
         courseDetailWithPathFields.id ??
         courseDetailWithPathFields.course_id ??

--- a/src/utility/util.ts
+++ b/src/utility/util.ts
@@ -110,6 +110,7 @@ import {
   CoursePath,
   LessonNode,
   recommendNextLesson,
+  shouldUseAssessment,
 } from '../hooks/useLearningPath';
 import { runBackgroundWorkerTask } from '../workers/backgroundWorkerClient';
 import { store } from '../redux/store';
@@ -2952,7 +2953,9 @@ export class Util {
       }
 
       if (
-        storedPathwayMode === LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY &&
+        shouldUseAssessment(
+          storedPathwayMode || LEARNING_PATHWAY_MODE.DISABLED,
+        ) &&
         course.subject_id
       ) {
         const activeCourseCode = await getCourseCode(course);
@@ -2978,7 +2981,7 @@ export class Util {
                   ? 'framework'
                   : null,
             },
-            mode: storedPathwayMode,
+            mode: storedPathwayMode || LEARNING_PATHWAY_MODE.DISABLED,
             coursePath: peerCourse,
             skipAssessment: true,
           });
@@ -3092,7 +3095,9 @@ export class Util {
         nextAssessmentLesson: LessonNode | null,
       ) => {
         if (
-          storedPathwayMode !== LEARNING_PATHWAY_MODE.ASSESSMENT_ONLY ||
+          !shouldUseAssessment(
+            storedPathwayMode || LEARNING_PATHWAY_MODE.DISABLED,
+          ) ||
           !activeLesson ||
           !activeLesson.is_assessment ||
           (!course.subject_id && !course.framework_id)


### PR DESCRIPTION
- Add test to preserve played assessment nodes when syncing assessment-only courses without a pending node. 
- Update useLearningPath to (1) preserve existing assessment nodes when no active node is found, (2) rename and harden the same-assessment lookup to handle missing framework/course tokens and ensure subject/course-code checks, and (3) prefer existing assessment progress correctly. 
- Make LidoPlayer resilient to course payloads that use course_id/course_code (compute assessment progress key reliably). 
- Import and use shouldUseAssessment in util to correctly guard assessment logic and provide a safe fallback for stored pathway mode.