### PR TITLE
fix: Implemented the native bridge/memory fix.

### DIFF
--- a/src/pages/LoginScreen.tsx
+++ b/src/pages/LoginScreen.tsx
@@ -59,6 +59,14 @@ import {
 } from '../utility/termsAndConditions';
 import { isTeacherAppRole } from '../utility/roleUtil';
 
+const NATIVE_LOADING_ANIMATIONS = ['/assets/home.gif'];
+const WEB_LOADING_ANIMATIONS = [
+  '/assets/home.gif',
+  '/assets/hw-book.gif',
+  '/assets/profiles-grid.gif',
+  '/assets/subjects-book.gif',
+];
+
 const LoginScreen: React.FC = () => {
   const history = useHistory();
   const tcHtmlUrlFeature = useFeatureValue<string>(TC_HTML_URL, '');
@@ -119,6 +127,7 @@ const LoginScreen: React.FC = () => {
   const loginTermsUrl = loginTermsBaseUrl
     ? buildTermsUrl(loginTermsBaseUrl, currentLang)
     : 'assets/termsandconditions/TermsandConditionsofChimple.html';
+  const isNativePlatform = Capacitor.isNativePlatform();
 
   const loadingMessages = [
     t('Track your learning progress.'),
@@ -126,12 +135,11 @@ const LoginScreen: React.FC = () => {
     t('Customize your profiles.'),
     t('Assign or get regular homework.'),
   ];
-  const loadingAnimations = [
-    '/assets/home.gif',
-    '/assets/hw-book.gif',
-    '/assets/profiles-grid.gif',
-    '/assets/subjects-book.gif',
-  ];
+  // Native WebView GIF decoding happens beside Capacitor bridge work, so keep
+  // Android on one animation instead of cycling through every large GIF.
+  const loadingAnimations = isNativePlatform
+    ? NATIVE_LOADING_ANIMATIONS
+    : WEB_LOADING_ANIMATIONS;
   const [loadingAnimationsIndex, setLoadingAnimationsIndex] = useState(0);
   const [currentMessageIndex, setCurrentMessageIndex] = useState(0);
 
@@ -146,7 +154,7 @@ const LoginScreen: React.FC = () => {
     }, 5000);
 
     return () => clearInterval(interval);
-  }, [loadingMessages.length]);
+  }, [loadingAnimations.length, loadingMessages.length]);
 
   useEffect(() => {
     const initialize = async () => {
@@ -680,7 +688,6 @@ const LoginScreen: React.FC = () => {
         );
         return;
       }
-      setAnimatedLoading(false);
       dispatch(setAuthLoading(false));
       dispatch(setAuthUser(authUser));
       dispatch(setUser(userData));

--- a/src/utility/logger.ts
+++ b/src/utility/logger.ts
@@ -1,5 +1,10 @@
 /* eslint-disable no-console */
 
+import {
+  NativeBridgePayload,
+  sanitizeNativeBridgePayload,
+} from './safeNativeBridgePayload';
+
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent';
 type LogMethod = 'debug' | 'info' | 'warn' | 'error';
 type LogContext = Record<string, unknown>;
@@ -190,7 +195,8 @@ const buildPayload = (level: LogMethod, args: unknown[]): LogPayload => {
 
 const formatForNative = (obj: unknown): string => {
   try {
-    return JSON.stringify(obj, null, 2);
+    const safePayload = sanitizeNativeBridgePayload(obj as NativeBridgePayload);
+    return JSON.stringify(safePayload, null, 2);
   } catch {
     return '[Object]';
   }
@@ -233,7 +239,9 @@ const emit = (level: LogMethod, args: unknown[]) => {
 
     if (IS_NATIVE) {
       const serialized = cleanedArgs.map((a) =>
-        a && typeof a === 'object' ? formatForNative(a) : a,
+        a && typeof a === 'object'
+          ? formatForNative(a)
+          : sanitizeNativeBridgePayload(a as NativeBridgePayload),
       );
       return console.log(`[${level.toUpperCase()}] ${message}`, ...serialized);
     }

--- a/src/utility/safeNativeBridgePayload.test.ts
+++ b/src/utility/safeNativeBridgePayload.test.ts
@@ -1,0 +1,93 @@
+import { sanitizeNativeBridgePayload } from './safeNativeBridgePayload';
+
+describe('sanitizeNativeBridgePayload', () => {
+  it('summarizes fields that commonly hold native-bridge unsafe payloads', () => {
+    const result = sanitizeNativeBridgePayload({
+      status: 'ok',
+      rows: Array.from({ length: 25 }, (_, index) => ({ id: index })),
+      base64: 'a'.repeat(1000),
+    });
+
+    expect(result).toEqual({
+      status: 'ok',
+      rows: {
+        field: 'rows',
+        type: 'array',
+        count: 25,
+        summarized: true,
+      },
+      base64: {
+        field: 'base64',
+        type: 'string',
+        length: 1000,
+        approximateBytes: 750,
+        summarized: true,
+      },
+    });
+  });
+
+  it('limits depth, object keys, array items, and long strings', () => {
+    const result = sanitizeNativeBridgePayload({
+      values: Array.from({ length: 12 }, (_, index) => ({
+        label: 'x'.repeat(600),
+        nested: { one: { two: { three: 'deep' } } },
+        index,
+      })),
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+      e: 5,
+      f: 6,
+      g: 7,
+      h: 8,
+      i: 9,
+      j: 10,
+      k: 11,
+      l: 12,
+      m: 13,
+      n: 14,
+      o: 15,
+      p: 16,
+      q: 17,
+      r: 18,
+      s: 19,
+      t: 20,
+      u: 21,
+    });
+
+    expect(JSON.stringify(result).length).toBeLessThan(9000);
+    expect(result).toMatchObject({
+      values: expect.arrayContaining([
+        expect.objectContaining({
+          label: expect.objectContaining({
+            type: 'string',
+            length: 600,
+            truncated: true,
+          }),
+          nested: expect.objectContaining({
+            type: 'object',
+            keyCount: 1,
+            summarized: true,
+          }),
+        }),
+        expect.objectContaining({
+          type: 'array',
+          truncatedItems: 2,
+          summarized: true,
+        }),
+      ]),
+      __truncatedKeys: 2,
+    });
+  });
+
+  it('keeps error details bounded', () => {
+    const result = sanitizeNativeBridgePayload(
+      new Error('native bridge failed'),
+    );
+
+    expect(result).toMatchObject({
+      message: 'native bridge failed',
+    });
+  });
+});

--- a/src/utility/safeNativeBridgePayload.ts
+++ b/src/utility/safeNativeBridgePayload.ts
@@ -1,0 +1,178 @@
+export type NativeBridgePayload =
+  | null
+  | undefined
+  | string
+  | number
+  | bigint
+  | boolean
+  | symbol
+  | ((...args: never[]) => NativeBridgePayload)
+  | Error
+  | NativeBridgePayload[]
+  | { [key: string]: NativeBridgePayload };
+
+export type SafeNativeBridgePayload =
+  | null
+  | string
+  | number
+  | boolean
+  | SafeNativeBridgePayload[]
+  | { [key: string]: SafeNativeBridgePayload };
+
+const MAX_STRING_LENGTH = 500;
+const MAX_ARRAY_ITEMS = 10;
+const MAX_OBJECT_KEYS = 20;
+const MAX_DEPTH = 3;
+const LARGE_FIELD_NAMES = new Set([
+  'payload',
+  'response',
+  'rows',
+  'records',
+  'data',
+  'metadata',
+  'students',
+  'profiles',
+  'lessons',
+  'results',
+  'image',
+  'base64',
+  'blob',
+  'file',
+  'children',
+]);
+
+const BYTE_LENGTH_DIVISOR = 4;
+
+const summarizeString = (value: string): SafeNativeBridgePayload => {
+  if (value.length <= MAX_STRING_LENGTH) return value;
+
+  return {
+    type: 'string',
+    length: value.length,
+    preview: value.slice(0, MAX_STRING_LENGTH),
+    truncated: true,
+  };
+};
+
+const summarizeLargeField = (
+  key: string,
+  value: NativeBridgePayload,
+): SafeNativeBridgePayload => {
+  if (Array.isArray(value)) {
+    return {
+      field: key,
+      type: 'array',
+      count: value.length,
+      summarized: true,
+    };
+  }
+
+  if (typeof value === 'string') {
+    return {
+      field: key,
+      type: 'string',
+      length: value.length,
+      approximateBytes: Math.ceil(value.length / BYTE_LENGTH_DIVISOR) * 3,
+      summarized: true,
+    };
+  }
+
+  if (value && typeof value === 'object') {
+    return {
+      field: key,
+      type: value instanceof Error ? 'error' : 'object',
+      keyCount: value instanceof Error ? 2 : Object.keys(value).length,
+      summarized: true,
+    };
+  }
+
+  return sanitizeNativeBridgePayload(value);
+};
+
+const sanitizeObject = (
+  value: { [key: string]: NativeBridgePayload },
+  depth: number,
+  seen: WeakSet<object>,
+): SafeNativeBridgePayload => {
+  if (seen.has(value)) {
+    return '[Circular]';
+  }
+  seen.add(value);
+
+  const entries = Object.entries(value);
+  const sanitizedEntries = entries
+    .slice(0, MAX_OBJECT_KEYS)
+    .map(([key, item]) => {
+      if (LARGE_FIELD_NAMES.has(key)) {
+        return [key, summarizeLargeField(key, item)] as const;
+      }
+
+      return [key, sanitizeNativeBridgePayload(item, depth + 1, seen)] as const;
+    });
+
+  const result: { [key: string]: SafeNativeBridgePayload } = {};
+  for (const [key, item] of sanitizedEntries) {
+    result[key] = item;
+  }
+
+  if (entries.length > MAX_OBJECT_KEYS) {
+    result.__truncatedKeys = entries.length - MAX_OBJECT_KEYS;
+  }
+
+  return result;
+};
+
+export const sanitizeNativeBridgePayload = (
+  value: NativeBridgePayload,
+  depth: number = 0,
+  seen: WeakSet<object> = new WeakSet<object>(),
+): SafeNativeBridgePayload => {
+  if (value === null || value === undefined) return null;
+
+  if (typeof value === 'string') return summarizeString(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'symbol') return value.toString();
+  if (typeof value === 'function') {
+    return {
+      type: 'function',
+      name: value.name || 'anonymous',
+      summarized: true,
+    };
+  }
+
+  if (value instanceof Error) {
+    return {
+      message: value.message,
+      stack: value.stack ? summarizeString(value.stack) : null,
+    };
+  }
+
+  if (depth >= MAX_DEPTH) {
+    return Array.isArray(value)
+      ? { type: 'array', count: value.length, summarized: true }
+      : {
+          type: 'object',
+          keyCount: Object.keys(value).length,
+          summarized: true,
+        };
+  }
+
+  if (Array.isArray(value)) {
+    const result = value
+      .slice(0, MAX_ARRAY_ITEMS)
+      .map((item) => sanitizeNativeBridgePayload(item, depth + 1, seen));
+
+    if (value.length > MAX_ARRAY_ITEMS) {
+      result.push({
+        type: 'array',
+        truncatedItems: value.length - MAX_ARRAY_ITEMS,
+        summarized: true,
+      });
+    }
+
+    return result;
+  }
+
+  return sanitizeObject(value, depth, seen);
+};


### PR DESCRIPTION
Root cause: the fatal stack points to Capacitor serializing a huge plugin payload. The app path that can feed large arbitrary objects into that native plugin is [logger.ts](utility/logger.ts), where native console.* output can be captured by Sentry as a breadcrumb and sent through SentryCapacitor.addBreadcrumb.

Fix:
Added [safeNativeBridgePayload.ts] to bound native/logging payloads:truncates long strings limits arrays, object depth, and object keys summarizes large fields like payload, response, rows, records, data, metadata, students, profiles, lessons, results, image, base64, blob, file, children.

Updated [logger.ts] so native console payloads are sanitized before they can become Sentry breadcrumbs or native bridge data.

Updated [LoginScreen.tsx] so Android native loading uses only /assets/home.gif instead of cycling through all four GIFs. Web keeps the existing carousel.

Added [safeNativeBridgePayload.test.ts].