### PR TITLE
Fix subject permissions and self-delete handling

### DIFF
--- a/src/teachers-module/components/DisplaySubjects.tsx
+++ b/src/teachers-module/components/DisplaySubjects.tsx
@@ -4,6 +4,8 @@ import { checkmarkCircle } from 'ionicons/icons';
 import React, { useEffect, useState } from 'react';
 import { TableTypes } from '../../common/constants';
 import { RoleType } from '../../interface/modelInterfaces';
+import { useAppSelector } from '../../redux/hooks';
+import { RootState } from '../../redux/store';
 import logger from '../../utility/logger';
 import { schoolUtil } from '../../utility/schoolUtil';
 import { Util } from '../../utility/util';
@@ -14,10 +16,6 @@ interface CurriculumWithCourses {
   courses: TableTypes<'course'>[];
 }
 
-type ClassWithRole = TableTypes<'class'> & {
-  role?: RoleType;
-};
-
 interface DisplaySubjectsProps {
   curriculumsWithCourses: CurriculumWithCourses[];
   selectedSubjects: string[];
@@ -26,6 +24,8 @@ interface DisplaySubjectsProps {
   isModalOpen: boolean;
   currentSubject: string | null;
   setIsModalOpen: (open: boolean) => void;
+  schoolId?: string;
+  classId?: string;
 }
 
 const DisplaySubjects: React.FC<DisplaySubjectsProps> = ({
@@ -36,21 +36,39 @@ const DisplaySubjects: React.FC<DisplaySubjectsProps> = ({
   isModalOpen,
   currentSubject,
   setIsModalOpen,
+  schoolId,
+  classId,
 }) => {
   // State to track whether the last subject warning should be shown
   const [isLastSubjectAlertOpen, setIsLastSubjectAlertOpen] = useState(false);
   const [canModify, setCanModify] = useState(true);
   const isTeacherSchoolMode = schoolUtil.isTeacherSchoolMode();
+  const roleMap = useAppSelector(
+    (state: RootState) =>
+      state.growthbook.attributes?.roleMap as
+        | Record<string, string>
+        | undefined,
+  );
 
   useEffect(() => {
-    const checkClassRole = async () => {
-      const cls = (await Util.getCurrentClass()) as ClassWithRole | undefined;
-      if (cls?.role === RoleType.TEACHER || isTeacherSchoolMode) {
-        setCanModify(false);
-      }
-    };
-    checkClassRole();
-  }, [isTeacherSchoolMode]);
+    const selectedSchoolId = Util.getCurrentSchool()?.id;
+    const selectedClassId = Util.getCurrentClass()?.id;
+    const activeSchoolRole = selectedSchoolId
+      ? roleMap?.[`${selectedSchoolId}_role`]
+      : undefined;
+    const normalizedRole = (activeSchoolRole ?? '').toLowerCase();
+    const schoolMatches =
+      !schoolId || !selectedSchoolId || schoolId === selectedSchoolId;
+    const classMatches =
+      !classId || !selectedClassId || classId === selectedClassId;
+    setCanModify(
+      !isTeacherSchoolMode &&
+        schoolMatches &&
+        classMatches &&
+        (normalizedRole === RoleType.TEACHER ||
+          normalizedRole === RoleType.PRINCIPAL),
+    );
+  }, [classId, isTeacherSchoolMode, roleMap, schoolId]);
 
   // Trigger subject removal logic
   const triggerRemoveSubject = (subject: string) => {

--- a/src/teachers-module/components/DisplaySubjects.tsx
+++ b/src/teachers-module/components/DisplaySubjects.tsx
@@ -25,7 +25,6 @@ interface DisplaySubjectsProps {
   currentSubject: string | null;
   setIsModalOpen: (open: boolean) => void;
   schoolId?: string;
-  classId?: string;
 }
 
 const DisplaySubjects: React.FC<DisplaySubjectsProps> = ({
@@ -37,7 +36,6 @@ const DisplaySubjects: React.FC<DisplaySubjectsProps> = ({
   currentSubject,
   setIsModalOpen,
   schoolId,
-  classId,
 }) => {
   // State to track whether the last subject warning should be shown
   const [isLastSubjectAlertOpen, setIsLastSubjectAlertOpen] = useState(false);
@@ -52,23 +50,18 @@ const DisplaySubjects: React.FC<DisplaySubjectsProps> = ({
 
   useEffect(() => {
     const selectedSchoolId = Util.getCurrentSchool()?.id;
-    const selectedClassId = Util.getCurrentClass()?.id;
     const activeSchoolRole = selectedSchoolId
       ? roleMap?.[`${selectedSchoolId}_role`]
       : undefined;
     const normalizedRole = (activeSchoolRole ?? '').toLowerCase();
     const schoolMatches =
       !schoolId || !selectedSchoolId || schoolId === selectedSchoolId;
-    const classMatches =
-      !classId || !selectedClassId || classId === selectedClassId;
     setCanModify(
       !isTeacherSchoolMode &&
         schoolMatches &&
-        classMatches &&
-        (normalizedRole === RoleType.TEACHER ||
-          normalizedRole === RoleType.PRINCIPAL),
+        normalizedRole === RoleType.PRINCIPAL,
     );
-  }, [classId, isTeacherSchoolMode, roleMap, schoolId]);
+  }, [isTeacherSchoolMode, roleMap, schoolId]);
 
   // Trigger subject removal logic
   const triggerRemoveSubject = (subject: string) => {

--- a/src/teachers-module/components/studentProfile/UserList.tsx
+++ b/src/teachers-module/components/studentProfile/UserList.tsx
@@ -20,17 +20,16 @@ const UserList: React.FC<{
   userType: CLASS_USERS;
 }> = ({ schoolDoc, classDoc, userType }) => {
   const api = ServiceConfig.getI()?.apiHandler;
-  const auth = ServiceConfig.getI()?.authHandler;
   const [allStudents, setAllStudents] = useState<TableTypes<'user'>[]>();
   const [allTeachers, setAllTeachers] = useState<TableTypes<'user'>[]>();
-  const [currentUser, setCurrentUser] = useState<TableTypes<'user'> | null>(
-    null,
-  );
   const [showConfirm, setShowConfirm] = useState(false);
   const [showSelfDeleteError, setShowSelfDeleteError] = useState(false);
   const [selectedUser, setSelectedUser] = useState<TableTypes<'user'> | null>(
     null,
   );
+  const currentUser = useAppSelector(
+    (state: RootState) => state.auth as AuthState,
+  ).user;
   const { roles } = useAppSelector(
     (state: RootState) => state.auth as AuthState,
   );
@@ -42,14 +41,6 @@ const UserList: React.FC<{
   useEffect(() => {
     init();
   }, []);
-
-  useEffect(() => {
-    const loadCurrentUser = async () => {
-      const user = await auth?.getCurrentUser();
-      setCurrentUser(user ?? null);
-    };
-    loadCurrentUser();
-  }, [auth]);
 
   const canDelete = useMemo(
     () =>

--- a/src/teachers-module/components/studentProfile/UserList.tsx
+++ b/src/teachers-module/components/studentProfile/UserList.tsx
@@ -2,6 +2,7 @@ import { IonAlert, IonIcon } from '@ionic/react';
 import { t } from 'i18next';
 import { trashOutline } from 'ionicons/icons';
 import React, { useEffect, useMemo, useState } from 'react';
+import CommonDialogBox from '../../../common/CommonDialogBox';
 import { CLASS_USERS, OPS_ROLES, TableTypes } from '../../../common/constants';
 import { RoleType } from '../../../interface/modelInterfaces';
 import { useAppSelector } from '../../../redux/hooks';
@@ -19,9 +20,14 @@ const UserList: React.FC<{
   userType: CLASS_USERS;
 }> = ({ schoolDoc, classDoc, userType }) => {
   const api = ServiceConfig.getI()?.apiHandler;
+  const auth = ServiceConfig.getI()?.authHandler;
   const [allStudents, setAllStudents] = useState<TableTypes<'user'>[]>();
   const [allTeachers, setAllTeachers] = useState<TableTypes<'user'>[]>();
+  const [currentUser, setCurrentUser] = useState<TableTypes<'user'> | null>(
+    null,
+  );
   const [showConfirm, setShowConfirm] = useState(false);
+  const [showSelfDeleteError, setShowSelfDeleteError] = useState(false);
   const [selectedUser, setSelectedUser] = useState<TableTypes<'user'> | null>(
     null,
   );
@@ -36,6 +42,14 @@ const UserList: React.FC<{
   useEffect(() => {
     init();
   }, []);
+
+  useEffect(() => {
+    const loadCurrentUser = async () => {
+      const user = await auth?.getCurrentUser();
+      setCurrentUser(user ?? null);
+    };
+    loadCurrentUser();
+  }, [auth]);
 
   const canDelete = useMemo(
     () =>
@@ -55,6 +69,10 @@ const UserList: React.FC<{
   };
 
   const handleDeleteClick = (user: TableTypes<'user'>) => {
+    if (user.id === currentUser?.id) {
+      setShowSelfDeleteError(true);
+      return;
+    }
     setSelectedUser(user);
     setShowConfirm(true);
   };
@@ -120,7 +138,7 @@ const UserList: React.FC<{
 
                 {!isExternalUser && !isTeacherSchoolMode && (
                   <div
-                    className="delete-button" //////
+                    className="delete-button"
                     onClick={() => handleDeleteClick(student)}
                   >
                     <IonIcon icon={trashOutline} className="trash-icon" />
@@ -180,6 +198,13 @@ const UserList: React.FC<{
             handler: () => setShowConfirm(false),
           },
         ]}
+      />
+      <CommonDialogBox
+        showConfirmFlag={showSelfDeleteError}
+        onDidDismiss={() => setShowSelfDeleteError(false)}
+        message="You cannot delete yourself."
+        rightButtonText="OK"
+        rightButtonHandler={() => setShowSelfDeleteError(false)}
       />
     </div>
   );

--- a/src/teachers-module/pages/SubjectSelection.tsx
+++ b/src/teachers-module/pages/SubjectSelection.tsx
@@ -82,21 +82,22 @@ const SubjectSelection: React.FC = () => {
   const { roles } = useAppSelector(
     (state: RootState) => state.auth as AuthState,
   );
+  const roleMap = useAppSelector(
+    (state: RootState) =>
+      state.growthbook.attributes?.roleMap as
+        | Record<string, string>
+        | undefined,
+  );
   const userRoles = roles || [];
   const isExternalUser = userRoles.includes(RoleType.EXTERNAL_USER);
   useEffect(() => {
     const init = async () => {
-      const cls = await Util.getCurrentClass();
-      if ((cls as any)?.role === RoleType.TEACHER) {
-        setCanModify(false);
-      }
-
       if (paramClassId) {
         await fetchSchoolAndClassSubjects(paramClassId, CLASS);
         await fetchClassDetails();
         if (isSelectSubject) setIsSelecting(true);
       } else if (paramSchoolId) {
-        await fetchCurriculumsAndCourses(SCHOOL);
+        await fetchCurriculumsAndCourses(SCHOOL, paramSchoolId);
         await fetchSchoolAndClassSubjects(paramSchoolId, SCHOOL);
         if (isSelectSubject) setIsSelecting(true);
       }
@@ -104,6 +105,30 @@ const SubjectSelection: React.FC = () => {
 
     init();
   }, [paramClassId, paramSchoolId]);
+
+  useEffect(() => {
+    const selectedSchoolId = Util.getCurrentSchool()?.id;
+    const selectedClassId = Util.getCurrentClass()?.id;
+    const activeSchoolId = currentSchool?.id ?? paramSchoolId;
+    const activeSchoolRole = activeSchoolId
+      ? roleMap?.[`${activeSchoolId}_role`]
+      : undefined;
+    const normalizedRole = (activeSchoolRole ?? '').toLowerCase();
+    const schoolMatches =
+      !currentSchool?.id ||
+      !selectedSchoolId ||
+      currentSchool.id === selectedSchoolId;
+    const classMatches =
+      !currentClass?.id ||
+      !selectedClassId ||
+      currentClass.id === selectedClassId;
+    setCanModify(
+      schoolMatches &&
+        classMatches &&
+        (normalizedRole === RoleType.TEACHER ||
+          normalizedRole === RoleType.PRINCIPAL),
+    );
+  }, [currentClass?.id, currentSchool?.id, paramSchoolId, roleMap]);
 
   const fetchCurriculumsAndCourses = async (
     context: 'school' | 'class',
@@ -118,7 +143,7 @@ const SubjectSelection: React.FC = () => {
       ]);
       // Fetch school-specific courses for class context
       const schoolCourses =
-        context === CLASS && schoolId
+        schoolId && (context === CLASS || context === SCHOOL)
           ? await api.getCoursesBySchoolId(schoolId)
           : [];
       // Extract course IDs for filtering
@@ -126,10 +151,9 @@ const SubjectSelection: React.FC = () => {
         (schoolCourse) => schoolCourse.course_id,
       );
       // Filter courseDocs based on the context
-      const filteredCourseDocs =
-        context === CLASS
-          ? courseDocs.filter((course) => schoolCourseIds.includes(course.id))
-          : courseDocs;
+      const filteredCourseDocs = schoolId
+        ? courseDocs.filter((course) => schoolCourseIds.includes(course.id))
+        : courseDocs;
 
       // Map courses to curriculums and grades
       const curriculumWithCourses = curriculumDocs.reduce<
@@ -193,12 +217,7 @@ const SubjectSelection: React.FC = () => {
         return match ? parseInt(match[0], 10) : 0;
       }
 
-      // Update state based on context
-      if (context === SCHOOL) {
-        setCurriculumsWithCourses(sortedCurriculums);
-      } else {
-        setCurriculumsWithCourses(sortedCurriculums);
-      }
+      setCurriculumsWithCourses(sortedCurriculums);
     } catch (error) {
       logger.error(t('Failed to fetch curriculums and courses'), error);
     }
@@ -597,6 +616,8 @@ const SubjectSelection: React.FC = () => {
           isModalOpen={isModalOpen}
           currentSubject={currentSubject}
           setIsModalOpen={setIsModalOpen}
+          schoolId={currentSchool?.id ?? paramSchoolId ?? undefined}
+          classId={currentClass?.id ?? paramClassId ?? undefined}
         />
       ) : (
         <SubjectSelectionComponent

--- a/src/teachers-module/pages/SubjectSelection.tsx
+++ b/src/teachers-module/pages/SubjectSelection.tsx
@@ -108,7 +108,6 @@ const SubjectSelection: React.FC = () => {
 
   useEffect(() => {
     const selectedSchoolId = Util.getCurrentSchool()?.id;
-    const selectedClassId = Util.getCurrentClass()?.id;
     const activeSchoolId = currentSchool?.id ?? paramSchoolId;
     const activeSchoolRole = activeSchoolId
       ? roleMap?.[`${activeSchoolId}_role`]
@@ -118,17 +117,8 @@ const SubjectSelection: React.FC = () => {
       !currentSchool?.id ||
       !selectedSchoolId ||
       currentSchool.id === selectedSchoolId;
-    const classMatches =
-      !currentClass?.id ||
-      !selectedClassId ||
-      currentClass.id === selectedClassId;
-    setCanModify(
-      schoolMatches &&
-        classMatches &&
-        (normalizedRole === RoleType.TEACHER ||
-          normalizedRole === RoleType.PRINCIPAL),
-    );
-  }, [currentClass?.id, currentSchool?.id, paramSchoolId, roleMap]);
+    setCanModify(schoolMatches && normalizedRole === RoleType.PRINCIPAL);
+  }, [currentSchool?.id, paramSchoolId, roleMap]);
 
   const fetchCurriculumsAndCourses = async (
     context: 'school' | 'class',
@@ -618,7 +608,6 @@ const SubjectSelection: React.FC = () => {
           currentSubject={currentSubject}
           setIsModalOpen={setIsModalOpen}
           schoolId={currentSchool?.id ?? paramSchoolId ?? undefined}
-          classId={currentClass?.id ?? paramClassId ?? undefined}
         />
       ) : (
         <SubjectSelectionComponent

--- a/src/teachers-module/pages/SubjectSelection.tsx
+++ b/src/teachers-module/pages/SubjectSelection.tsx
@@ -151,9 +151,10 @@ const SubjectSelection: React.FC = () => {
         (schoolCourse) => schoolCourse.course_id,
       );
       // Filter courseDocs based on the context
-      const filteredCourseDocs = schoolId
-        ? courseDocs.filter((course) => schoolCourseIds.includes(course.id))
-        : courseDocs;
+      const filteredCourseDocs =
+        context === CLASS
+          ? courseDocs.filter((course) => schoolCourseIds.includes(course.id))
+          : courseDocs;
 
       // Map courses to curriculums and grades
       const curriculumWithCourses = curriculumDocs.reduce<


### PR DESCRIPTION
Summary

This PR fixes two permission-related issues for users who have different roles across multiple schools.

Issue 1: Teacher self-deletion

Issue:
When the same user was assigned as a Teacher in one school and a Principal in another, they could switch to the Teacher school and delete their own Teacher profile. Users should never be able to delete their own profile.

Fix:

Reused the existing self-deletion validation implemented for the Principal flow.
Prevented the delete action when the logged-in user attempts to delete their own Teacher profile.
Kept the existing Delete icon and confirmation flow unchanged for all other users.

Issue 2: Cross-school subject permissions

Issue:
Subject management permissions (subject checkboxes, Add/Edit actions, etc.) were not being restricted to the currently selected school and class. As a result, permissions could leak across schools when the same user had different roles in different schools.

Fix:

Updated the permission checks to use the currently selected school and class as the source of truth.
Subject management actions are now available only for the selected school's classes/subjects where the user has the appropriate role.
Prevented subject management actions from appearing for classes or subjects belonging to other schools after switching school context.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/46265122-e114-4c2b-a2fd-217bf831ebf1" />


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3f19f7b2-03f1-4770-9f38-962e5b1a421c" />
