### PR TITLE
fix: Add loading screen for web Google login

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,20 +25,47 @@ import {
   createGrowthBookClient,
   initializeGrowthBook,
 } from './startup/growthbookClient';
-import { initializeNativeRuntime } from './startup/nativeRuntime';
+import {
+  initializeNativeRuntime,
+  isNativePlatform,
+} from './startup/nativeRuntime';
 import { initializePlatformSetup } from './startup/platformSetup';
 import { createAppRoot, renderRoot } from './startup/renderRoot';
 import { bootstrapServicesAndRender } from './startup/serviceBootstrap';
+import Loading from './components/Loading';
+import {
+  clearWebGoogleLoginPending,
+  isWebGoogleLoginPending,
+} from './services/auth/webGoogleLoginLoading';
 initializeErrorReporting();
 initializePlatformSetup();
 
 const root = createAppRoot();
 const growthbook = createGrowthBookClient();
+const shouldShowWebGoogleLoginLoading =
+  !isNativePlatform && isWebGoogleLoginPending();
+let hasRenderedApp = false;
+let webGoogleLoginLoadingTimeout: number | undefined;
+
+const renderApp = () => {
+  if (hasRenderedApp) return;
+  hasRenderedApp = true;
+
+  if (webGoogleLoginLoadingTimeout !== undefined) {
+    window.clearTimeout(webGoogleLoginLoadingTimeout);
+  }
+  if (shouldShowWebGoogleLoginLoading) clearWebGoogleLoginPending();
+
+  renderRoot(root, growthbook);
+};
+
+if (shouldShowWebGoogleLoginLoading) {
+  root.render(<Loading isLoading={true} />);
+  webGoogleLoginLoadingTimeout = window.setTimeout(renderApp, 30_000);
+}
 
 void initializeGrowthBook(growthbook);
 initializeNativeRuntime();
 
-bootstrapServicesAndRender(() => {
-  renderRoot(root, growthbook);
-});
+bootstrapServicesAndRender(renderApp);
 serviceWorkerRegistration.unregister();

--- a/src/services/auth/SupabaseAuth.ts
+++ b/src/services/auth/SupabaseAuth.ts
@@ -33,6 +33,10 @@ import logger from '../../utility/logger';
 import { isRecoverableStorageError } from '../../utility/recoverableStorageError';
 import { logAuthDebug } from '../../utility/authDebug';
 import { normalizeTcVersion } from '../../utility/termsAndConditions';
+import {
+  clearWebGoogleLoginPending,
+  markWebGoogleLoginPending,
+} from './webGoogleLoginLoading';
 
 export class SupabaseAuth implements ServiceAuth {
   public static i: SupabaseAuth;
@@ -271,6 +275,7 @@ export class SupabaseAuth implements ServiceAuth {
         });
       } else {
         const redirectTo = window.location.origin;
+        markWebGoogleLoginPending();
         const { error } = await this._auth.signInWithOAuth({
           provider: 'google',
           options: {
@@ -282,6 +287,7 @@ export class SupabaseAuth implements ServiceAuth {
         });
 
         if (error) {
+          clearWebGoogleLoginPending();
           logger.error('Web Google login failed:', error);
           return { success: false, isSpl: false, userData: null };
         }
@@ -330,6 +336,7 @@ export class SupabaseAuth implements ServiceAuth {
         userData,
       };
     } catch (error: any) {
+      if (!Capacitor.isNativePlatform()) clearWebGoogleLoginPending();
       logger.error(
         '🚀 ~ SupabaseAuth ~ googleSign ~ error:',
         error?.stack || error,

--- a/src/services/auth/webGoogleLoginLoading.ts
+++ b/src/services/auth/webGoogleLoginLoading.ts
@@ -1,0 +1,25 @@
+const WEB_GOOGLE_LOGIN_PENDING_KEY = 'web_google_login_pending_at';
+
+export const markWebGoogleLoginPending = () => {
+  try {
+    sessionStorage.setItem(WEB_GOOGLE_LOGIN_PENDING_KEY, 'true');
+  } catch {
+    // Continue OAuth even if sessionStorage is unavailable.
+  }
+};
+
+export const clearWebGoogleLoginPending = () => {
+  try {
+    sessionStorage.removeItem(WEB_GOOGLE_LOGIN_PENDING_KEY);
+  } catch {
+    // This marker only controls the web Google login loader.
+  }
+};
+
+export const isWebGoogleLoginPending = () => {
+  try {
+    return sessionStorage.getItem(WEB_GOOGLE_LOGIN_PENDING_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
Show a loading indicator during Google OAuth redirects on the web platform. Uses sessionStorage to track login state across redirects. This improves UX by providing visual feedback during the OAuth flow.