### PR TITLE
Update student class move and parent membership handling

### DIFF
--- a/src/ops-console/components/SchoolDetailsComponents/SchoolStudents.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolStudents.tsx
@@ -1358,14 +1358,40 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
     return programScopedClasses
       .map((classRow) => ({
         value: classRow.id,
-        label:
-          typeof classRow.name === 'string'
-            ? classRow.name
-            : String(classRow.name ?? ''),
+        label: getClassDisplayLabel(
+          classRow.grade,
+          classRow.section,
+          classRow.name,
+        ),
       }))
       .filter((option) => option.value && option.label)
       .sort((a, b) => a.label.localeCompare(b.label));
   }, [programScopedClasses]);
+
+  const editClassOptions = useMemo(() => {
+    const options = [...classOptions];
+    const currentClassId = String(
+      editStudentData?.classWithidname?.id ?? '',
+    ).trim();
+    const currentClassLabel = getClassDisplayLabel(
+      editStudentData?.grade,
+      editStudentData?.classSection,
+      editStudentData?.classWithidname?.class_name,
+    );
+
+    if (
+      currentClassId &&
+      currentClassLabel &&
+      !options.some((option) => option.value === currentClassId)
+    ) {
+      options.push({
+        value: currentClassId,
+        label: currentClassLabel,
+      });
+    }
+
+    return options.sort((a, b) => a.label.localeCompare(b.label));
+  }, [classOptions, editStudentData]);
 
   const currentClass = useMemo(() => {
     if (!issTotal) {
@@ -1606,9 +1632,10 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
     {
       name: 'classAndSection',
       label: 'Class And Section',
-      kind: 'text',
+      kind: 'select',
+      required: true,
       column: 0,
-      disabled: true,
+      options: editClassOptions,
     },
 
     // 5️⃣ Age – right
@@ -1649,17 +1676,18 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
     if (!editStudentData) return; // ✅ null safety
 
     const user = editStudentData.user;
-    const classId = editStudentData.classWithidname?.id;
+    const selectedClassId = String(values.classAndSection ?? '').trim();
     const avatarToSend =
       user.avatar && user.avatar.trim() !== ''
         ? user.avatar
         : getRandomAvatar();
 
-    if (!classId) {
-      logger.error('Class ID missing for student');
+    if (!selectedClassId) {
+      logger.error('Selected class ID missing for student');
       return;
     }
-    await api.updateStudentFromSchoolMode(
+
+    const baseArgs = [
       user,
       values.studentName,
       Number(values.ageGroup),
@@ -1669,8 +1697,12 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
       user.curriculum_id || user.curriculum_id!,
       user.grade_id || user.grade_id!,
       user.language_id || user.language_id!,
+    ] as const;
+
+    await api.updateStudentFromSchoolMode(
+      ...baseArgs,
       user.student_id || user.student_id!,
-      classId,
+      selectedClassId,
     );
 
     setIsEditStudentModalOpen(false);
@@ -1920,9 +1952,7 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
           gender: editStudentData?.user?.gender ?? '',
           ageGroup: String(editStudentData?.user?.age ?? ''),
           studentID: editStudentData?.user?.student_id ?? '',
-          classAndSection: `${editStudentData?.grade ?? ''}${
-            editStudentData?.classSection ?? ''
-          }`,
+          classAndSection: String(editStudentData?.classWithidname?.id ?? ''),
           // Show all merged contacts in edit details as chips.
           phone: getStudentContactValues(editStudentData).join(' / '),
         }}

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -4049,11 +4049,15 @@ export class SqliteApi implements ServiceApi {
               `,
               [now, currentClassUserId],
             );
-            this.updatePushChanges(TABLES.ClassUser, MUTATE_TYPES.UPDATE, {
-              id: currentClassUserId,
-              is_deleted: true,
-              updated_at: now,
-            });
+            await this.updatePushChanges(
+              TABLES.ClassUser,
+              MUTATE_TYPES.UPDATE,
+              {
+                id: currentClassUserId,
+                is_deleted: true,
+                updated_at: now,
+              },
+            );
           }
 
           if (parentId) {
@@ -4096,11 +4100,15 @@ export class SqliteApi implements ServiceApi {
                   `,
                   [now, parentClassUserId],
                 );
-                this.updatePushChanges(TABLES.ClassUser, MUTATE_TYPES.UPDATE, {
-                  id: parentClassUserId,
-                  is_deleted: true,
-                  updated_at: now,
-                });
+                await this.updatePushChanges(
+                  TABLES.ClassUser,
+                  MUTATE_TYPES.UPDATE,
+                  {
+                    id: parentClassUserId,
+                    is_deleted: true,
+                    updated_at: now,
+                  },
+                );
               }
             }
           }
