### PR TITLE
Fix mobile export save flow by writing Excel files directly to Downloads

### DIFF
--- a/android/app/src/main/java/org/chimple/bahama/PortPlugin.java
+++ b/android/app/src/main/java/org/chimple/bahama/PortPlugin.java
@@ -292,7 +292,63 @@ public void shareContentWithAndroidShare(PluginCall call) {
         if (fileName == null || fileName.trim().isEmpty()) {
               fileName = "ProcessedFile.xlsx";
        }
-       
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            byte[] fileBytes = Base64.decode(fileData, Base64.NO_WRAP);
+            ContentResolver resolver = getContext().getContentResolver();
+            String mimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+            ContentValues values = new ContentValues();
+            values.put(MediaStore.Downloads.DISPLAY_NAME, fileName);
+            values.put(MediaStore.Downloads.MIME_TYPE, mimeType);
+            values.put(
+                MediaStore.Downloads.RELATIVE_PATH,
+                Environment.DIRECTORY_DOWNLOADS + "/Chimple"
+            );
+            values.put(MediaStore.Downloads.IS_PENDING, 1);
+
+            Uri downloadsCollection = MediaStore.Downloads.getContentUri(
+                MediaStore.VOLUME_EXTERNAL_PRIMARY
+            );
+            Uri fileUri = null;
+
+            try {
+                fileUri = resolver.insert(downloadsCollection, values);
+                if (fileUri == null) {
+                    call.reject("Failed to create download record");
+                    return;
+                }
+
+                try (OutputStream outputStream = resolver.openOutputStream(fileUri)) {
+                    if (outputStream == null) {
+                        call.reject("Failed to open download output stream");
+                        return;
+                    }
+
+                    try (BufferedOutputStream bos = new BufferedOutputStream(outputStream)) {
+                        bos.write(fileBytes);
+                        bos.flush();
+                    }
+                }
+
+                ContentValues completed = new ContentValues();
+                completed.put(MediaStore.Downloads.IS_PENDING, 0);
+                resolver.update(fileUri, completed, null, null);
+
+                Toast.makeText(getContext(), "File saved to Downloads", Toast.LENGTH_SHORT).show();
+                JSObject result = new JSObject();
+                result.put("uri", fileUri.toString());
+                call.resolve(result);
+            } catch (Exception e) {
+                if (fileUri != null) {
+                    try {
+                        resolver.delete(fileUri, null, null);
+                    } catch (Exception ignored) {
+                    }
+                }
+                call.reject("Error saving file: " + e.getMessage());
+            }
+            return;
+        }
+
         fileDataStorage = fileData;
         Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);

--- a/android/app/src/main/java/org/chimple/bahama/PortPlugin.java
+++ b/android/app/src/main/java/org/chimple/bahama/PortPlugin.java
@@ -319,8 +319,7 @@ public void shareContentWithAndroidShare(PluginCall call) {
 
                 try (OutputStream outputStream = resolver.openOutputStream(fileUri)) {
                     if (outputStream == null) {
-                        call.reject("Failed to open download output stream");
-                        return;
+                        throw new IOException("Failed to open download output stream");
                     }
 
                     try (BufferedOutputStream bos = new BufferedOutputStream(outputStream)) {
@@ -333,7 +332,9 @@ public void shareContentWithAndroidShare(PluginCall call) {
                 completed.put(MediaStore.Downloads.IS_PENDING, 0);
                 resolver.update(fileUri, completed, null, null);
 
-                Toast.makeText(getContext(), "File saved to Downloads", Toast.LENGTH_SHORT).show();
+                getActivity().runOnUiThread(() ->
+                    Toast.makeText(getContext(), "File saved to Downloads", Toast.LENGTH_SHORT).show()
+                );
                 JSObject result = new JSObject();
                 result.put("uri", fileUri.toString());
                 call.resolve(result);


### PR DESCRIPTION
- Updated the Android export save flow in PortPlugin.saveProceesedXlsxFile(...).
- Added a direct-save path for Android 10+ using MediaStore.Downloads.
- Saved exported Excel files to Downloads/Chimple instead of opening the system file picker on newer Android devices.
- Kept the existing ACTION_CREATE_DOCUMENT flow unchanged for older Android versions.
- Avoided the app leaving to the external file manager on Android 10+, which helps prevent the blank screen/crash seen after export.
- Left the export file generation logic unchanged; only the native mobile save behavior was updated.
