### PR TITLE
Fix missing Add Subject after OPS to kids-mode student creation

### DIFF
--- a/src/components/profileDetails/ProfileDetails.test.tsx
+++ b/src/components/profileDetails/ProfileDetails.test.tsx
@@ -59,6 +59,7 @@ jest.mock('../../analytics/profileClickUtil', () => ({
 const mockApi = {
   getAllLanguages: jest.fn(),
   getParentStudentProfiles: jest.fn(),
+  getSchoolsForUser: jest.fn(),
   createProfile: jest.fn(),
   updateStudent: jest.fn(),
   createAutoProfile: jest.fn(),
@@ -120,6 +121,7 @@ beforeEach(() => {
   ]);
 
   mockApi.getParentStudentProfiles.mockResolvedValue([]);
+  mockApi.getSchoolsForUser.mockResolvedValue([]);
   mockAuth.getCurrentUser.mockResolvedValue({ id: 'user-1' });
 
   (Util.getCurrentStudent as jest.Mock).mockReturnValue(null);

--- a/src/components/profileDetails/ProfileDetails.tsx
+++ b/src/components/profileDetails/ProfileDetails.tsx
@@ -18,6 +18,7 @@ import {
   GENDER,
   LANGUAGE,
   LATEST_TC_VERSION,
+  MODES,
   PAGES,
   PROFILE_DETAILS_GROWTHBOOK_VARIATION,
   TableTypes,
@@ -225,6 +226,13 @@ const ProfileDetails = () => {
     const { className, schoolName } = await Util.fetchCurrentClassAndSchool();
     setClassName(className);
     setSchoolName(schoolName);
+  };
+
+  const normalizeModeBeforeHomeNavigation = async () => {
+    const currMode = await schoolUtil.getCurrMode();
+    if (currMode === MODES.TEACHER) {
+      await schoolUtil.setCurrMode(MODES.PARENT);
+    }
   };
 
   const lockOrientation = () => {
@@ -444,6 +452,7 @@ const ProfileDetails = () => {
       setGbUpdated(true);
 
       await Util.ensureLidoCommonAudioForStudent(student);
+      await normalizeModeBeforeHomeNavigation();
       history.replace(PAGES.HOME);
     } catch (err) {
       logger.error('Error saving profile:', err);
@@ -498,6 +507,7 @@ const ProfileDetails = () => {
         action_type: ACTION_TYPES.PROFILE_CREATED,
       });
 
+      await normalizeModeBeforeHomeNavigation();
       history.replace(PAGES.HOME);
     } catch (err) {
       logger.error('Error skipping profile:', err);

--- a/src/components/profileDetails/ProfileDetails.tsx
+++ b/src/components/profileDetails/ProfileDetails.tsx
@@ -229,9 +229,13 @@ const ProfileDetails = () => {
   };
 
   const normalizeModeBeforeHomeNavigation = async () => {
-    const currMode = await schoolUtil.getCurrMode();
-    if (currMode === MODES.TEACHER) {
-      await schoolUtil.setCurrMode(MODES.PARENT);
+    try {
+      const currMode = await schoolUtil.getCurrMode();
+      if (currMode === MODES.TEACHER) {
+        await schoolUtil.setCurrMode(MODES.PARENT);
+      }
+    } catch (error) {
+      logger.error('Failed to normalize mode before home navigation:', error);
     }
   };
 


### PR DESCRIPTION
# Summary

This PR fixes a mode handoff issue in the student profile creation flow.

When a user entered the Kids App flow from the OPS to Teacher path and created a new student profile, the app could navigate to `/home` while still retaining `TEACHER` mode. Because the Subjects page only shows `Add Subject` for eligible parent/home modes, the button did not appear on the first visit.

This change normalizes the mode before navigating to the student home screen after profile creation, so the newly created student enters the expected parent-style flow and the `Add Subject` option is shown immediately.

# Root Cause

The create-student flow navigated directly from `ProfileDetails` to `/home` without correcting a stale `TEACHER` mode inherited from the OPS to Teacher switch path.

As a result:
- the student was correctly treated as unlinked
- but the Subjects page still read `currMode` as `TEACHER`
- so `canAddSubject` evaluated to `false`

# Fix

- Normalize stale `TEACHER` mode to `PARENT` before navigating to `PAGES.HOME`
- Apply the same behavior in both profile creation paths:
  - Save new profile
  - Skip / auto-create profile

# Impact

- Newly created students from the OPS to Kids App flow now land in the correct mode
- `Add Subject` is shown on the first visit to the Subjects page
- Existing teacher, school, and parent flows remain unchanged unless the stale mode is specifically `TEACHER`