### PR TITLE
fix: Update learning path when switching assessment modes

### DIFF
--- a/src/hooks/useLearningPath.ts
+++ b/src/hooks/useLearningPath.ts
@@ -797,6 +797,22 @@ export const useLearningPath = (opts?: {
       return learningPath;
     }
     if (mode != pathMode) {
+      if (shouldUseAssessment(pathMode) && shouldUseAssessment(mode)) {
+        learningPath.pathMode = mode;
+        const res = await updateLearningPathIfNeeded(
+          learningPath,
+          courses,
+          currentStudent,
+          mode,
+          classId,
+        );
+        if (res.updated) learningPath = res.learningPath;
+        learningPath.pathMode = mode;
+        learningPath.updated_at = new Date().toISOString();
+        await saveLearningPath(currentStudent, learningPath);
+        return learningPath;
+      }
+
       learningPath = await buildPath({
         student: currentStudent,
         courses,


### PR DESCRIPTION
- When changing pathMode between two assessment-based modes, call updateLearningPathIfNeeded instead of rebuilding the entire path. 
- The new branch sets learningPath.pathMode, runs updateLearningPathIfNeeded(...), applies returned changes if any, updates updated_at, saves the learning path, and returns it. 
- This preserves assessment state and avoids unnecessary rebuilds when both old and new modes use assessments.