### PR TITLE
fix: Fetch cancelled_by_user separately in campaigns

### DIFF
--- a/src/ops-console/components/campaignsOverview/CampaignsOverview.tsx
+++ b/src/ops-console/components/campaignsOverview/CampaignsOverview.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import CampaignAssignmentTab from '../../pages/CampaignAssignmentTab';
+import { ServiceConfig } from '../../../services/ServiceConfig';
+import logger from '../../../utility/logger';
 import CampaignMessages from '../campaignMessages/CampaignMessages';
 import './CampaignsOverview.css';
 import CampaignsOverviewHeaderBar from './CampaignsOverviewHeaderBar';
@@ -39,13 +41,16 @@ const CampaignsOverview: React.FC<CampaignsOverviewProps> = ({
 }) => {
   const history = useHistory();
   const [selectedTab, setSelectedTab] = useState(activeTab);
-  const campaignViewModel =
-    buildCampaignsOverviewViewModel(campaignOverviewData);
   const resolvedCampaignId = [
     campaignId,
     campaignOverviewData?.data?.campaignId,
     campaignOverviewData?.data?.dashboardMetrics?.campaign_id,
   ].find((id): id is string => typeof id === 'string' && id.trim().length > 0);
+  const [resolvedCampaignOverviewData, setResolvedCampaignOverviewData] =
+    useState(campaignOverviewData);
+  const campaignViewModel = buildCampaignsOverviewViewModel(
+    resolvedCampaignOverviewData,
+  );
 
   useEffect(() => {
     document.body.classList.add('campaigns-overview-active');
@@ -53,6 +58,43 @@ const CampaignsOverview: React.FC<CampaignsOverviewProps> = ({
       document.body.classList.remove('campaigns-overview-active');
     };
   }, []);
+
+  useEffect(() => {
+    setResolvedCampaignOverviewData(campaignOverviewData);
+  }, [campaignOverviewData]);
+
+  useEffect(() => {
+    const loadCampaignCancellationDetails = async () => {
+      if (!resolvedCampaignId || !campaignOverviewData) {
+        return;
+      }
+
+      try {
+        const cancellationData =
+          await ServiceConfig.getI().apiHandler.getCampaignCancellationDetails(
+            resolvedCampaignId,
+          );
+
+        setResolvedCampaignOverviewData((currentData) => {
+          if (!currentData?.data) {
+            return currentData;
+          }
+
+          return {
+            ...currentData,
+            data: {
+              ...currentData.data,
+              cancellationData,
+            },
+          };
+        });
+      } catch (error) {
+        logger.error('Error loading campaign cancellation details:', error);
+      }
+    };
+
+    void loadCampaignCancellationDetails();
+  }, [campaignOverviewData, resolvedCampaignId]);
 
   const handleTabClick = (tab: string): void => {
     setSelectedTab(tab);
@@ -81,7 +123,9 @@ const CampaignsOverview: React.FC<CampaignsOverviewProps> = ({
       <CampaignsOverviewHeaderBar
         title={title}
         breadcrumb={
-          campaignOverviewData ? campaignViewModel.breadcrumb : breadcrumb
+          resolvedCampaignOverviewData
+            ? campaignViewModel.breadcrumb
+            : breadcrumb
         }
         tabs={tabs}
         activeTab={selectedTab}

--- a/src/ops-console/components/campaignsOverview/CampaignsOverview.tsx
+++ b/src/ops-console/components/campaignsOverview/CampaignsOverview.tsx
@@ -8,6 +8,7 @@ import './CampaignsOverview.css';
 import CampaignsOverviewHeaderBar from './CampaignsOverviewHeaderBar';
 import {
   buildCampaignsOverviewViewModel,
+  CAMPAIGN_LISTING_STATUS,
   CampaignsOverviewApiResponse,
   DEFAULT_CAMPAIGNS_OVERVIEW_BREADCRUMB,
   DEFAULT_CAMPAIGNS_OVERVIEW_TABS,
@@ -65,7 +66,11 @@ const CampaignsOverview: React.FC<CampaignsOverviewProps> = ({
 
   useEffect(() => {
     const loadCampaignCancellationDetails = async () => {
-      if (!resolvedCampaignId || !campaignOverviewData) {
+      if (
+        !resolvedCampaignId ||
+        !campaignOverviewData ||
+        campaignOverviewData.data?.status !== CAMPAIGN_LISTING_STATUS.CANCELLED
+      ) {
         return;
       }
 

--- a/src/ops-console/components/campaignsOverview/CampaignsOverviewLogic.test.ts
+++ b/src/ops-console/components/campaignsOverview/CampaignsOverviewLogic.test.ts
@@ -188,10 +188,6 @@ describe('CampaignsOverviewLogic', () => {
           objective: 'homework_campaign',
           start_date: '2026-05-25',
           end_date: '2026-05-30',
-          updated_at: '2026-05-25T11:39:22.148553+00:00',
-          cancelled_by_user: {
-            name: 'Ops Admin',
-          },
           manager: {
             name: 'Teacher 11 22',
           },
@@ -200,6 +196,11 @@ describe('CampaignsOverviewLogic', () => {
             institutes_count: null,
             students_count: null,
           },
+        },
+        cancellationData: {
+          canceledBy: 'Ops Admin',
+          canceledOn: '2026-05-25T11:39:22.148553+00:00',
+          messageToAdmin: null,
         },
       },
     };

--- a/src/ops-console/components/campaignsOverview/CampaignsOverviewLogic.ts
+++ b/src/ops-console/components/campaignsOverview/CampaignsOverviewLogic.ts
@@ -40,10 +40,17 @@ export interface CampaignsOverviewApiResponse {
 export interface CampaignsOverviewApiData {
   campaignId?: string | null;
   campaign?: CampaignsOverviewApiCampaign | null;
+  cancellationData?: CampaignsOverviewApiCancellationData | null;
   dashboardMetrics?: CampaignsOverviewDashboardMetrics | null;
   avgWeeklyActiveUsers?: number | null;
   avgWeeklyEngagementTimeMinutes?: number | null;
   status?: CampaignListingStatus | string | null;
+}
+
+export interface CampaignsOverviewApiCancellationData {
+  canceledBy?: string | null;
+  canceledOn?: string | null;
+  messageToAdmin?: string | null;
 }
 
 export interface CampaignsOverviewDashboardMetrics {
@@ -67,7 +74,6 @@ export interface CampaignsOverviewApiCampaign {
   end_date?: string | null;
   updated_at?: string | null;
   campaign_status?: CampaignStatus | null;
-  cancelled_by_user?: CampaignsOverviewApiPerson | null;
   manager?: CampaignsOverviewApiPerson | null;
   program?: CampaignsOverviewApiProgram | null;
 }
@@ -377,6 +383,7 @@ export const buildCampaignsOverviewViewModel = (
   response?: CampaignsOverviewApiResponse,
 ): CampaignsOverviewViewModel => {
   const campaign = response?.data?.campaign;
+  const cancellationData = response?.data?.cancellationData;
   const metrics = response?.data?.dashboardMetrics;
   const program = campaign?.program;
   const status = normalizeCampaignListingStatus(
@@ -418,9 +425,9 @@ export const buildCampaignsOverviewViewModel = (
         metrics?.active_students ?? response?.data?.avgWeeklyActiveUsers,
     },
     cancellationDetails: {
-      canceledBy: formatValue(campaign?.cancelled_by_user?.name),
-      canceledOn: formatDateTime(campaign?.updated_at),
-      messageToAdmin: formatValue(campaign?.comments),
+      canceledBy: formatValue(cancellationData?.canceledBy),
+      canceledOn: formatDateTime(cancellationData?.canceledOn),
+      messageToAdmin: formatValue(cancellationData?.messageToAdmin),
     },
   };
 };

--- a/src/services/api/ApiHandler.ts
+++ b/src/services/api/ApiHandler.ts
@@ -1,6 +1,7 @@
 import {
   AssignmentCartData,
   AssignmentDateRangeData,
+  CampaignCancellationDetails,
   CampaignAssignmentOptions,
   CampaignAssignmentOptionsParams,
   CampaignListingItem,
@@ -1640,6 +1641,13 @@ export class ApiHandler implements ServiceApi {
   ): Promise<void> {
     return await this.s.cancelCampaign(campaignId, reason);
   }
+
+  public async getCampaignCancellationDetails(
+    campaignId: string,
+  ): Promise<CampaignCancellationDetails | null> {
+    return await this.s.getCampaignCancellationDetails(campaignId);
+  }
+
   public async getCampaignAssignments(
     campaignId: string,
     filters: CampaignAssignmentFilters,

--- a/src/services/api/ServiceApi.ts
+++ b/src/services/api/ServiceApi.ts
@@ -401,7 +401,6 @@ export type CampaignAssignmentOptions = {
 export type CampaignListingItem = {
   campaignId: string;
   campaign: TableTypes<'campaign'> & {
-    cancelled_by_user?: TableTypes<'user'> | TableTypes<'user'>[] | null;
     manager?: TableTypes<'user'> | TableTypes<'user'>[] | null;
     program?: TableTypes<'program'> | TableTypes<'program'>[] | null;
   };
@@ -411,6 +410,12 @@ export type CampaignListingItem = {
   avgWeeklyActiveUsers: number | null;
   avgWeeklyEngagementTimeMinutes: number | null;
   status: CampaignListingStatus;
+};
+
+export type CampaignCancellationDetails = {
+  canceledBy: string | null;
+  canceledOn: string | null;
+  messageToAdmin: string | null;
 };
 
 export type CampaignListingParams = {
@@ -2450,6 +2455,13 @@ export interface ServiceApi {
    * The reason is supplied by the UI for cancellation auditing and validation.
    */
   cancelCampaign(campaignId: string, reason: string): Promise<void>;
+
+  /**
+   * Fetches campaign cancellation details for a given campaign ID.
+   */
+  getCampaignCancellationDetails(
+    campaignId: string,
+  ): Promise<CampaignCancellationDetails | null>;
   /**
    * Fetches campaign assignments for a given campaign ID, with optional filters for school, grade, subject, chapter, and lesson.
    * @param {string} campaignId - The ID of the campaign to fetch assignments for.

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -101,6 +101,7 @@ import {
   AssignmentBatchGroupRow,
   AssignmentCartData,
   AssignmentDateRangeData,
+  CampaignCancellationDetails,
   CampaignAssignmentOptions,
   CampaignAssignmentOptionsParams,
   CampaignListingItem,
@@ -8054,6 +8055,13 @@ order by
   async cancelCampaign(campaignId: string, reason: string): Promise<void> {
     return await this._serverApi.cancelCampaign(campaignId, reason);
   }
+
+  async getCampaignCancellationDetails(
+    campaignId: string,
+  ): Promise<CampaignCancellationDetails | null> {
+    return await this._serverApi.getCampaignCancellationDetails(campaignId);
+  }
+
   async getCampaignAssignments(
     campaignId: string,
     filters: CampaignAssignmentFilters,

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -9986,7 +9986,7 @@ export class SupabaseApi implements ServiceApi {
       const nativeSortColumn = CAMPAIGN_LISTING_NATIVE_SORT_COLUMNS[orderBy];
       const shouldUseDatabasePagination =
         !isFieldCoordinator && Boolean(nativeSortColumn);
-      const campaignListingSelect = `*, cancelled_by_user:cancelled_by(*), manager:manager_id(*), program:program_id(*),
+      const campaignListingSelect = `*, manager:manager_id(*), program:program_id(*),
         target_audience:target_audience_id(
           id,
           is_all_schools,
@@ -10030,11 +10030,47 @@ export class SupabaseApi implements ServiceApi {
       }
 
       const mappedCampaigns = (data ?? []) as CampaignListingQueryRow[];
+      const cancelledByIds = Array.from(
+        new Set(
+          mappedCampaigns
+            .map((campaign) => campaign.cancelled_by)
+            .filter((id): id is string => Boolean(id)),
+        ),
+      );
+      let campaignsWithCancelledByUser = mappedCampaigns;
+
+      if (cancelledByIds.length > 0) {
+        const { data: cancelledByUsers, error: cancelledByUsersError } =
+          await supabase
+            .from('user')
+            .select('*')
+            .in('id', cancelledByIds)
+            .eq('is_deleted', false);
+
+        if (cancelledByUsersError) {
+          logger.error(
+            'Error fetching campaign cancelled by users:',
+            cancelledByUsersError,
+          );
+        } else {
+          const cancelledByUserMap = new Map(
+            (cancelledByUsers ?? []).map((user) => [user.id, user]),
+          );
+
+          campaignsWithCancelledByUser = mappedCampaigns.map((campaign) => ({
+            ...campaign,
+            cancelled_by_user: campaign.cancelled_by
+              ? (cancelledByUserMap.get(campaign.cancelled_by) ?? null)
+              : null,
+          }));
+        }
+      }
+
       // Apply field-coordinator visibility after the base campaign query so audience links can be inspected.
       const visibleCampaigns = shouldUseDatabasePagination
-        ? mappedCampaigns
+        ? campaignsWithCancelledByUser
         : isFieldCoordinator
-          ? mappedCampaigns.filter((campaign) => {
+          ? campaignsWithCancelledByUser.filter((campaign) => {
               const targetAudience = getSingleRelationValue(
                 campaign.target_audience,
               );

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -80,6 +80,7 @@ import {
   CampaignSchoolOption,
   CampaignSetupOptions,
   ClassMetricsForClassListingRow,
+  CampaignCancellationDetails,
   CreateCampaignSetupPayload,
   CreateCampaignSetupResult,
   LaunchCampaignPayload,
@@ -352,7 +353,6 @@ type CampaignListingAudienceRow = Pick<
 };
 
 type CampaignListingQueryRow = TableTypes<'campaign'> & {
-  cancelled_by_user?: TableTypes<'user'> | TableTypes<'user'>[] | null;
   manager?: TableTypes<'user'> | TableTypes<'user'>[] | null;
   program?: TableTypes<'program'> | TableTypes<'program'>[] | null;
   target_audience?:
@@ -10030,47 +10030,12 @@ export class SupabaseApi implements ServiceApi {
       }
 
       const mappedCampaigns = (data ?? []) as CampaignListingQueryRow[];
-      const cancelledByIds = Array.from(
-        new Set(
-          mappedCampaigns
-            .map((campaign) => campaign.cancelled_by)
-            .filter((id): id is string => Boolean(id)),
-        ),
-      );
-      let campaignsWithCancelledByUser = mappedCampaigns;
-
-      if (cancelledByIds.length > 0) {
-        const { data: cancelledByUsers, error: cancelledByUsersError } =
-          await supabase
-            .from('user')
-            .select('*')
-            .in('id', cancelledByIds)
-            .eq('is_deleted', false);
-
-        if (cancelledByUsersError) {
-          logger.error(
-            'Error fetching campaign cancelled by users:',
-            cancelledByUsersError,
-          );
-        } else {
-          const cancelledByUserMap = new Map(
-            (cancelledByUsers ?? []).map((user) => [user.id, user]),
-          );
-
-          campaignsWithCancelledByUser = mappedCampaigns.map((campaign) => ({
-            ...campaign,
-            cancelled_by_user: campaign.cancelled_by
-              ? (cancelledByUserMap.get(campaign.cancelled_by) ?? null)
-              : null,
-          }));
-        }
-      }
 
       // Apply field-coordinator visibility after the base campaign query so audience links can be inspected.
       const visibleCampaigns = shouldUseDatabasePagination
-        ? campaignsWithCancelledByUser
+        ? mappedCampaigns
         : isFieldCoordinator
-          ? campaignsWithCancelledByUser.filter((campaign) => {
+          ? mappedCampaigns.filter((campaign) => {
               const targetAudience = getSingleRelationValue(
                 campaign.target_audience,
               );
@@ -10168,6 +10133,57 @@ export class SupabaseApi implements ServiceApi {
       logger.error('Error cancelling campaign:', error);
       throw error;
     }
+  }
+
+  async getCampaignCancellationDetails(
+    campaignId: string,
+  ): Promise<CampaignCancellationDetails | null> {
+    if (!this.supabase || !campaignId) {
+      return null;
+    }
+
+    const { data, error } = await this.supabase
+      .from('campaign')
+      .select('updated_at, comments, cancelled_by')
+      .eq('id', campaignId)
+      .eq('is_deleted', false)
+      .maybeSingle();
+
+    if (error) {
+      logger.error('Error fetching campaign cancellation details:', error);
+      return null;
+    }
+
+    if (!data) {
+      return null;
+    }
+
+    let canceledBy: string | null = null;
+
+    if (data.cancelled_by) {
+      const { data: cancelledByUser, error: cancelledByUserError } =
+        await this.supabase
+          .from('user')
+          .select('name')
+          .eq('id', data.cancelled_by)
+          .eq('is_deleted', false)
+          .maybeSingle();
+
+      if (cancelledByUserError) {
+        logger.error(
+          'Error fetching campaign cancelled by user:',
+          cancelledByUserError,
+        );
+      } else {
+        canceledBy = cancelledByUser?.name ?? null;
+      }
+    }
+
+    return {
+      canceledBy,
+      canceledOn: data.updated_at ?? null,
+      messageToAdmin: data.comments ?? null,
+    };
   }
 
   async getCampaignAudienceOptions(

--- a/src/services/api/campaignListingHelpers.ts
+++ b/src/services/api/campaignListingHelpers.ts
@@ -143,7 +143,6 @@ export const sortCampaignListingItems = (
 
 export const mapCampaignListingItem = (
   row: TableTypes<'campaign'> & {
-    cancelled_by_user?: TableTypes<'user'> | TableTypes<'user'>[] | null;
     manager?: TableTypes<'user'> | TableTypes<'user'>[] | null;
     program?: TableTypes<'program'> | TableTypes<'program'>[] | null;
   },
@@ -394,12 +393,8 @@ export const mapCampaignListingItemToOverviewData = (
 ): CampaignsOverviewApiResponse => ({
   data: {
     campaignId: campaign.campaignId,
-    // Reuse listing payload data for overview so we do not issue a second API request on row click.
     campaign: {
       ...campaign.campaign,
-      cancelled_by_user: getSingleCampaignRelationValue(
-        campaign.campaign.cancelled_by_user,
-      ),
       manager: getSingleCampaignRelationValue(campaign.campaign.manager),
       program: getSingleCampaignRelationValue(campaign.campaign.program),
     },


### PR DESCRIPTION
Move cancelled_by_user fetching from nested select to a separate query with manual mapping. This reduces query complexity and improves efficiency when fetching campaign listings.