### PR TITLE
fix: add validation for remote assets and rename speech polyfill imports to prevent naming conflicts

### DIFF
--- a/src/hooks/useRemoteAssetFlags.ts
+++ b/src/hooks/useRemoteAssetFlags.ts
@@ -37,12 +37,17 @@ export const useRemoteAssetFlags = () => {
     );
 
     if (shouldShowRemoteAssets) {
-      const assetKey = `learning:${learningPathAssets?.uniqueId ?? ''}`;
+      const { asset_repo_url: assetRepoUrl, uniqueId } = learningPathAssets;
+      if (!assetRepoUrl || !uniqueId) {
+        return;
+      }
+
+      const assetKey = `learning:${uniqueId}`;
       if (!downloadedAssetKeysRef.current.has(assetKey)) {
         downloadedAssetKeysRef.current.add(assetKey);
         void Util.DownloadRemoteAssets(
-          learningPathAssets?.asset_repo_url,
-          learningPathAssets?.uniqueId,
+          assetRepoUrl,
+          uniqueId,
           'remoteAsset',
           'Learning Path',
         );
@@ -57,12 +62,17 @@ export const useRemoteAssetFlags = () => {
     );
 
     if (shouldShowHomeworkRemoteAssets) {
-      const assetKey = `homework:${homeworkPathwayAssets?.uniqueId ?? ''}`;
+      const { asset_repo_url: assetRepoUrl, uniqueId } = homeworkPathwayAssets;
+      if (!assetRepoUrl || !uniqueId) {
+        return;
+      }
+
+      const assetKey = `homework:${uniqueId}`;
       if (!downloadedAssetKeysRef.current.has(assetKey)) {
         downloadedAssetKeysRef.current.add(assetKey);
         void Util.DownloadRemoteAssets(
-          homeworkPathwayAssets?.asset_repo_url,
-          homeworkPathwayAssets?.uniqueId,
+          assetRepoUrl,
+          uniqueId,
           'homeworkRemoteAsset',
           'Homework',
         );

--- a/src/hooks/useRemoteAssetFlags.ts
+++ b/src/hooks/useRemoteAssetFlags.ts
@@ -37,7 +37,8 @@ export const useRemoteAssetFlags = () => {
     );
 
     if (shouldShowRemoteAssets) {
-      const { asset_repo_url: assetRepoUrl, uniqueId } = learningPathAssets;
+      const { asset_repo_url: assetRepoUrl, uniqueId } =
+        learningPathAssets ?? {};
       if (!assetRepoUrl || !uniqueId) {
         return;
       }
@@ -62,7 +63,8 @@ export const useRemoteAssetFlags = () => {
     );
 
     if (shouldShowHomeworkRemoteAssets) {
-      const { asset_repo_url: assetRepoUrl, uniqueId } = homeworkPathwayAssets;
+      const { asset_repo_url: assetRepoUrl, uniqueId } =
+        homeworkPathwayAssets ?? {};
       if (!assetRepoUrl || !uniqueId) {
         return;
       }

--- a/src/startup/platformSetup.ts
+++ b/src/startup/platformSetup.ts
@@ -1,8 +1,8 @@
 import { defineCustomElements as jeepSqlite } from 'jeep-sqlite/loader';
 import { defineCustomElements, JSX as LocalJSX } from 'lido-standalone/loader';
 import {
-  SpeechSynthesis,
-  SpeechSynthesisUtterance,
+  SpeechSynthesis as WindowsSpeechSynthesis,
+  SpeechSynthesisUtterance as WindowsSpeechSynthesisUtterance,
 } from '../utility/WindowsSpeech';
 import { initializeFireBase } from '../services/Firebase';
 import { isNativePlatform } from './nativeRuntime';
@@ -13,9 +13,9 @@ type NavigatorWithUserAgentData = Navigator & {
   };
 };
 
-type WindowWithSpeechPolyfills = Window & {
-  speechSynthesis?: SpeechSynthesis;
-  SpeechSynthesisUtterance?: typeof SpeechSynthesisUtterance;
+type SpeechPolyfillWindow = {
+  speechSynthesis?: unknown;
+  SpeechSynthesisUtterance?: unknown;
 };
 
 declare global {
@@ -47,13 +47,13 @@ const applyMobileWebBrowserClass = () => {
 const initializeSpeechPolyfills = () => {
   if (typeof window === 'undefined') return;
 
-  const windowWithSpeechPolyfills = window as WindowWithSpeechPolyfills;
+  const windowWithSpeechPolyfills = window as unknown as SpeechPolyfillWindow;
 
   if (!windowWithSpeechPolyfills.speechSynthesis) {
-    windowWithSpeechPolyfills.speechSynthesis = new SpeechSynthesis();
+    windowWithSpeechPolyfills.speechSynthesis = new WindowsSpeechSynthesis();
   }
   if (!windowWithSpeechPolyfills.SpeechSynthesisUtterance) {
     windowWithSpeechPolyfills.SpeechSynthesisUtterance =
-      SpeechSynthesisUtterance;
+      WindowsSpeechSynthesisUtterance;
   }
 };


### PR DESCRIPTION
I updated [src/hooks/useRemoteAssetFlags.ts](/home/rahul/Documents/GitHub/cuba/src/hooks/useRemoteAssetFlags.ts) to guard asset_repo_url and uniqueId before calling Util.DownloadRemoteAssets(...), so TypeScript no longer has to accept string | undefined where a string is required.

I also updated [src/startup/platformSetup.ts](/home/rahul/Documents/GitHub/cuba/src/startup/platformSetup.ts) to avoid conflicting with the built-in DOM speech types. Instead of casting window to a Window subtype that redefines speechSynthesis, I switched to a narrow property-bag cast and aliased the custom speech polyfill classes from [src/utility/WindowsSpeech.ts](/home/rahul/Documents/GitHub/cuba/src/utility/WindowsSpeech.ts).