### PR TITLE
Fix Newly Created Programs Are Not Displayed in the Program Listing Page

### DIFF
--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -11007,6 +11007,8 @@ export class SupabaseApi implements ServiceApi {
         return false;
       }
       const programId = uuidv4();
+      const _currentUser =
+        await ServiceConfig.getI().authHandler.getCurrentUser();
 
       const record: any = {
         id: programId,
@@ -11036,7 +11038,10 @@ export class SupabaseApi implements ServiceApi {
       };
 
       // Step 1: Insert the program
-      const { error } = await this.supabase.from(TABLES.Program).insert(record);
+      const { data, error } = await this.supabase
+        .from(TABLES.Program)
+        .insert(record)
+        .single();
 
       if (error) {
         logger.error('Insert error:', error);

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -477,6 +477,7 @@ const mapStickerBookRow = (book: TableTypes<'sticker_book'>): StickerBook => ({
 
 const GENERIC_LEADERBOARD_LIMIT = 50;
 const SCHOOL_METRICS_DAY_WINDOWS = [7, 15, 30] as const;
+const PROGRAM_METRICS_DAY_WINDOWS = [7, 15, 30] as const;
 const TABLES_EXCLUDED_FROM_SYNC = new Set<TABLES>([
   TABLES.ProgramUser,
   TABLES.ReqNewSchool,
@@ -1725,6 +1726,40 @@ export class SupabaseApi implements ServiceApi {
     } catch (error) {
       logger.error('computeSchoolMetricsForSchool failed:', {
         schoolId,
+        error,
+      });
+      return false;
+    }
+  }
+
+  async computeProgramMetricsForProgram(programId: string): Promise<boolean> {
+    if (!this.supabase) return false;
+    if (!programId) {
+      logger.error(
+        'computeProgramMetricsForProgram called without a valid programId',
+      );
+      return false;
+    }
+    try {
+      for (const dayWindow of PROGRAM_METRICS_DAY_WINDOWS) {
+        const { error } = await this.supabase.rpc('compute_program_metrics', {
+          p_days: dayWindow,
+          p_program_id: programId,
+        });
+
+        if (error) {
+          logger.error('Error computing program metrics:', {
+            programId,
+            dayWindow,
+            error,
+          });
+          return false;
+        }
+      }
+      return true;
+    } catch (error) {
+      logger.error('computeProgramMetricsForProgram failed:', {
+        programId,
         error,
       });
       return false;
@@ -10972,8 +11007,6 @@ export class SupabaseApi implements ServiceApi {
         return false;
       }
       const programId = uuidv4();
-      const _currentUser =
-        await ServiceConfig.getI().authHandler.getCurrentUser();
 
       const record: any = {
         id: programId,
@@ -11003,10 +11036,7 @@ export class SupabaseApi implements ServiceApi {
       };
 
       // Step 1: Insert the program
-      const { data, error } = await this.supabase
-        .from(TABLES.Program)
-        .insert(record)
-        .single();
+      const { error } = await this.supabase.from(TABLES.Program).insert(record);
 
       if (error) {
         logger.error('Insert error:', error);
@@ -11031,6 +11061,8 @@ export class SupabaseApi implements ServiceApi {
         logger.error('Error inserting program users:', programUserError);
         return false;
       }
+
+      await this.computeProgramMetricsForProgram(programId);
 
       return true;
     } catch (error) {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -6176,6 +6176,10 @@ export type Database = {
         Args: { p_days: number; p_school_id?: string };
         Returns: undefined;
       };
+      compute_program_metrics: {
+        Args: { p_days: number; p_program_id?: string };
+        Returns: undefined;
+      };
       count_users_by_school: {
         Args: { p_school_id: string };
         Returns: {


### PR DESCRIPTION
## Summary
This PR fixes an issue where newly created programs were not appearing in the Program Listing page after successful program creation.

## Root Cause
The Program Listing page reads program data from `program_metrics`. During the program creation flow, the new `program` and related `program_user` records were created successfully, but `program_metrics` was not recomputed immediately afterward. Because of that, the listing had no corresponding `program_metrics` row to display for the newly created program.

## Changes Made
- Added program metrics recompute flow after successful program creation
- Added `computeProgramMetricsForProgram(programId)` in `SupabaseApi.ts`
- Triggered program metrics recomputation after `program_user` insertion completes
- Added `compute_program_metrics` under `Functions` in `database.ts`

## Expected Outcome
After creating a new program, it should now appear in the Program Listing page and be searchable without requiring a manual backfill or separate refresh process.

## Notes
This fix depends on the database allowing `compute_program_metrics` to write to `program_metrics` for the executing role.