### PR TITLE
Fix user profile creation in Oops DB for new users

### DIFF
--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -1268,7 +1268,7 @@ export class SqliteApi implements ServiceApi {
       updated_at: now,
       is_deleted: false,
       is_tc_accepted: true,
-      tc_agreed_version: tcVersion,
+      tc_agreed_version: tcVersion ?? 0,
       email: null,
       phone: null,
       fcm_token: null,
@@ -1747,7 +1747,7 @@ export class SqliteApi implements ServiceApi {
       updated_at: new Date().toISOString(),
       is_deleted: false,
       is_tc_accepted: true,
-      tc_agreed_version: tcVersion,
+      tc_agreed_version: tcVersion ?? 0,
       email: null,
       phone: null,
       fcm_token: null,
@@ -5274,6 +5274,8 @@ export class SqliteApi implements ServiceApi {
       countryCode,
     );
     const localeId = locale?.id ?? DEFAULT_LOCALE_ID;
+    const tcAgreedVersion = user.tc_agreed_version ?? 0;
+    user.tc_agreed_version = tcAgreedVersion;
 
     await this.executeQuery(
       `
@@ -5290,7 +5292,7 @@ export class SqliteApi implements ServiceApi {
         user.curriculum_id,
         user.language_id,
         (user.locale_id = localeId),
-        user.tc_agreed_version,
+        tcAgreedVersion,
       ],
     );
     await this.updatePushChanges(TABLES.User, MUTATE_TYPES.INSERT, user);
@@ -8109,7 +8111,7 @@ order by
       updated_at: new Date().toISOString(),
       is_deleted: false,
       is_tc_accepted: true,
-      tc_agreed_version: tcVersion,
+      tc_agreed_version: tcVersion ?? 0,
       email: null,
       phone: null,
       fcm_token: null,

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -11230,7 +11230,7 @@ export class SupabaseApi implements ServiceApi {
       updated_at: now,
       is_deleted: false,
       is_tc_accepted: true,
-      tc_agreed_version: 0,
+      tc_agreed_version: tcVersion ?? 0,
       email: null,
       phone: null,
       fcm_token: null,

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -468,7 +468,7 @@ export class SupabaseApi implements ServiceApi {
       curriculum_id: user.curriculum_id,
       language_id: user.language_id,
       locale_id: localeId,
-      tc_agreed_version: user.tc_agreed_version,
+      tc_agreed_version: user.tc_agreed_version ?? 0,
     });
 
     if (error) {
@@ -926,6 +926,9 @@ export class SupabaseApi implements ServiceApi {
   ) {
     const data = { ...data1 };
     data.updated_at = new Date().toISOString();
+    if (tableName === TABLES.User && data.tc_agreed_version == null) {
+      data.tc_agreed_version = 0;
+    }
     if (!this.supabase) return;
     let res: PostgrestSingleResponse<any> | undefined = undefined;
     switch (mutateType) {
@@ -1590,7 +1593,7 @@ export class SupabaseApi implements ServiceApi {
       updated_at: now,
       is_deleted: false,
       is_tc_accepted: true,
-      tc_agreed_version: tcVersion,
+      tc_agreed_version: tcVersion ?? 0,
       email: null,
       phone: null,
       fcm_token: null,
@@ -1745,7 +1748,7 @@ export class SupabaseApi implements ServiceApi {
       updated_at: timestamp,
       is_deleted: false,
       is_tc_accepted: true,
-      tc_agreed_version: tcVersion,
+      tc_agreed_version: tcVersion ?? 0,
       email: null,
       phone: null,
       fcm_token: null,
@@ -11227,7 +11230,7 @@ export class SupabaseApi implements ServiceApi {
       updated_at: now,
       is_deleted: false,
       is_tc_accepted: true,
-      tc_agreed_version: tcVersion,
+      tc_agreed_version: 0,
       email: null,
       phone: null,
       fcm_token: null,

--- a/src/services/auth/SupabaseAuth.ts
+++ b/src/services/auth/SupabaseAuth.ts
@@ -543,7 +543,7 @@ export class SupabaseAuth implements ServiceAuth {
     try {
       if (!this._auth) return;
       const api = ServiceConfig.getI().apiHandler;
-      const agreedVersion = normalizeTcVersion(tcAgreedVersion);
+      const agreedVersion = normalizeTcVersion(tcAgreedVersion) ?? 0;
 
       const { data: user, error } = await this._auth.verifyOtp({
         phone: phoneNumber,
@@ -669,7 +669,7 @@ export class SupabaseAuth implements ServiceAuth {
     try {
       if (!this._supabaseDb || !session.user) return null;
       let api = ServiceConfig.getI().apiHandler;
-      const agreedVersion = normalizeTcVersion(tcAgreedVersion);
+      const agreedVersion = normalizeTcVersion(tcAgreedVersion) ?? 0;
       const user = session.user;
       const email = user.email;
       const id = user.id;


### PR DESCRIPTION
## Issue
When a new user is created, the corresponding user profile is not being created in the Oops database.

## Root Cause
User creation was failing because `tc_agreed_version` was being sent as `NULL`, violating the NOT NULL constraint on the `user` table.

## Fix
- Default `tc_agreed_version` to `0` when no value is provided.
- Prevent the NOT NULL constraint violation during user/profile creation.

## Testing
- Verified phone signup.
- Verified parent profile creation.
- Verified child profile creation.
- Confirmed records are created successfully in the correct Oops database.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1292fd57-9738-4c25-b933-e600706916c8" />


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0a558d33-6c9e-4aea-b238-78190e8c2bf2" />
