### PR TITLE
Added campaign assignment tab with filtering

### DIFF
--- a/src/ops-console/components/campaignsOverview/CampaignsOverview.tsx
+++ b/src/ops-console/components/campaignsOverview/CampaignsOverview.tsx
@@ -9,7 +9,7 @@ import {
 } from './CampaignsOverviewLogic';
 import CampaignsOverviewHeaderBar from './CampaignsOverviewHeaderBar';
 import CampaignsOverviewWidgets from './CampaignsOverviewWidgets';
-// import CampaignMessages from '../campaignMessages/CampaignMessages';
+import CampaignAssignmentTab from '../../pages/CampaignAssignmentTab';
 import './CampaignsOverview.css';
 import './CampaignsOverviewMobile.css';
 
@@ -18,6 +18,7 @@ export interface CampaignsOverviewProps {
   breadcrumb?: readonly string[];
   tabs?: readonly string[];
   activeTab?: string;
+  campaignId?: string;
   campaignOverviewData?: CampaignsOverviewApiResponse;
   onBackClick?: () => void;
   onBreadcrumbClick?: (item: string, index: number) => void;
@@ -29,6 +30,7 @@ const CampaignsOverview: React.FC<CampaignsOverviewProps> = ({
   breadcrumb = DEFAULT_CAMPAIGNS_OVERVIEW_BREADCRUMB,
   tabs = DEFAULT_CAMPAIGNS_OVERVIEW_TABS,
   activeTab = DEFAULT_CAMPAIGNS_OVERVIEW_TABS[0],
+  campaignId,
   campaignOverviewData,
   onBackClick,
   onBreadcrumbClick,
@@ -38,6 +40,10 @@ const CampaignsOverview: React.FC<CampaignsOverviewProps> = ({
   const [selectedTab, setSelectedTab] = useState(activeTab);
   const campaignViewModel =
     buildCampaignsOverviewViewModel(campaignOverviewData);
+  const resolvedCampaignId =
+    campaignId ??
+    campaignOverviewData?.data?.campaignId ??
+    campaignOverviewData?.data?.dashboardMetrics?.campaign_id;
 
   useEffect(() => {
     document.body.classList.add('campaigns-overview-active');
@@ -53,7 +59,8 @@ const CampaignsOverview: React.FC<CampaignsOverviewProps> = ({
 
   const shouldShowOverviewWidgets =
     selectedTab === DEFAULT_CAMPAIGNS_OVERVIEW_TABS[0];
-  const shouldShowMessages = selectedTab === DEFAULT_CAMPAIGNS_OVERVIEW_TABS[2];
+  const shouldShowAssignments =
+    selectedTab === DEFAULT_CAMPAIGNS_OVERVIEW_TABS[1];
   const handleBackClick = (): void => {
     if (onBackClick) {
       onBackClick();
@@ -87,9 +94,9 @@ const CampaignsOverview: React.FC<CampaignsOverviewProps> = ({
           cancellationDetails={campaignViewModel.cancellationDetails}
         />
       )}
-      {/* {shouldShowMessages && (
-        <CampaignMessages data={campaignOverviewData?.data} />
-      )} */}
+      {shouldShowAssignments && resolvedCampaignId && (
+        <CampaignAssignmentTab campaignId={resolvedCampaignId} />
+      )}
     </main>
   );
 };

--- a/src/ops-console/pages/CampaignAssignmentTab.css
+++ b/src/ops-console/pages/CampaignAssignmentTab.css
@@ -1,0 +1,193 @@
+.campaign-assignment-tab {
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 0;
+  box-sizing: border-box;
+  /* padding: 1.5rem; */
+  /* gap: 1.5rem; */
+  overflow: hidden;
+}
+
+.campaign-assignment-filterBar {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #eaecf0;
+  border-radius: 0.5rem;
+  box-sizing: border-box;
+}
+
+.campaign-assignment-filterRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.campaign-assignment-actionsGroup {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.campaign-assignment-filter {
+  min-width: 0;
+}
+
+.campaign-assignment-filterLabel.MuiTypography-root {
+  color: #667085 !important;
+  font-size: 0.875rem;
+  font-weight: 600 !important;
+  line-height: 1.25rem;
+  /* margin-bottom: 0.4rem !important; */
+  margin-bottom: 0 !important;
+  white-space: nowrap;
+}
+
+/* .campaign-assignment-filterField {
+  min-width: 8.25rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0;
+} */
+
+.campaign-assignment-filterField {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.campaign-assignment-select.MuiInputBase-root {
+  width: 140px;
+  min-width: 140px;
+  min-height: 2.125rem;
+  border-radius: 0.4375rem;
+  background-color: #ffffff;
+  min-width: 7.5rem;
+}
+
+.campaign-assignment-select .MuiSelect-select {
+  padding-top: 0.4rem;
+  padding-bottom: 0.4rem;
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+  min-height: 1.25rem;
+}
+
+.campaign-assignment-menu {
+  border-radius: 0.75rem;
+  box-shadow: 0 0.75rem 1.5rem rgba(16, 24, 40, 0.14);
+  max-height: 22rem;
+}
+
+.campaign-assignment-menu .MuiMenuItem-root {
+  min-height: 2.5rem;
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+}
+
+.campaign-assignment-filterField .campaign-assignment-filterLabel {
+  white-space: nowrap;
+}
+
+.campaign-assignment-table-container {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid #eaecf0;
+  border-radius: 0.5rem;
+  margin-top: 13px;
+}
+
+.campaign-assignment-table-container .data-tablebody-container {
+  border-radius: 0.5rem;
+}
+
+.campaign-assignment-table-container table {
+  min-width: 100%;
+}
+
+.campaign-assignment-table-container th,
+.campaign-assignment-table-container td {
+  white-space: nowrap;
+}
+
+.campaign-assignment-table-container .data-tablebody-head-cell {
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  font-size: 0.6875rem;
+}
+
+.campaign-assignment-table-container .data-tablebody-cell {
+  font-size: 0.8125rem;
+}
+
+.campaign-assignment-emptyState {
+  min-height: 15rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.campaign-assignment-emptyStateTitle.MuiTypography-root {
+  color: #1d2939 !important;
+  font-weight: 600 !important;
+  font-size: 1.125rem;
+  margin-bottom: 0.5rem !important;
+}
+
+.campaign-assignment-emptyStateMessage.MuiTypography-root {
+  color: #475467 !important;
+  font-size: 0.875rem !important;
+  line-height: 1.5;
+  max-width: 24rem;
+}
+
+.campaign-assignment-footer {
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 0.25rem 0 0;
+  background: #ffffff;
+}
+
+@media (max-width: 768px) {
+  .campaign-assignment-tab {
+    padding: 1rem;
+    gap: 1rem;
+  }
+
+  .campaign-assignment-filterBar {
+    padding: 0.5rem 0.75rem;
+  }
+
+  .campaign-assignment-filterRow {
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .campaign-assignment-filterField {
+    min-width: 7rem;
+    width: auto;
+    align-items: flex-start;
+  }
+
+  .campaign-assignment-select.MuiInputBase-root {
+    min-width: 7rem;
+  }
+
+  .campaign-assignment-table-container table {
+    min-width: 40rem;
+  }
+}

--- a/src/ops-console/pages/CampaignAssignmentTab.test.tsx
+++ b/src/ops-console/pages/CampaignAssignmentTab.test.tsx
@@ -1,0 +1,342 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import CampaignAssignmentTab from './CampaignAssignmentTab';
+import { ServiceConfig } from '../../services/ServiceConfig';
+
+jest.mock('i18next', () => ({
+  t: (key: string) => key,
+}));
+
+jest.mock('../../utility/logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('../../services/ServiceConfig', () => ({
+  ServiceConfig: {
+    getI: jest.fn(),
+  },
+}));
+
+jest.mock('../components/DataTableBody', () => ({
+  __esModule: true,
+  default: ({
+    rows,
+  }: {
+    rows: Array<{ lessonName?: string; assignmentDate?: string }>;
+  }) => (
+    <div data-testid="data-table">
+      {rows.map((row, index) => (
+        <div key={index}>
+          <span>{row.assignmentDate}</span>
+          <span>{row.lessonName}</span>
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock('../components/DataTablePagination', () => ({
+  __esModule: true,
+  default: ({
+    page,
+    pageCount,
+    onPageChange,
+  }: {
+    page: number;
+    pageCount: number;
+    onPageChange: (page: number) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="pagination"
+      onClick={() => onPageChange(page + 1)}
+    >
+      page:{page} count:{pageCount}
+    </button>
+  ),
+}));
+
+describe('CampaignAssignmentTab', () => {
+  const api = {
+    getAllGrades: jest.fn(),
+    getCampaignSubjectsByCampaignId: jest.fn(),
+    getCampaignAssignments: jest.fn(),
+  };
+
+  const defaultGrades = [
+    { id: '1', name: 'Grade 1' },
+    { id: '2', name: 'Grade 2' },
+  ];
+
+  const defaultSubjects = [
+    { id: '11', name: 'Math' },
+    { id: '12', name: 'Science' },
+  ];
+
+  const defaultAssignments = [
+    {
+      assignmentDate: '2026-05-25',
+      gradeName: 'Grade 1',
+      subjectName: 'Math',
+      lessonName: 'Lesson Alpha',
+    },
+  ];
+
+  const renderTab = (campaignId?: string) =>
+    render(<CampaignAssignmentTab campaignId={campaignId} />);
+
+  const primeApi = ({
+    grades = defaultGrades,
+    subjects = defaultSubjects,
+    assignments = defaultAssignments,
+    total = 1,
+    gradeError = null,
+    subjectError = null,
+    assignmentError = null,
+  }: {
+    grades?: Array<{ id: string; name: string }>;
+    subjects?: Array<{ id: string; name: string }>;
+    assignments?: Array<{
+      assignmentDate: string;
+      gradeName: string;
+      subjectName: string;
+      lessonName: string;
+    }>;
+    total?: number;
+    gradeError?: Error | null;
+    subjectError?: Error | null;
+    assignmentError?: Error | null;
+  } = {}) => {
+    api.getAllGrades.mockImplementation(() =>
+      gradeError ? Promise.reject(gradeError) : Promise.resolve(grades),
+    );
+    api.getCampaignSubjectsByCampaignId.mockImplementation(() =>
+      subjectError ? Promise.reject(subjectError) : Promise.resolve(subjects),
+    );
+    api.getCampaignAssignments.mockImplementation(() =>
+      assignmentError
+        ? Promise.reject(assignmentError)
+        : Promise.resolve({ assignments, total }),
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (ServiceConfig.getI as jest.Mock).mockReturnValue({
+      apiHandler: api,
+    });
+  });
+
+  it('loads filters and assignments for the provided campaign id', async () => {
+    primeApi();
+
+    renderTab('campaign-1');
+
+    await waitFor(() =>
+      expect(api.getCampaignSubjectsByCampaignId).toHaveBeenCalledWith(
+        'campaign-1',
+      ),
+    );
+    await waitFor(() =>
+      expect(api.getCampaignAssignments).toHaveBeenCalledWith('campaign-1', {
+        page: 1,
+        pageSize: 20,
+      }),
+    );
+
+    expect(api.getAllGrades).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('data-table')).toBeInTheDocument();
+    expect(screen.getByText('Lesson Alpha')).toBeInTheDocument();
+  });
+
+  it('renders the fetched assignment date text', async () => {
+    primeApi();
+
+    renderTab('campaign-1');
+
+    expect(await screen.findByText('2026-05-25')).toBeInTheDocument();
+  });
+
+  it('shows empty state when assignments are empty', async () => {
+    primeApi({ assignments: [], total: 0 });
+
+    renderTab('campaign-1');
+
+    expect(await screen.findByText('No Assignments Found')).toBeInTheDocument();
+  });
+
+  it('does not call APIs when campaign id is missing', async () => {
+    renderTab();
+
+    expect(await screen.findByText('No Assignments Found')).toBeInTheDocument();
+    expect(api.getAllGrades).not.toHaveBeenCalled();
+    expect(api.getCampaignSubjectsByCampaignId).not.toHaveBeenCalled();
+    expect(api.getCampaignAssignments).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the empty state when assignment loading fails', async () => {
+    primeApi({ assignmentError: new Error('assignment failed'), total: 0 });
+
+    renderTab('campaign-1');
+
+    expect(await screen.findByText('No Assignments Found')).toBeInTheDocument();
+    expect(api.getCampaignAssignments).toHaveBeenCalled();
+  });
+
+  it('still loads assignments when filter loading fails', async () => {
+    primeApi({ gradeError: new Error('grade failed') });
+
+    renderTab('campaign-1');
+
+    await waitFor(() =>
+      expect(api.getCampaignAssignments).toHaveBeenCalledWith('campaign-1', {
+        page: 1,
+        pageSize: 20,
+      }),
+    );
+  });
+
+  it('refetches when the campaign id changes', async () => {
+    primeApi();
+
+    const { rerender } = render(
+      <CampaignAssignmentTab campaignId="campaign-1" />,
+    );
+
+    await waitFor(() =>
+      expect(api.getCampaignAssignments).toHaveBeenCalledWith('campaign-1', {
+        page: 1,
+        pageSize: 20,
+      }),
+    );
+
+    rerender(<CampaignAssignmentTab campaignId="campaign-2" />);
+
+    await waitFor(() =>
+      expect(api.getCampaignAssignments).toHaveBeenLastCalledWith(
+        'campaign-2',
+        {
+          page: 1,
+          pageSize: 20,
+        },
+      ),
+    );
+  });
+
+  it('advances to page 2 when pagination is clicked once', async () => {
+    primeApi({ total: 41 });
+
+    renderTab('campaign-1');
+
+    await screen.findByTestId('pagination');
+    fireEvent.click(screen.getByTestId('pagination'));
+
+    await waitFor(() =>
+      expect(api.getCampaignAssignments).toHaveBeenLastCalledWith(
+        'campaign-1',
+        {
+          page: 2,
+          pageSize: 20,
+        },
+      ),
+    );
+  });
+
+  it('advances to page 3 when pagination is clicked twice', async () => {
+    primeApi({ total: 41 });
+
+    renderTab('campaign-1');
+
+    await screen.findByTestId('pagination');
+    fireEvent.click(screen.getByTestId('pagination'));
+    await waitFor(() =>
+      expect(screen.getByTestId('pagination')).toHaveTextContent('page:2'),
+    );
+    fireEvent.click(screen.getByTestId('pagination'));
+
+    await waitFor(() =>
+      expect(api.getCampaignAssignments).toHaveBeenLastCalledWith(
+        'campaign-1',
+        {
+          page: 3,
+          pageSize: 20,
+        },
+      ),
+    );
+  });
+
+  it('shows the loading spinner while requests are pending', () => {
+    api.getAllGrades.mockImplementation(() => new Promise(() => undefined));
+    api.getCampaignSubjectsByCampaignId.mockImplementation(
+      () => new Promise(() => undefined),
+    );
+    api.getCampaignAssignments.mockImplementation(
+      () => new Promise(() => undefined),
+    );
+
+    renderTab('campaign-1');
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('renders the default grade filter value', async () => {
+    primeApi();
+
+    renderTab('campaign-1');
+
+    expect(await screen.findByText('All grades')).toBeInTheDocument();
+  });
+
+  it('renders the default subject filter value', async () => {
+    primeApi();
+
+    renderTab('campaign-1');
+
+    expect(await screen.findByText('All subjects')).toBeInTheDocument();
+  });
+
+  it('renders both filter comboboxes', async () => {
+    primeApi();
+
+    renderTab('campaign-1');
+
+    expect(await screen.findAllByRole('combobox')).toHaveLength(2);
+  });
+
+  it('keeps the grade and subject labels visible after load', async () => {
+    primeApi();
+
+    renderTab('campaign-1');
+
+    expect(await screen.findByText('Grade')).toBeInTheDocument();
+    expect(await screen.findByText('Subject')).toBeInTheDocument();
+  });
+
+  it('keeps the filter bar visible alongside the assignments table', async () => {
+    primeApi();
+
+    renderTab('campaign-1');
+
+    expect(await screen.findByTestId('data-table')).toBeInTheDocument();
+    expect(await screen.findByTestId('pagination')).toBeInTheDocument();
+  });
+
+  it.each([
+    [0, 'page:1 count:1'],
+    [1, 'page:1 count:1'],
+    [20, 'page:1 count:1'],
+    [21, 'page:1 count:2'],
+    [41, 'page:1 count:3'],
+  ])('calculates pagination for total %s', async (total, expected) => {
+    primeApi({ total, assignments: defaultAssignments });
+
+    renderTab('campaign-1');
+
+    expect(await screen.findByTestId('pagination')).toHaveTextContent(
+      expected as string,
+    );
+  });
+});

--- a/src/ops-console/pages/CampaignAssignmentTab.tsx
+++ b/src/ops-console/pages/CampaignAssignmentTab.tsx
@@ -25,7 +25,7 @@ import type {
 const ROWS_PER_PAGE = 20;
 
 interface CampaignAssignmentTabProps {
-  campaignId: string;
+  campaignId?: string;
 }
 
 const CampaignAssignmentTab: React.FC<CampaignAssignmentTabProps> = ({
@@ -51,6 +51,13 @@ const CampaignAssignmentTab: React.FC<CampaignAssignmentTabProps> = ({
     let cancelled = false;
 
     async function loadFilters() {
+      if (!campaignId) {
+        setGrades([]);
+        setSubjects([]);
+        setIsLoadingFilters(false);
+        return;
+      }
+
       setIsLoadingFilters(true);
       try {
         const [nextGrades, nextSubjects] = await Promise.all([
@@ -90,6 +97,13 @@ const CampaignAssignmentTab: React.FC<CampaignAssignmentTabProps> = ({
     let cancelled = false;
 
     async function loadAssignments() {
+      if (!campaignId) {
+        setAssignments([]);
+        setTotal(0);
+        setIsLoadingAssignments(false);
+        return;
+      }
+
       setIsLoadingAssignments(true);
       try {
         const response = await api.getCampaignAssignments(campaignId, {

--- a/src/ops-console/pages/CampaignAssignmentTab.tsx
+++ b/src/ops-console/pages/CampaignAssignmentTab.tsx
@@ -1,0 +1,325 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Checkbox,
+  CircularProgress,
+  FormControl,
+  ListItemText,
+  MenuItem,
+  OutlinedInput,
+  Select,
+  type SelectChangeEvent,
+  Typography,
+} from '@mui/material';
+import { t } from 'i18next';
+import { ServiceConfig } from '../../services/ServiceConfig';
+import logger from '../../utility/logger';
+import './CampaignAssignmentTab.css';
+import DataTableBody, { type Column } from '../components/DataTableBody';
+import DataTablePagination from '../components/DataTablePagination';
+import type {
+  CampaignAssignmentSummaryRow,
+  CampaignOption,
+} from '../../services/api/ServiceApi';
+
+const ROWS_PER_PAGE = 20;
+
+interface CampaignAssignmentTabProps {
+  campaignId: string;
+}
+
+const CampaignAssignmentTab: React.FC<CampaignAssignmentTabProps> = ({
+  campaignId,
+}) => {
+  const api = ServiceConfig.getI().apiHandler;
+
+  const [grades, setGrades] = useState<CampaignOption[]>([]);
+  const [subjects, setSubjects] = useState<CampaignOption[]>([]);
+  const [assignments, setAssignments] = useState<
+    CampaignAssignmentSummaryRow[]
+  >([]);
+
+  const [selectedGrades, setSelectedGrades] = useState<string[]>([]);
+  const [selectedSubjects, setSelectedSubjects] = useState<string[]>([]);
+
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [isLoadingFilters, setIsLoadingFilters] = useState(true);
+  const [isLoadingAssignments, setIsLoadingAssignments] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadFilters() {
+      setIsLoadingFilters(true);
+      try {
+        const [nextGrades, nextSubjects] = await Promise.all([
+          api.getAllGrades(),
+          api.getCampaignSubjectsByCampaignId(campaignId),
+        ]);
+
+        if (cancelled) return;
+
+        setGrades(
+          nextGrades.map((grade) => ({
+            id: String(grade.id),
+            name: String(grade.name),
+          })),
+        );
+        setSubjects(
+          nextSubjects.map((subject) => ({
+            id: String(subject.id),
+            name: String(subject.name),
+          })),
+        );
+      } catch (err) {
+        logger.error('Failed to load campaign assignment filters:', err);
+      } finally {
+        if (!cancelled) setIsLoadingFilters(false);
+      }
+    }
+
+    loadFilters();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [api, campaignId]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadAssignments() {
+      setIsLoadingAssignments(true);
+      try {
+        const response = await api.getCampaignAssignments(campaignId, {
+          page,
+          pageSize: ROWS_PER_PAGE,
+          ...(selectedGrades.length ? { gradeIds: selectedGrades } : {}),
+          ...(selectedSubjects.length ? { subjectIds: selectedSubjects } : {}),
+        });
+
+        if (cancelled) return;
+
+        setAssignments(response.assignments ?? []);
+        setTotal(response.total ?? 0);
+      } catch (err) {
+        logger.error('Failed to load campaign assignments:', err);
+        if (!cancelled) {
+          setAssignments([]);
+          setTotal(0);
+        }
+      } finally {
+        if (!cancelled) setIsLoadingAssignments(false);
+      }
+    }
+
+    loadAssignments();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [api, campaignId, page, selectedGrades, selectedSubjects]);
+
+  const pageCount = Math.max(1, Math.ceil(total / ROWS_PER_PAGE));
+  const isLoading = isLoadingFilters || isLoadingAssignments;
+
+  useEffect(() => {
+    if (page > pageCount) {
+      setPage(pageCount);
+    }
+  }, [page, pageCount]);
+
+  const gradeNameById = useMemo(
+    () => new Map(grades.map((grade) => [grade.id, grade.name])),
+    [grades],
+  );
+
+  const subjectNameById = useMemo(
+    () => new Map(subjects.map((subject) => [subject.id, subject.name])),
+    [subjects],
+  );
+
+  const columns = useMemo<Column<CampaignAssignmentSummaryRow>[]>(
+    () => [
+      {
+        key: 'assignmentDate',
+        label: t('Date'),
+        sortable: false,
+        width: 210,
+        render: (row) =>
+          new Date(row.assignmentDate).toLocaleDateString(undefined, {
+            weekday: 'long',
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          }),
+      },
+      {
+        key: 'gradeName',
+        label: t('Grade'),
+        sortable: false,
+        width: 140,
+      },
+      {
+        key: 'subjectName',
+        label: t('Subject'),
+        sortable: false,
+        width: 180,
+      },
+      {
+        key: 'lessonName',
+        label: t('Lesson Name'),
+        sortable: false,
+      },
+    ],
+    [],
+  );
+
+  const selectedGradeLabel = (id: string) => gradeNameById.get(id) ?? id;
+  const selectedSubjectLabel = (id: string) => subjectNameById.get(id) ?? id;
+
+  const handleMultiSelectChange =
+    (setter: React.Dispatch<React.SetStateAction<string[]>>) =>
+    (event: SelectChangeEvent<string[]>) => {
+      const value = event.target.value;
+      setter(typeof value === 'string' ? value.split(',') : value);
+      setPage(1);
+    };
+
+  return (
+    <div className="campaign-assignment-tab">
+      <Box className="campaign-assignment-filterBar">
+        <Box className="campaign-assignment-filterRow">
+          <Box className="campaign-assignment-filterField">
+            <Typography
+              variant="caption"
+              className="campaign-assignment-filterLabel"
+            >
+              {t('Grade')}
+            </Typography>
+
+            <FormControl
+              size="small"
+              className="campaign-assignment-filter"
+              disabled={isLoadingFilters}
+            >
+              <Select
+                multiple
+                displayEmpty
+                value={selectedGrades}
+                onChange={handleMultiSelectChange(setSelectedGrades)}
+                input={<OutlinedInput />}
+                renderValue={(selected) => {
+                  const values = selected as string[];
+                  if (values.length === 0) return t('All grades');
+                  return values.map(selectedGradeLabel).join(', ');
+                }}
+                className="campaign-assignment-select"
+                MenuProps={{
+                  PaperProps: { className: 'campaign-assignment-menu' },
+                }}
+              >
+                {grades.map((grade) => (
+                  <MenuItem key={grade.id} value={grade.id}>
+                    <Checkbox checked={selectedGrades.includes(grade.id)} />
+                    <ListItemText primary={grade.name} />
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+
+          <Box className="campaign-assignment-filterField">
+            <Typography
+              variant="caption"
+              className="campaign-assignment-filterLabel"
+            >
+              {t('Subject')}
+            </Typography>
+            <FormControl
+              size="small"
+              className="campaign-assignment-filter campaign-assignment-filterField"
+              disabled={isLoadingFilters}
+            >
+              <Select
+                multiple
+                displayEmpty
+                value={selectedSubjects}
+                onChange={handleMultiSelectChange(setSelectedSubjects)}
+                input={<OutlinedInput />}
+                renderValue={(selected) => {
+                  const values = selected as string[];
+                  if (values.length === 0) return t('All subjects');
+                  return values.map(selectedSubjectLabel).join(', ');
+                }}
+                className="campaign-assignment-select"
+                MenuProps={{
+                  PaperProps: { className: 'campaign-assignment-menu' },
+                }}
+              >
+                {subjects.map((subject) => (
+                  <MenuItem key={subject.id} value={subject.id}>
+                    <Checkbox checked={selectedSubjects.includes(subject.id)} />
+                    <ListItemText primary={subject.name} />
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+        </Box>
+      </Box>
+
+      <div className="campaign-assignment-table-container">
+        {isLoading && (
+          <Box
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            minHeight={240}
+            width="100%"
+          >
+            <CircularProgress size={28} />
+          </Box>
+        )}
+
+        {!isLoading && assignments.length > 0 && (
+          <DataTableBody
+            columns={columns}
+            rows={assignments}
+            orderBy="assignmentDate"
+            order="asc"
+            onSort={() => {}}
+            loading={false}
+            tableMinWidth={820}
+            tableWidth="100%"
+            headerNoEllipsis
+          />
+        )}
+
+        {!isLoading && assignments.length === 0 && (
+          <Box className="campaign-assignment-emptyState">
+            <Typography
+              variant="h6"
+              className="campaign-assignment-emptyStateTitle"
+            >
+              {t('No Assignments Found')}
+            </Typography>
+          </Box>
+        )}
+      </div>
+
+      {!isLoading && assignments.length > 0 && (
+        <div className="campaign-assignment-footer">
+          <DataTablePagination
+            page={page}
+            pageCount={pageCount}
+            onPageChange={setPage}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CampaignAssignmentTab;

--- a/src/services/api/ApiHandler.ts
+++ b/src/services/api/ApiHandler.ts
@@ -19,6 +19,9 @@ import {
   OpsStudentPerformanceBandsParams,
   SchoolProgramAccessResponse,
   ServiceApi,
+  CampaignAssignmentsResponse,
+  CampaignOption,
+  CampaignAssignmentFilters,
 } from './ServiceApi';
 import {
   SOURCE,
@@ -1618,6 +1621,19 @@ export class ApiHandler implements ServiceApi {
     params: CampaignAssignmentOptionsParams,
   ): Promise<CampaignAssignmentOptions> {
     return await this.s.getCampaignAssignmentOptions(params);
+  }
+
+  public async getCampaignAssignments(
+    campaignId: string,
+    filters: CampaignAssignmentFilters,
+  ): Promise<CampaignAssignmentsResponse> {
+    return await this.s.getCampaignAssignments(campaignId, filters);
+  }
+
+  public async getCampaignSubjectsByCampaignId(
+    campaignId: string,
+  ): Promise<CampaignOption[]> {
+    return await this.s.getCampaignSubjectsByCampaignId(campaignId);
   }
 
   public async getUniqueGeoData(): Promise<{

--- a/src/services/api/ServiceApi.ts
+++ b/src/services/api/ServiceApi.ts
@@ -373,6 +373,29 @@ export type CampaignAssignmentOptions = {
   grades: CampaignAssignmentGradeOption[];
 };
 
+export type CampaignAssignmentFilters = {
+  page: number;
+  pageSize: number;
+  gradeIds?: string[];
+  subjectIds?: string[];
+};
+
+export type CampaignAssignmentSummaryRow = {
+  assignmentId: string;
+  assignmentDate: string;
+  gradeId: string;
+  gradeName: string;
+  subjectId: string;
+  subjectName: string;
+  lessonId: string;
+  lessonName: string;
+};
+
+export type CampaignAssignmentsResponse = {
+  assignments: CampaignAssignmentSummaryRow[];
+  total: number;
+};
+
 export interface ServiceApi {
   /**
    * Creates a AutoUser for at_school and hybrid school models when a new school is created
@@ -2359,6 +2382,26 @@ export interface ServiceApi {
   getCampaignAssignmentOptions(
     params: CampaignAssignmentOptionsParams,
   ): Promise<CampaignAssignmentOptions>;
+
+  /**
+   * Fetches campaign assignments for a given campaign ID, with optional filters for school, grade, subject, chapter, and lesson.
+   * @param {string} campaignId - The ID of the campaign to fetch assignments for.
+   * @param {CampaignAssignmentFilters} filters - Optional filters to narrow down the assignments.
+   * @returns {Promise<CampaignAssignmentsResponse>} - A promise resolving to the campaign assignments data.
+   */
+  getCampaignAssignments(
+    campaignId: string,
+    filters: CampaignAssignmentFilters,
+  ): Promise<CampaignAssignmentsResponse>;
+
+  /**
+   * Fetches the unique subjects used by a campaign's assignments.
+   * @param {string} campaignId - The campaign ID.
+   * @returns {Promise<CampaignOption[]>} - Unique subjects for that campaign.
+   */
+  getCampaignSubjectsByCampaignId(
+    campaignId: string,
+  ): Promise<CampaignOption[]>;
 
   /**
    * Get unique geo data

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -119,6 +119,9 @@ import {
   OpsStudentPerformanceBandsParams,
   SchoolProgramAccessResponse,
   ServiceApi,
+  CampaignAssignmentsResponse,
+  CampaignOption,
+  CampaignAssignmentFilters,
 } from './ServiceApi';
 import { SupabaseApi } from './SupabaseApi';
 import { isAssessmentBatchClosed } from '../assessment/assessmentBatchStatus.service';
@@ -8031,6 +8034,19 @@ order by
     params: CampaignAssignmentOptionsParams,
   ): Promise<CampaignAssignmentOptions> {
     return await this._serverApi.getCampaignAssignmentOptions(params);
+  }
+
+  async getCampaignAssignments(
+    campaignId: string,
+    filters: CampaignAssignmentFilters,
+  ): Promise<CampaignAssignmentsResponse> {
+    return await this._serverApi.getCampaignAssignments(campaignId, filters);
+  }
+
+  async getCampaignSubjectsByCampaignId(
+    campaignId: string,
+  ): Promise<CampaignOption[]> {
+    return await this._serverApi.getCampaignSubjectsByCampaignId(campaignId);
   }
 
   async getUniqueGeoData(): Promise<{

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -90,6 +90,10 @@ import {
   SchoolProgramAccessRow,
   ServiceApi,
   StudentLeaderboardInfo,
+  CampaignAssignmentsResponse,
+  CampaignAssignmentSummaryRow,
+  CampaignAssignmentFilters,
+  CampaignOption,
 } from './ServiceApi';
 import { Database, Json } from '../database';
 import {
@@ -7171,6 +7175,7 @@ export class SupabaseApi implements ServiceApi {
       return [];
     }
   }
+
   async getCurriculumById(
     id: string,
   ): Promise<TableTypes<'curriculum'> | undefined> {
@@ -10205,6 +10210,143 @@ export class SupabaseApi implements ServiceApi {
         subjects: subjectsByGrade.get(gradeId) ?? [],
       })),
     };
+  }
+
+  async getCampaignAssignments(
+    campaignId: string,
+    filters: CampaignAssignmentFilters,
+  ): Promise<CampaignAssignmentsResponse> {
+    if (!this.supabase || !campaignId) {
+      return {
+        assignments: [],
+        total: 0,
+      };
+    }
+
+    const page = filters.page ?? 1;
+    const pageSize = filters.pageSize ?? 10;
+
+    const from = (page - 1) * pageSize;
+    const to = from + pageSize - 1;
+
+    logger.info('page', page, 'pageSize', pageSize, 'from', from, 'to', to);
+
+    let query = this.supabase
+      .from('assignment')
+      .select(
+        `
+          id,
+          starts_at,
+          lesson (
+            id,
+            name
+          ),
+          class!inner (
+            grade!inner (
+              id,
+              name
+            )
+          ),
+          course!inner (
+            subject!inner (
+              id,
+              name
+            )
+          )
+        `,
+        { count: 'exact' },
+      )
+      .eq('campaign_id', campaignId);
+
+    // Apply filters only if provided
+    if (filters.gradeIds?.length) {
+      query = query.in('class.grade.id', filters.gradeIds);
+    }
+
+    if (filters.subjectIds?.length) {
+      query = query.in('course.subject.id', filters.subjectIds);
+    }
+
+    query = query.order('starts_at', { ascending: true }).range(from, to);
+
+    const { data, count, error } = await query;
+
+    if (error) {
+      throw error;
+    }
+
+    return {
+      assignments:
+        data?.map((assignment) => ({
+          assignmentId: assignment.id,
+          assignmentDate: assignment.starts_at,
+
+          gradeId: assignment.class?.grade?.id ?? '',
+          gradeName: assignment.class?.grade?.name ?? '',
+
+          subjectId: assignment.course?.subject?.id ?? '',
+          subjectName: assignment.course?.subject?.name ?? '',
+
+          lessonId: assignment.lesson?.id ?? '',
+          lessonName: assignment.lesson?.name ?? '',
+        })) ?? [],
+      total: count ?? 0,
+    };
+  }
+
+  async getCampaignSubjectsByCampaignId(
+    campaignId: string,
+  ): Promise<CampaignOption[]> {
+    if (!this.supabase || !campaignId) {
+      return [];
+    }
+
+    const { data, error } = await this.supabase
+      .from(TABLES.Assignment)
+      .select(
+        `
+        course:course_id(
+          subject:subject_id(
+            id,
+            name
+          )
+        )
+      `,
+      )
+      .eq('campaign_id', campaignId)
+      .eq('is_deleted', false)
+      .not('course_id', 'is', null);
+
+    if (error) {
+      logger.error('Error fetching campaign subjects:', error);
+      return [];
+    }
+
+    const uniqueSubjects = new Map<string, CampaignOption>();
+
+    (
+      (data ?? []) as Array<{
+        course?: {
+          subject?: CampaignOption | CampaignOption[] | null;
+        } | null;
+      }>
+    ).forEach((row) => {
+      const course = Array.isArray(row.course) ? row.course[0] : row.course;
+      const subject = Array.isArray(course?.subject)
+        ? course?.subject[0]
+        : course?.subject;
+
+      if (subject?.id && subject?.name) {
+        uniqueSubjects.set(String(subject.id), {
+          id: String(subject.id),
+          name: String(subject.name),
+        });
+      }
+    });
+
+    return Array.from(uniqueSubjects.values()).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
   }
 
   private mapCampaignSavedAudienceGroup(

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -10256,7 +10256,8 @@ export class SupabaseApi implements ServiceApi {
         `,
         { count: 'exact' },
       )
-      .eq('campaign_id', campaignId);
+      .eq('campaign_id', campaignId)
+      .eq('is_deleted', false);
 
     // Apply filters only if provided
     if (filters.gradeIds?.length) {


### PR DESCRIPTION
Implement a new Campaign Assignment Tab component that displays assignments for a campaign with filtering by grade and subject, pagination, and a data table. Includes new API methods to fetch assignments and subjects from Supabase, and updates the CampaignsOverview component to render the assignment tab.