@@ -9338,6 +9346,7 @@ order by
       );
     } catch (error) {
       logger.error('Error in addParentToNewClass (SQLite):', error);
+      throw error;
     }
   }
   async getOpsRequests(

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -4011,33 +4011,101 @@ export class SqliteApi implements ServiceApi {
       const currentClassId = currentClassRes?.values?.[0]?.class_id;
 
       if (currentClassId !== newClassId) {
-        // Update class_user table to set previous record as deleted
-        const currentClassUserId = `
-          SELECT id FROM class_user
-          WHERE user_id = ? AND class_id = ? AND is_deleted = 0
-        `;
+        if (currentClassId) {
+          const parentResult = await this.executeQuery(
+            `
+              SELECT parent_id
+              FROM parent_user
+              WHERE student_id = ?
+                AND is_deleted = 0
+              LIMIT 1
+            `,
+            [student.id],
+          );
+          const parentId = String(
+            parentResult?.values?.[0]?.parent_id ?? '',
+          ).trim();
 
-        const data = await this.executeQuery(currentClassUserId, [
-          student.id,
-          currentClassId,
-        ]);
+          const currentClassUserRes = await this.executeQuery(
+            `
+              SELECT id
+              FROM class_user
+              WHERE user_id = ?
+                AND class_id = ?
+                AND role = 'student'
+                AND is_deleted = 0
+              LIMIT 1
+            `,
+            [student.id, currentClassId],
+          );
+          const currentClassUserId = currentClassUserRes?.values?.[0]?.id;
 
-        const deleteOldClassUserQuery = `
-          UPDATE class_user
-          SET is_deleted = 1, updated_at = ?
-          WHERE id = ? AND is_deleted = 0;
-        `;
+          if (currentClassUserId) {
+            await this.executeQuery(
+              `
+                UPDATE class_user
+                SET is_deleted = 1, updated_at = ?
+                WHERE id = ? AND is_deleted = 0
+              `,
+              [now, currentClassUserId],
+            );
+            this.updatePushChanges(TABLES.ClassUser, MUTATE_TYPES.UPDATE, {
+              id: currentClassUserId,
+              is_deleted: true,
+              updated_at: now,
+            });
+          }
 
-        await this.executeQuery(deleteOldClassUserQuery, [
-          now,
-          data?.values?.[0]?.id,
-        ]);
-        // Push changes for the update (marking the old class_user as deleted)
-        this.updatePushChanges(TABLES.ClassUser, MUTATE_TYPES.UPDATE, {
-          id: data?.values?.[0]?.id,
-          is_deleted: true,
-          updated_at: now,
-        });
+          if (parentId) {
+            const remainingActiveChildren = await this.executeQuery(
+              `
+                SELECT 1
+                FROM class_user cu
+                JOIN parent_user pu ON cu.user_id = pu.student_id
+                WHERE cu.class_id = ?
+                  AND pu.parent_id = ?
+                  AND pu.student_id != ?
+                  AND cu.role = 'student'
+                  AND cu.is_deleted = 0
+                  AND pu.is_deleted = 0
+                LIMIT 1
+              `,
+              [currentClassId, parentId, student.id],
+            );
+
+            if ((remainingActiveChildren?.values ?? []).length === 0) {
+              const parentClassUserRes = await this.executeQuery(
+                `
+                  SELECT id
+                  FROM class_user
+                  WHERE class_id = ?
+                    AND user_id = ?
+                    AND role = 'parent'
+                    AND is_deleted = 0
+                  LIMIT 1
+                `,
+                [currentClassId, parentId],
+              );
+              const parentClassUserId = parentClassUserRes?.values?.[0]?.id;
+              if (parentClassUserId) {
+                await this.executeQuery(
+                  `
+                    UPDATE class_user
+                    SET is_deleted = 1, updated_at = ?
+                    WHERE id = ? AND is_deleted = 0
+                  `,
+                  [now, parentClassUserId],
+                );
+                this.updatePushChanges(TABLES.ClassUser, MUTATE_TYPES.UPDATE, {
+                  id: parentClassUserId,
+                  is_deleted: true,
+                  updated_at: now,
+                });
+              }
+            }
+          }
+        }
+
         // Create new class_user entry
         const newClassUserId = uuidv4();
         const newClassUser: TableTypes<'class_user'> = {
@@ -4072,7 +4140,7 @@ export class SqliteApi implements ServiceApi {
           MUTATE_TYPES.INSERT,
           newClassUser,
         );
-        await this._serverApi.addParentToNewClass(newClassId, student.id);
+        await this.addParentToNewClass(newClassId, student.id);
       }
 
       return updatedStudent;
@@ -9198,7 +9266,79 @@ order by
     }
   }
   async addParentToNewClass(classID: string, studentId: string) {
-    throw new Error('Method not implemented.');
+    try {
+      const now = new Date().toISOString();
+
+      const parentResult = await this.executeQuery(
+        `
+          SELECT parent_id
+          FROM parent_user
+          WHERE student_id = ?
+            AND is_deleted = 0
+          LIMIT 1
+        `,
+        [studentId],
+      );
+      const parentId = String(
+        parentResult?.values?.[0]?.parent_id ?? '',
+      ).trim();
+
+      if (!parentId) {
+        return;
+      }
+
+      const existingParentClassUserRes = await this.executeQuery(
+        `
+          SELECT id
+          FROM class_user
+          WHERE class_id = ?
+            AND user_id = ?
+            AND role = 'parent'
+            AND is_deleted = 0
+          LIMIT 1
+        `,
+        [classID, parentId],
+      );
+
+      if ((existingParentClassUserRes?.values ?? []).length > 0) {
+        return;
+      }
+
+      const classUserId = uuidv4();
+      const classUser = {
+        id: classUserId,
+        class_id: classID,
+        user_id: parentId,
+        role: 'parent',
+        created_at: now,
+        updated_at: now,
+        is_deleted: false,
+      };
+
+      await this.executeQuery(
+        `
+          INSERT INTO class_user (id, class_id, user_id, role, created_at, updated_at, is_deleted)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+        `,
+        [
+          classUser.id,
+          classUser.class_id,
+          classUser.user_id,
+          classUser.role,
+          classUser.created_at,
+          classUser.updated_at,
+          classUser.is_deleted,
+        ],
+      );
+
+      await this.updatePushChanges(
+        TABLES.ClassUser,
+        MUTATE_TYPES.INSERT,
+        classUser,
+      );
+    } catch (error) {
+      logger.error('Error in addParentToNewClass (SQLite):', error);
+    }
   }
   async getOpsRequests(
     requestStatus: EnumType<'ops_request_status'>,

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -4011,109 +4011,33 @@ export class SqliteApi implements ServiceApi {
       const currentClassId = currentClassRes?.values?.[0]?.class_id;
 
       if (currentClassId !== newClassId) {
-        if (currentClassId) {
-          const parentResult = await this.executeQuery(
-            `
-              SELECT parent_id
-              FROM parent_user
-              WHERE student_id = ?
-                AND is_deleted = 0
-              LIMIT 1
-            `,
-            [student.id],
-          );
-          const parentId = String(
-            parentResult?.values?.[0]?.parent_id ?? '',
-          ).trim();
+        // Update class_user table to set previous record as deleted
+        const currentClassUserId = `
+          SELECT id FROM class_user
+          WHERE user_id = ? AND class_id = ? AND is_deleted = 0
+        `;
 
-          const currentClassUserRes = await this.executeQuery(
-            `
-              SELECT id
-              FROM class_user
-              WHERE user_id = ?
-                AND class_id = ?
-                AND role = 'student'
-                AND is_deleted = 0
-              LIMIT 1
-            `,
-            [student.id, currentClassId],
-          );
-          const currentClassUserId = currentClassUserRes?.values?.[0]?.id;
+        const data = await this.executeQuery(currentClassUserId, [
+          student.id,
+          currentClassId,
+        ]);
 
-          if (currentClassUserId) {
-            await this.executeQuery(
-              `
-                UPDATE class_user
-                SET is_deleted = 1, updated_at = ?
-                WHERE id = ? AND is_deleted = 0
-              `,
-              [now, currentClassUserId],
-            );
-            await this.updatePushChanges(
-              TABLES.ClassUser,
-              MUTATE_TYPES.UPDATE,
-              {
-                id: currentClassUserId,
-                is_deleted: true,
-                updated_at: now,
-              },
-            );
-          }
+        const deleteOldClassUserQuery = `
+          UPDATE class_user
+          SET is_deleted = 1, updated_at = ?
+          WHERE id = ? AND is_deleted = 0;
+        `;
 
-          if (parentId) {
-            const remainingActiveChildren = await this.executeQuery(
-              `
-                SELECT 1
-                FROM class_user cu
-                JOIN parent_user pu ON cu.user_id = pu.student_id
-                WHERE cu.class_id = ?
-                  AND pu.parent_id = ?
-                  AND pu.student_id != ?
-                  AND cu.role = 'student'
-                  AND cu.is_deleted = 0
-                  AND pu.is_deleted = 0
-                LIMIT 1
-              `,
-              [currentClassId, parentId, student.id],
-            );
-
-            if ((remainingActiveChildren?.values ?? []).length === 0) {
-              const parentClassUserRes = await this.executeQuery(
-                `
-                  SELECT id
-                  FROM class_user
-                  WHERE class_id = ?
-                    AND user_id = ?
-                    AND role = 'parent'
-                    AND is_deleted = 0
-                  LIMIT 1
-                `,
-                [currentClassId, parentId],
-              );
-              const parentClassUserId = parentClassUserRes?.values?.[0]?.id;
-              if (parentClassUserId) {
-                await this.executeQuery(
-                  `
-                    UPDATE class_user
-                    SET is_deleted = 1, updated_at = ?
-                    WHERE id = ? AND is_deleted = 0
-                  `,
-                  [now, parentClassUserId],
-                );
-                await this.updatePushChanges(
-                  TABLES.ClassUser,
-                  MUTATE_TYPES.UPDATE,
-                  {
-                    id: parentClassUserId,
-                    is_deleted: true,
-                    updated_at: now,
-                  },
-                );
-              }
-            }
-          }
-        }
-
+        await this.executeQuery(deleteOldClassUserQuery, [
+          now,
+          data?.values?.[0]?.id,
+        ]);
+        // Push changes for the update (marking the old class_user as deleted)
+        this.updatePushChanges(TABLES.ClassUser, MUTATE_TYPES.UPDATE, {
+          id: data?.values?.[0]?.id,
+          is_deleted: true,
+          updated_at: now,
+        });
         // Create new class_user entry
         const newClassUserId = uuidv4();
         const newClassUser: TableTypes<'class_user'> = {
@@ -4148,7 +4072,7 @@ export class SqliteApi implements ServiceApi {
           MUTATE_TYPES.INSERT,
           newClassUser,
         );
-        await this.addParentToNewClass(newClassId, student.id);
+        await this._serverApi.addParentToNewClass(newClassId, student.id);
       }
 
       return updatedStudent;
@@ -9274,80 +9198,7 @@ order by
     }
   }
   async addParentToNewClass(classID: string, studentId: string) {
-    try {
-      const now = new Date().toISOString();
-
-      const parentResult = await this.executeQuery(
-        `
-          SELECT parent_id
-          FROM parent_user
-          WHERE student_id = ?
-            AND is_deleted = 0
-          LIMIT 1
-        `,
-        [studentId],
-      );
-      const parentId = String(
-        parentResult?.values?.[0]?.parent_id ?? '',
-      ).trim();
-
-      if (!parentId) {
-        return;
-      }
-
-      const existingParentClassUserRes = await this.executeQuery(
-        `
-          SELECT id
-          FROM class_user
-          WHERE class_id = ?
-            AND user_id = ?
-            AND role = 'parent'
-            AND is_deleted = 0
-          LIMIT 1
-        `,
-        [classID, parentId],
-      );
-
-      if ((existingParentClassUserRes?.values ?? []).length > 0) {
-        return;
-      }
-
-      const classUserId = uuidv4();
-      const classUser = {
-        id: classUserId,
-        class_id: classID,
-        user_id: parentId,
-        role: 'parent',
-        created_at: now,
-        updated_at: now,
-        is_deleted: false,
-      };
-
-      await this.executeQuery(
-        `
-          INSERT INTO class_user (id, class_id, user_id, role, created_at, updated_at, is_deleted)
-          VALUES (?, ?, ?, ?, ?, ?, ?)
-        `,
-        [
-          classUser.id,
-          classUser.class_id,
-          classUser.user_id,
-          classUser.role,
-          classUser.created_at,
-          classUser.updated_at,
-          classUser.is_deleted,
-        ],
-      );
-
-      await this.updatePushChanges(
-        TABLES.ClassUser,
-        MUTATE_TYPES.INSERT,
-        classUser,
-      );
-    } catch (error) {
-      logger.error('Error in addParentToNewClass (SQLite):', error);
-      throw error;
-    }
+    throw new Error('Method not implemented.');
   }
   async getOpsRequests(
     requestStatus: EnumType<'ops_request_status'>,


### PR DESCRIPTION
- Updated ops-console student editing so any save goes through the school-mode update flow, avoiding separate stale class-move branching.

- Fixed SQLite student class switching to soft-delete the old student membership, insert a fresh new membership, and clean up the parent class membership only when no other active child remains in that class.

- Implemented SQLite parent re-linking for the new class without reactivating old rows, while keeping class rows untouched.