### PR TITLE
fix: Removed school performance card & use 7-day teachers performance

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1091,7 +1091,6 @@
   "Patterns": "Patterns",
   "Penguin": "Penguin",
   "Performance (7 days)": "Performance (7 days)",
-  "Performance (15 days)": "Performance (15 days)",
   "Performance": "Performance",
   "Performing Well": "Performing Well",
   "Phone / Email": "Phone / Email",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1090,6 +1090,7 @@
   "Paste media drive link...": "Paste media drive link...",
   "Patterns": "Patterns",
   "Penguin": "Penguin",
+  "Performance (7 days)": "Performance (7 days)",
   "Performance (15 days)": "Performance (15 days)",
   "Performance": "Performance",
   "Performing Well": "Performing Well",

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolOverview.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolOverview.tsx
@@ -100,14 +100,6 @@ const SchoolOverview: React.FC<SchoolOverviewProps> = ({ data, isMobile }) => {
   ].filter((item) => item.value !== undefined && item.value !== null);
   const [programName, programType, model] = programDetailsItems;
 
-  //school performance
-  const activeStudents =
-    data.schoolStats?.active_student_percentage?.toFixed(2) ?? '0.00';
-  const avgWeekTime =
-    data.schoolStats?.avg_weekly_time_minutes?.toFixed(2) ?? '0.00';
-  const activeTeachers =
-    data.schoolStats?.active_teacher_percentage?.toFixed(2) ?? '0.00';
-
   const interactionItems = [
     { label: 'Number of Visits', value: data.interactionStats?.visits ?? 0 },
     {
@@ -194,12 +186,6 @@ const SchoolOverview: React.FC<SchoolOverviewProps> = ({ data, isMobile }) => {
     </InfoCard>
   );
 
-  const schoolPerformanceItems = [
-    { label: 'Active Students', value: `${activeStudents}%` },
-    { label: 'Avg week time in mins', value: `${avgWeekTime} mins` },
-    { label: 'Active Teachers', value: `${activeTeachers}%` },
-  ].filter((item) => item.value !== undefined && item.value !== null);
-
   const history = useHistory();
   let keyContacts: Array<any> = [];
   const rawKeyContacts = data?.schoolData?.key_contacts;
@@ -229,36 +215,6 @@ const SchoolOverview: React.FC<SchoolOverviewProps> = ({ data, isMobile }) => {
       {isMobile ? (
         <Box className="column-container">
           <InteractionMetricsSection />
-          <InfoCard
-            title={t('School Performance')}
-            className="performance-card"
-          >
-            <Box className="info-card-items">
-              {schoolPerformanceItems.map((item, idx) => (
-                <Box
-                  key={idx}
-                  display="flex"
-                  justifyContent="space-between"
-                  alignItems="center"
-                  mb={1}
-                >
-                  <Typography variant="subtitle2">{t(item.label)}</Typography>
-                  <Typography variant="body1">{item.value}</Typography>
-                </Box>
-              ))}
-            </Box>
-            {!isExternalUser && (
-              <Button
-                fullWidth
-                size="small"
-                className="full-width-button"
-                variant="outlined"
-                sx={{ mt: 2, textTransform: 'none' }}
-              >
-                {t('View Detailed Analytics')}
-              </Button>
-            )}
-          </InfoCard>
           <InfoCard
             title={t('Key Contacts')}
             children={
@@ -351,42 +307,10 @@ const SchoolOverview: React.FC<SchoolOverviewProps> = ({ data, isMobile }) => {
         </Box>
       ) : (
         <Grid container spacing={2}>
-          <Grid size={{ xs: 12, md: 8 }}>
+          <Grid size={{ xs: 12, md: 12 }}>
             <Box className="column-container">
               <InteractionMetricsSection />
             </Box>
-          </Grid>
-          <Grid size={{ xs: 12, md: 4 }}>
-            <InfoCard
-              title={t('School Performance')}
-              className="performance-card"
-            >
-              <Box className="info-card-items">
-                {schoolPerformanceItems.map((item, idx) => (
-                  <Box
-                    key={idx}
-                    display="flex"
-                    justifyContent="space-between"
-                    alignItems="center"
-                    mb={1}
-                  >
-                    <Typography variant="subtitle2">{t(item.label)}</Typography>
-                    <Typography variant="body1">{item.value}</Typography>
-                  </Box>
-                ))}
-              </Box>
-              {!isExternalUser && (
-                <Button
-                  fullWidth
-                  size="small"
-                  className="full-width-button"
-                  variant="outlined"
-                  sx={{ mt: 2, textTransform: 'none' }}
-                >
-                  {t('View Detailed Analytics')}
-                </Button>
-              )}
-            </InfoCard>
           </Grid>
 
           <Grid size={{ xs: 12, md: 12 }}>

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolTeachers.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolTeachers.tsx
@@ -1302,7 +1302,7 @@ const SchoolTeachers: React.FC<SchoolTeachersProps> = ({
     },
     {
       key: 'performance',
-      label: t('Performance (15 days)'),
+      label: t('Performance (7 days)'),
       align: 'center',
       width: 120,
       sortable: false,

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -14780,7 +14780,7 @@ export class SupabaseApi implements ServiceApi {
   ): Promise<number | null> {
     if (!this.supabase) return null;
 
-    const FIFTEEN_DAYS_AGO = new Date(
+    const SEVEN_DAYS_AGO = new Date(
       Date.now() - 7 * 24 * 60 * 60 * 1000,
     ).toISOString();
 
@@ -14790,7 +14790,7 @@ export class SupabaseApi implements ServiceApi {
       .eq('created_by', teacherId)
       .eq('class_id', classId)
       .eq('is_deleted', false)
-      .gte('created_at', FIFTEEN_DAYS_AGO);
+      .gte('created_at', SEVEN_DAYS_AGO);
 
     if (error) {
       logger.error('Error fetching assignments:', error);

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -14781,7 +14781,7 @@ export class SupabaseApi implements ServiceApi {
     if (!this.supabase) return null;
 
     const FIFTEEN_DAYS_AGO = new Date(
-      Date.now() - 15 * 24 * 60 * 60 * 1000,
+      Date.now() - 7 * 24 * 60 * 60 * 1000,
     ).toISOString();
 
     const { data, error } = await this.supabase


### PR DESCRIPTION
- Remove the School Performance InfoCard and its computed metrics from SchoolOverview and expand the interaction section to full width. 
- Update the teachers table label from 'Performance (15 days)' to 'Performance (7 days)' and change the Supabase API timeframe constant from 15 to 7 days so frontend and backend match.