### PR TITLE
fix: Support cancelled_by_user and IST formatting

### DIFF
--- a/src/ops-console/components/campaignsOverview/CampaignsOverviewLogic.test.ts
+++ b/src/ops-console/components/campaignsOverview/CampaignsOverviewLogic.test.ts
@@ -189,6 +189,9 @@ describe('CampaignsOverviewLogic', () => {
           start_date: '2026-05-25',
           end_date: '2026-05-30',
           updated_at: '2026-05-25T11:39:22.148553+00:00',
+          cancelled_by_user: {
+            name: 'Ops Admin',
+          },
           manager: {
             name: 'Teacher 11 22',
           },
@@ -220,8 +223,8 @@ describe('CampaignsOverviewLogic', () => {
         'Active Participants': 1,
       },
       cancellationDetails: {
-        canceledBy: 'Teacher 11 22',
-        canceledOn: 'May 25, 2026, 11:39 AM',
+        canceledBy: 'Ops Admin',
+        canceledOn: 'May 25, 2026, 5:09 PM',
         messageToAdmin: '--',
       },
     });

--- a/src/ops-console/components/campaignsOverview/CampaignsOverviewLogic.ts
+++ b/src/ops-console/components/campaignsOverview/CampaignsOverviewLogic.ts
@@ -67,6 +67,7 @@ export interface CampaignsOverviewApiCampaign {
   end_date?: string | null;
   updated_at?: string | null;
   campaign_status?: CampaignStatus | null;
+  cancelled_by_user?: CampaignsOverviewApiPerson | null;
   manager?: CampaignsOverviewApiPerson | null;
   program?: CampaignsOverviewApiProgram | null;
 }
@@ -94,6 +95,7 @@ const STATUS_KEY = 'status';
 const INFO_SUFFIX = 'Info';
 const CAMPAIGN_DURATION_KEY = 'campaign duration';
 const DAYS_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
+const INDIA_TIME_ZONE = 'Asia/Kolkata';
 const MONTH_NAMES = [
   'Jan',
   'Feb',
@@ -222,7 +224,7 @@ const formatDateTime = (dateText?: string | null): string => {
     hour: 'numeric',
     minute: '2-digit',
     hour12: true,
-    timeZone: 'UTC',
+    timeZone: INDIA_TIME_ZONE,
   }).format(date);
 };
 
@@ -416,7 +418,7 @@ export const buildCampaignsOverviewViewModel = (
         metrics?.active_students ?? response?.data?.avgWeeklyActiveUsers,
     },
     cancellationDetails: {
-      canceledBy: formatValue(campaign?.manager?.name),
+      canceledBy: formatValue(campaign?.cancelled_by_user?.name),
       canceledOn: formatDateTime(campaign?.updated_at),
       messageToAdmin: formatValue(campaign?.comments),
     },

--- a/src/services/api/ServiceApi.ts
+++ b/src/services/api/ServiceApi.ts
@@ -401,6 +401,7 @@ export type CampaignAssignmentOptions = {
 export type CampaignListingItem = {
   campaignId: string;
   campaign: TableTypes<'campaign'> & {
+    cancelled_by_user?: TableTypes<'user'> | TableTypes<'user'>[] | null;
     manager?: TableTypes<'user'> | TableTypes<'user'>[] | null;
     program?: TableTypes<'program'> | TableTypes<'program'>[] | null;
   };

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -352,6 +352,7 @@ type CampaignListingAudienceRow = Pick<
 };
 
 type CampaignListingQueryRow = TableTypes<'campaign'> & {
+  cancelled_by_user?: TableTypes<'user'> | TableTypes<'user'>[] | null;
   manager?: TableTypes<'user'> | TableTypes<'user'>[] | null;
   program?: TableTypes<'program'> | TableTypes<'program'>[] | null;
   target_audience?:
@@ -9985,7 +9986,7 @@ export class SupabaseApi implements ServiceApi {
       const nativeSortColumn = CAMPAIGN_LISTING_NATIVE_SORT_COLUMNS[orderBy];
       const shouldUseDatabasePagination =
         !isFieldCoordinator && Boolean(nativeSortColumn);
-      const campaignListingSelect = `*, manager:manager_id(*), program:program_id(*),
+      const campaignListingSelect = `*, cancelled_by_user:cancelled_by(*), manager:manager_id(*), program:program_id(*),
         target_audience:target_audience_id(
           id,
           is_all_schools,
@@ -10112,11 +10113,15 @@ export class SupabaseApi implements ServiceApi {
       return;
     }
 
+    const {
+      data: { user },
+    } = await this.supabase.auth.getUser();
     const timestamp = new Date().toISOString();
     const { error } = await this.supabase
       .from('campaign')
       .update({
         campaign_status: CAMPAIGN_STATUS.INACTIVE,
+        cancelled_by: user?.id ?? null,
         comments: trimmedReason,
         updated_at: timestamp,
       })

--- a/src/services/api/campaignListingHelpers.ts
+++ b/src/services/api/campaignListingHelpers.ts
@@ -143,6 +143,7 @@ export const sortCampaignListingItems = (
 
 export const mapCampaignListingItem = (
   row: TableTypes<'campaign'> & {
+    cancelled_by_user?: TableTypes<'user'> | TableTypes<'user'>[] | null;
     manager?: TableTypes<'user'> | TableTypes<'user'>[] | null;
     program?: TableTypes<'program'> | TableTypes<'program'>[] | null;
   },
@@ -396,6 +397,9 @@ export const mapCampaignListingItemToOverviewData = (
     // Reuse listing payload data for overview so we do not issue a second API request on row click.
     campaign: {
       ...campaign.campaign,
+      cancelled_by_user: getSingleCampaignRelationValue(
+        campaign.campaign.cancelled_by_user,
+      ),
       manager: getSingleCampaignRelationValue(campaign.campaign.manager),
       program: getSingleCampaignRelationValue(campaign.campaign.program),
     },

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -584,6 +584,7 @@ export type Database = {
           campaign_status:
             | Database['public']['Enums']['campaign_status']
             | null;
+          cancelled_by: string | null;
           comments: string | null;
           created_at: string | null;
           end_date: string;
@@ -604,6 +605,7 @@ export type Database = {
           campaign_status?:
             | Database['public']['Enums']['campaign_status']
             | null;
+          cancelled_by?: string | null;
           comments?: string | null;
           created_at?: string | null;
           end_date: string;
@@ -624,6 +626,7 @@ export type Database = {
           campaign_status?:
             | Database['public']['Enums']['campaign_status']
             | null;
+          cancelled_by?: string | null;
           comments?: string | null;
           created_at?: string | null;
           end_date?: string;


### PR DESCRIPTION
Add support for cancelled_by_user across the stack and switch date formatting to Asia/Kolkata. Changes include: add cancelled_by_user types in ServiceApi, SupabaseApi, campaignListingHelpers and database types; include cancelled_by_user in Supabase campaign select and set cancelled_by to the current user when cancelling a campaign; map cancelled_by_user into campaign overview and use it for cancellationDetails.canceledBy; update tests to reflect cancelled_by_user and IST timestamp formatting.