### PR TITLE
Fix student class edit dropdown scope

### DIFF
--- a/src/ops-console/components/SchoolDetailsComponents/ClassDetailsPage.test.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/ClassDetailsPage.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import ClassDetailsPage from './ClassDetailsPage';
+import type { ClassRow, SchoolDetailsData } from './SchoolClass';
+
+jest.mock('i18next', () => ({
+  t: (key: string) => key,
+}));
+
+jest.mock('@mui/material', () => ({
+  ...jest.requireActual('@mui/material'),
+  useMediaQuery: () => false,
+}));
+
+jest.mock('../../../redux/hooks', () => ({
+  useAppSelector: () => ({ roles: [] }),
+}));
+
+jest.mock('../../../utility/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+}));
+
+const mockSchoolStudents = jest.fn(() => <div data-testid="school-students" />);
+
+jest.mock('./SchoolStudents', () => ({
+  __esModule: true,
+  default: (props: unknown) => mockSchoolStudents(props),
+}));
+
+jest.mock('./ClassInfoCard', () => () => <div data-testid="class-info-card" />);
+jest.mock('./WhatsAppInfoCard', () => () => (
+  <div data-testid="whatsapp-info-card" />
+));
+jest.mock('./AddNoteModal', () => () => null);
+
+type ApiHandlerMock = {
+  getStudentInfoBySchoolId: jest.Mock;
+  getActiveStudentsCountByClass: jest.Mock;
+  createNoteForSchool: jest.Mock;
+};
+
+const mockApiHandler: ApiHandlerMock = {
+  getStudentInfoBySchoolId: jest.fn(),
+  getActiveStudentsCountByClass: jest.fn(),
+  createNoteForSchool: jest.fn(),
+};
+
+jest.mock('../../../services/ServiceConfig', () => ({
+  ServiceConfig: {
+    getI: () => ({
+      apiHandler: mockApiHandler,
+    }),
+  },
+}));
+
+describe('ClassDetailsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApiHandler.getStudentInfoBySchoolId.mockResolvedValue({
+      data: [],
+      total: 0,
+    });
+    mockApiHandler.getActiveStudentsCountByClass.mockResolvedValue(0);
+  });
+
+  it('passes the full school class list into the nested student editor', async () => {
+    const classRows = [
+      { id: 'class-1', name: '1A' },
+      { id: 'class-2', name: '1B' },
+    ] as ClassRow[];
+
+    const data = {
+      schoolData: {
+        id: 'school-1',
+        model: 'at_school',
+      },
+      classData: classRows,
+    } as SchoolDetailsData;
+
+    render(
+      <ClassDetailsPage
+        data={data}
+        schoolId="school-1"
+        classId="class-1"
+        classRow={classRows[0]}
+      />,
+    );
+
+    await waitFor(() => expect(mockSchoolStudents).toHaveBeenCalled());
+
+    expect(mockSchoolStudents.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          classData: classRows,
+        }),
+      }),
+    );
+  });
+});

--- a/src/ops-console/components/SchoolDetailsComponents/ClassDetailsPage.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/ClassDetailsPage.tsx
@@ -214,7 +214,7 @@ const ClassDetailsPage: React.FC<Props> = ({
             schoolData: data?.schoolData,
             students: initialStudents,
             totalStudentCount: initialTotal,
-            classData: [onlyClassRow].filter(Boolean) as ClassRow[],
+            classData: classDataArray,
             totalCount: initialTotal,
           }}
           schoolId={schoolId}

--- a/src/ops-console/components/SchoolDetailsComponents/FormCard.test.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/FormCard.test.tsx
@@ -178,4 +178,37 @@ describe('FormCard', () => {
       }),
     );
   });
+
+  it('does not render a placeholder option for edit-mode class selection', () => {
+    render(
+      <FormCard
+        open={true}
+        title="Edit Student Details"
+        submitLabel="Save Changes"
+        fields={[
+          {
+            name: 'classAndSection',
+            label: 'Class And Section',
+            kind: 'select',
+            required: true,
+            suppressPlaceholderOption: true,
+            options: [
+              { value: 'class-1', label: 'Class A' },
+              { value: 'class-2', label: 'Class B' },
+            ],
+          },
+        ]}
+        initialValues={{
+          classAndSection: 'class-1',
+        }}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    expect(
+      screen.queryByText('Select Class And Section'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveValue('class-1');
+  });
 });

--- a/src/ops-console/components/SchoolDetailsComponents/FormCard.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/FormCard.tsx
@@ -14,6 +14,7 @@ export interface FieldConfig {
   kind: FieldKind;
   required?: boolean;
   placeholder?: string;
+  suppressPlaceholderOption?: boolean;
   options?: { value: string; label: string }[];
   column?: FieldColumn;
   multi?: boolean;
@@ -321,11 +322,13 @@ const FormCard: React.FC<EntityModalProps> = ({
                 setOpenSelect(null);
               }}
             >
-              <option value="">
-                {field.placeholder
-                  ? t(field.placeholder)
-                  : `${t('Select ')} ${t(field.label)}`}
-              </option>
+              {!field.suppressPlaceholderOption && (
+                <option value="">
+                  {field.placeholder
+                    ? t(field.placeholder)
+                    : `${t('Select ')} ${t(field.label)}`}
+                </option>
+              )}
               {field.options?.map((opt) => (
                 <option key={opt.value} value={opt.value}>
                   {t(opt.label)}

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolStudents.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolStudents.tsx
@@ -1634,6 +1634,7 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
       label: 'Class And Section',
       kind: 'select',
       required: true,
+      suppressPlaceholderOption: true,
       column: 0,
       options: editClassOptions,
     },


### PR DESCRIPTION
- Removed the extra Select Class And Section placeholder from the student edit dropdown in edit mode.
- Kept student editing tied to the school’s full class list, even when opening edit from a single class view.
- Updated ClassDetailsPage to pass the full school classData into SchoolStudents instead of only the currently selected class.
- Added regression tests to cover both the dropdown placeholder behavior and the full-class-list handoff.