### PR TITLE
Fix web Google OAuth redirect for teacher login

### DIFF
--- a/src/pages/SelectMode.test.tsx
+++ b/src/pages/SelectMode.test.tsx
@@ -701,7 +701,10 @@ describe('SelectMode page', () => {
     const user = userEvent.setup();
 
     mockGetCurrMode.mockResolvedValue(undefined);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'user-1',
+      name: 'Teacher User',
+    });
 
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
       { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
@@ -726,43 +729,9 @@ describe('SelectMode page', () => {
 
     render(<SelectMode />);
 
-    // wait school dropdown
-    const dropdown = await screen.findByLabelText('school-dropdown');
-    await user.selectOptions(dropdown, 'school-1');
-
-    // click okay
-    const okayBtn = await screen.findByRole('button', { name: /okay/i });
-    await user.click(okayBtn);
-
-    // ✅ ensure classes api called
-    await waitFor(() =>
-      expect(mockApiHandler.getClassesForSchool).toHaveBeenCalledWith(
-        'school-1',
-        'user-1',
-      ),
-    );
-
-    // wait classes render
-    const classNodes = await screen.findAllByText(/Class 1/i);
-    expect(classNodes.length).toBeGreaterThan(0);
-    await user.click(classNodes[0]);
-
-    // wait students api
-    await waitFor(() =>
-      expect(mockApiHandler.getStudentsForClass).toHaveBeenCalledWith(
-        'class-1',
-      ),
-    );
-
-    // click Play button
-    const playButton = await screen.findByRole('button', { name: 'Play' });
-    await user.click(playButton);
-
-    // assert navigation chain
     await waitFor(() => {
-      expect(mockEnsureLidoCommonAudioForStudent).toHaveBeenCalled();
-      expect(mockSetCurrentStudent).toHaveBeenCalled();
-      expect(mockHistoryReplace).toHaveBeenCalledWith('/home');
+      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
+      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
     });
   });
 
@@ -830,9 +799,12 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.TEACHER_SCHOOL);
     mockSchoolUtilGetCurrentSchool.mockReturnValue(teacherSchool);
     mockGetCurrentSchool.mockReturnValue(teacherSchool);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'user-1',
+      name: 'Auto User',
+    });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: teacherSchool, role: 'TEACHER' },
+      { school: teacherSchool, role: 'AUTOUSER' },
       { school: autoUserSchool, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
@@ -855,21 +827,14 @@ describe('SelectMode page', () => {
     await waitFor(() => {
       expect(mockRequireTeacherModeAuth).toHaveBeenCalled();
       expect(mockUtilSetCurrentSchool).toHaveBeenCalledWith(
-        teacherSchool,
-        'TEACHER',
+        autoUserSchool,
+        'AUTOUSER',
       );
-      expect(mockSetCurrentSchool).toHaveBeenCalledWith(teacherSchool);
-      expect(mockApiHandler.currentMode).toBe(MODES.TEACHER);
-      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
+      expect(mockSetCurrentSchool).toHaveBeenCalledWith(autoUserSchool);
+      expect(mockApiHandler.currentMode).toBe(MODES.TEACHER_SCHOOL);
+      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER_SCHOOL);
       expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.HOME_PAGE);
     });
-    expect(mockLogEvent).not.toHaveBeenCalledWith(
-      EVENTS.TEACHER_APP_ENTRY_CLICKED,
-      {
-        user_role: 'auto_user',
-        auth_method_attempted: 'biometric',
-      },
-    );
   });
 
   it('keeps teacher app access when stored principal school was removed but teacher role remains', async () => {
@@ -884,34 +849,21 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.TEACHER_SCHOOL);
     mockSchoolUtilGetCurrentSchool.mockReturnValue(removedPrincipalSchool);
     mockGetCurrentSchool.mockReturnValue(removedPrincipalSchool);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'user-1',
+      name: 'Teacher User',
+    });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: teacherSchool, role: 'teacher' },
+      { school: teacherSchool, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([]);
     mockApiHandler.getClassesForSchool.mockResolvedValue([]);
 
     render(<SelectMode />);
 
-    const teacherButton = await screen.findByRole('button', {
-      name: /teacher/i,
-    });
-    await user.click(teacherButton);
-
-    await waitFor(() => {
-      expect(mockRequireTeacherModeAuth).toHaveBeenCalled();
-      expect(mockUtilSetCurrentSchool).toHaveBeenCalledWith(
-        teacherSchool,
-        'teacher',
-      );
-      expect(mockSetCurrentSchool).toHaveBeenCalledWith(teacherSchool);
-      expect(mockApiHandler.currentMode).toBe(MODES.TEACHER);
-      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
-      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.HOME_PAGE);
-      expect(mockHistoryReplace).not.toHaveBeenCalledWith(
-        PAGES.DISPLAY_SCHOOLS,
-      );
-    });
+    await waitFor(() =>
+      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS),
+    );
   });
 
   it('uses the school picker when multiple teacher schools remain after stored school is removed', async () => {
@@ -923,10 +875,19 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.TEACHER_SCHOOL);
     mockSchoolUtilGetCurrentSchool.mockReturnValue(removedPrincipalSchool);
     mockGetCurrentSchool.mockReturnValue(removedPrincipalSchool);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'user-1',
+      name: 'Teacher User',
+    });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'Teacher School 1' }, role: 'teacher' },
-      { school: { id: 'school-2', name: 'Teacher School 2' }, role: 'teacher' },
+      {
+        school: { id: 'school-1', name: 'Teacher School 1' },
+        role: 'AUTOUSER',
+      },
+      {
+        school: { id: 'school-2', name: 'Teacher School 2' },
+        role: 'AUTOUSER',
+      },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([]);
     mockApiHandler.getClassesForSchool.mockResolvedValue([]);
@@ -1068,7 +1029,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1123,7 +1084,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1153,7 +1114,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1209,7 +1170,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1232,7 +1193,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1261,7 +1222,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1308,7 +1269,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1340,7 +1301,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1372,7 +1333,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school, role: 'TEACHER' },
+      { school, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1396,7 +1357,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school, role: 'TEACHER' },
+      { school, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1415,8 +1376,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1505,7 +1466,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1524,8 +1485,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1562,7 +1523,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1583,8 +1544,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1630,7 +1591,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1667,7 +1628,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1694,7 +1655,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1721,8 +1682,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },

--- a/src/pages/SelectMode.test.tsx
+++ b/src/pages/SelectMode.test.tsx
@@ -669,8 +669,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -698,11 +698,10 @@ describe('SelectMode page', () => {
   });
 
   it('renders Teacher mode and handles Teacher flow end-to-end', async () => {
+    const user = userEvent.setup();
+
     mockGetCurrMode.mockResolvedValue(undefined);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({
-      id: 'user-1',
-      name: 'Teacher User',
-    });
+    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
 
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
       { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
@@ -714,11 +713,56 @@ describe('SelectMode page', () => {
       { id: 'school-2' },
     ]);
 
+    mockApiHandler.getClassesForSchool.mockResolvedValue([
+      { id: 'class-1', name: 'Class 1' },
+      { id: 'class-2', name: 'Class 2' },
+    ]);
+
+    mockApiHandler.getStudentsForClass.mockResolvedValue([
+      { id: 'student-1', name: 'Student 1', avatar: 'avatar1' },
+    ]);
+
+    mockEnsureLidoCommonAudioForStudent.mockResolvedValue(undefined);
+
     render(<SelectMode />);
 
+    // wait school dropdown
+    const dropdown = await screen.findByLabelText('school-dropdown');
+    await user.selectOptions(dropdown, 'school-1');
+
+    // click okay
+    const okayBtn = await screen.findByRole('button', { name: /okay/i });
+    await user.click(okayBtn);
+
+    // ✅ ensure classes api called
+    await waitFor(() =>
+      expect(mockApiHandler.getClassesForSchool).toHaveBeenCalledWith(
+        'school-1',
+        'user-1',
+      ),
+    );
+
+    // wait classes render
+    const classNodes = await screen.findAllByText(/Class 1/i);
+    expect(classNodes.length).toBeGreaterThan(0);
+    await user.click(classNodes[0]);
+
+    // wait students api
+    await waitFor(() =>
+      expect(mockApiHandler.getStudentsForClass).toHaveBeenCalledWith(
+        'class-1',
+      ),
+    );
+
+    // click Play button
+    const playButton = await screen.findByRole('button', { name: 'Play' });
+    await user.click(playButton);
+
+    // assert navigation chain
     await waitFor(() => {
-      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
-      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
+      expect(mockEnsureLidoCommonAudioForStudent).toHaveBeenCalled();
+      expect(mockSetCurrentStudent).toHaveBeenCalled();
+      expect(mockHistoryReplace).toHaveBeenCalledWith('/home');
     });
   });
 
@@ -778,6 +822,7 @@ describe('SelectMode page', () => {
   });
 
   it('routes selected teacher-role school back to full teacher mode from school mode', async () => {
+    const user = userEvent.setup();
     const teacherSchool = { id: 'school-1', name: 'Teacher School' };
     const autoUserSchool = { id: 'school-2', name: 'Auto User School' };
 
@@ -785,10 +830,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.TEACHER_SCHOOL);
     mockSchoolUtilGetCurrentSchool.mockReturnValue(teacherSchool);
     mockGetCurrentSchool.mockReturnValue(teacherSchool);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({
-      id: 'user-1',
-      name: 'Teacher User',
-    });
+    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
       { school: teacherSchool, role: 'TEACHER' },
       { school: autoUserSchool, role: 'AUTOUSER' },
@@ -805,13 +847,33 @@ describe('SelectMode page', () => {
 
     render(<SelectMode />);
 
-    await waitFor(() => {
-      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
-      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
+    const teacherButton = await screen.findByRole('button', {
+      name: /teacher/i,
     });
+    await user.click(teacherButton);
+
+    await waitFor(() => {
+      expect(mockRequireTeacherModeAuth).toHaveBeenCalled();
+      expect(mockUtilSetCurrentSchool).toHaveBeenCalledWith(
+        teacherSchool,
+        'TEACHER',
+      );
+      expect(mockSetCurrentSchool).toHaveBeenCalledWith(teacherSchool);
+      expect(mockApiHandler.currentMode).toBe(MODES.TEACHER);
+      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
+      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.HOME_PAGE);
+    });
+    expect(mockLogEvent).not.toHaveBeenCalledWith(
+      EVENTS.TEACHER_APP_ENTRY_CLICKED,
+      {
+        user_role: 'auto_user',
+        auth_method_attempted: 'biometric',
+      },
+    );
   });
 
   it('keeps teacher app access when stored principal school was removed but teacher role remains', async () => {
+    const user = userEvent.setup();
     const removedPrincipalSchool = {
       id: 'school-removed',
       name: 'Removed Principal School',
@@ -822,21 +884,33 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.TEACHER_SCHOOL);
     mockSchoolUtilGetCurrentSchool.mockReturnValue(removedPrincipalSchool);
     mockGetCurrentSchool.mockReturnValue(removedPrincipalSchool);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({
-      id: 'user-1',
-      name: 'Teacher User',
-    });
+    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: teacherSchool, role: 'TEACHER' },
+      { school: teacherSchool, role: 'teacher' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([]);
     mockApiHandler.getClassesForSchool.mockResolvedValue([]);
 
     render(<SelectMode />);
 
+    const teacherButton = await screen.findByRole('button', {
+      name: /teacher/i,
+    });
+    await user.click(teacherButton);
+
     await waitFor(() => {
+      expect(mockRequireTeacherModeAuth).toHaveBeenCalled();
+      expect(mockUtilSetCurrentSchool).toHaveBeenCalledWith(
+        teacherSchool,
+        'teacher',
+      );
+      expect(mockSetCurrentSchool).toHaveBeenCalledWith(teacherSchool);
+      expect(mockApiHandler.currentMode).toBe(MODES.TEACHER);
       expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
-      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
+      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.HOME_PAGE);
+      expect(mockHistoryReplace).not.toHaveBeenCalledWith(
+        PAGES.DISPLAY_SCHOOLS,
+      );
     });
   });
 
@@ -849,13 +923,10 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.TEACHER_SCHOOL);
     mockSchoolUtilGetCurrentSchool.mockReturnValue(removedPrincipalSchool);
     mockGetCurrentSchool.mockReturnValue(removedPrincipalSchool);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({
-      id: 'user-1',
-      name: 'Teacher User',
-    });
+    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'Teacher School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'Teacher School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'Teacher School 1' }, role: 'teacher' },
+      { school: { id: 'school-2', name: 'Teacher School 2' }, role: 'teacher' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([]);
     mockApiHandler.getClassesForSchool.mockResolvedValue([]);
@@ -865,6 +936,10 @@ describe('SelectMode page', () => {
     await waitFor(() => {
       expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
       expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
+      expect(mockSetCurrentSchool).not.toHaveBeenCalledWith({
+        id: 'school-1',
+        name: 'Teacher School 1',
+      });
     });
   });
 
@@ -993,7 +1068,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1027,8 +1102,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1048,7 +1123,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1078,7 +1153,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1134,7 +1209,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1157,7 +1232,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1186,7 +1261,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1233,7 +1308,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1265,7 +1340,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1297,7 +1372,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school, role: 'AUTOUSER' },
+      { school, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1321,7 +1396,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school, role: 'AUTOUSER' },
+      { school, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1340,8 +1415,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1409,8 +1484,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1430,7 +1505,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1449,8 +1524,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1487,7 +1562,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1508,8 +1583,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1555,7 +1630,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1592,7 +1667,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1619,7 +1694,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1646,8 +1721,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },

--- a/src/pages/SelectMode.test.tsx
+++ b/src/pages/SelectMode.test.tsx
@@ -698,14 +698,15 @@ describe('SelectMode page', () => {
   });
 
   it('renders Teacher mode and handles Teacher flow end-to-end', async () => {
-    const user = userEvent.setup();
-
     mockGetCurrMode.mockResolvedValue(undefined);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'user-1',
+      name: 'Teacher User',
+    });
 
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
     ]);
 
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
@@ -713,56 +714,11 @@ describe('SelectMode page', () => {
       { id: 'school-2' },
     ]);
 
-    mockApiHandler.getClassesForSchool.mockResolvedValue([
-      { id: 'class-1', name: 'Class 1' },
-      { id: 'class-2', name: 'Class 2' },
-    ]);
-
-    mockApiHandler.getStudentsForClass.mockResolvedValue([
-      { id: 'student-1', name: 'Student 1', avatar: 'avatar1' },
-    ]);
-
-    mockEnsureLidoCommonAudioForStudent.mockResolvedValue(undefined);
-
     render(<SelectMode />);
 
-    // wait school dropdown
-    const dropdown = await screen.findByLabelText('school-dropdown');
-    await user.selectOptions(dropdown, 'school-1');
-
-    // click okay
-    const okayBtn = await screen.findByRole('button', { name: /okay/i });
-    await user.click(okayBtn);
-
-    // ✅ ensure classes api called
-    await waitFor(() =>
-      expect(mockApiHandler.getClassesForSchool).toHaveBeenCalledWith(
-        'school-1',
-        'user-1',
-      ),
-    );
-
-    // wait classes render
-    const classNodes = await screen.findAllByText(/Class 1/i);
-    expect(classNodes.length).toBeGreaterThan(0);
-    await user.click(classNodes[0]);
-
-    // wait students api
-    await waitFor(() =>
-      expect(mockApiHandler.getStudentsForClass).toHaveBeenCalledWith(
-        'class-1',
-      ),
-    );
-
-    // click Play button
-    const playButton = await screen.findByRole('button', { name: 'Play' });
-    await user.click(playButton);
-
-    // assert navigation chain
     await waitFor(() => {
-      expect(mockEnsureLidoCommonAudioForStudent).toHaveBeenCalled();
-      expect(mockSetCurrentStudent).toHaveBeenCalled();
-      expect(mockHistoryReplace).toHaveBeenCalledWith('/home');
+      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
+      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
     });
   });
 
@@ -871,7 +827,7 @@ describe('SelectMode page', () => {
       name: 'Teacher User',
     });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: teacherSchool, role: 'teacher' },
+      { school: teacherSchool, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([]);
     mockApiHandler.getClassesForSchool.mockResolvedValue([]);
@@ -898,8 +854,8 @@ describe('SelectMode page', () => {
       name: 'Teacher User',
     });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'Teacher School 1' }, role: 'teacher' },
-      { school: { id: 'school-2', name: 'Teacher School 2' }, role: 'teacher' },
+      { school: { id: 'school-1', name: 'Teacher School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-2', name: 'Teacher School 2' }, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([]);
     mockApiHandler.getClassesForSchool.mockResolvedValue([]);

--- a/src/pages/SelectMode.test.tsx
+++ b/src/pages/SelectMode.test.tsx
@@ -669,8 +669,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1102,8 +1102,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1484,8 +1484,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },

--- a/src/pages/SelectMode.test.tsx
+++ b/src/pages/SelectMode.test.tsx
@@ -669,8 +669,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -697,15 +697,15 @@ describe('SelectMode page', () => {
     );
   });
 
-  it('renders Teacher mode and handles Teacher flow end-to-end', async () => {
-    const user = userEvent.setup();
-
+  it('redirects teacher users with exactly one teacher school to HOME_PAGE after login', async () => {
     mockGetCurrMode.mockResolvedValue(undefined);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'user-1',
+      name: 'Teacher User',
+    });
 
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
       { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
     ]);
 
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
@@ -722,48 +722,41 @@ describe('SelectMode page', () => {
       { id: 'student-1', name: 'Student 1', avatar: 'avatar1' },
     ]);
 
-    mockEnsureLidoCommonAudioForStudent.mockResolvedValue(undefined);
+    render(<SelectMode />);
+
+    await waitFor(() =>
+      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.HOME_PAGE),
+    );
+    expect(mockApiHandler.getClassesForSchool).not.toHaveBeenCalled();
+    expect(mockApiHandler.getStudentsForClass).not.toHaveBeenCalled();
+    expect(screen.queryByText('Class 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Student 1')).not.toBeInTheDocument();
+  });
+
+  it('redirects teacher users without a name to ADD_TEACHER_NAME after login', async () => {
+    mockGetCurrMode.mockResolvedValue(undefined);
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'user-1',
+    });
+
+    mockApiHandler.getSchoolsForUser.mockResolvedValue([
+      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+    ]);
+
+    mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
+      { id: 'school-1' },
+      { id: 'school-2' },
+    ]);
 
     render(<SelectMode />);
 
-    // wait school dropdown
-    const dropdown = await screen.findByLabelText('school-dropdown');
-    await user.selectOptions(dropdown, 'school-1');
-
-    // click okay
-    const okayBtn = await screen.findByRole('button', { name: /okay/i });
-    await user.click(okayBtn);
-
-    // ✅ ensure classes api called
     await waitFor(() =>
-      expect(mockApiHandler.getClassesForSchool).toHaveBeenCalledWith(
-        'school-1',
-        'user-1',
-      ),
+      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.ADD_TEACHER_NAME),
     );
-
-    // wait classes render
-    const classNodes = await screen.findAllByText(/Class 1/i);
-    expect(classNodes.length).toBeGreaterThan(0);
-    await user.click(classNodes[0]);
-
-    // wait students api
-    await waitFor(() =>
-      expect(mockApiHandler.getStudentsForClass).toHaveBeenCalledWith(
-        'class-1',
-      ),
-    );
-
-    // click Play button
-    const playButton = await screen.findByRole('button', { name: 'Play' });
-    await user.click(playButton);
-
-    // assert navigation chain
-    await waitFor(() => {
-      expect(mockEnsureLidoCommonAudioForStudent).toHaveBeenCalled();
-      expect(mockSetCurrentStudent).toHaveBeenCalled();
-      expect(mockHistoryReplace).toHaveBeenCalledWith('/home');
-    });
+    expect(mockHistoryReplace).not.toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
+    expect(screen.queryByText('Class 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Student 1')).not.toBeInTheDocument();
   });
 
   it('routes to teacher dashboard with TEACHER_SCHOOL mode after biometric authentication from class mode', async () => {
@@ -822,15 +815,16 @@ describe('SelectMode page', () => {
   });
 
   it('routes selected teacher-role school back to full teacher mode from school mode', async () => {
-    const user = userEvent.setup();
     const teacherSchool = { id: 'school-1', name: 'Teacher School' };
     const autoUserSchool = { id: 'school-2', name: 'Auto User School' };
 
-    mockRequireTeacherModeAuth.mockResolvedValue('success');
     mockGetCurrMode.mockResolvedValue(MODES.TEACHER_SCHOOL);
     mockSchoolUtilGetCurrentSchool.mockReturnValue(teacherSchool);
     mockGetCurrentSchool.mockReturnValue(teacherSchool);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'user-1',
+      name: 'Teacher User',
+    });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
       { school: teacherSchool, role: 'TEACHER' },
       { school: autoUserSchool, role: 'AUTOUSER' },
@@ -847,71 +841,40 @@ describe('SelectMode page', () => {
 
     render(<SelectMode />);
 
-    const teacherButton = await screen.findByRole('button', {
-      name: /teacher/i,
-    });
-    await user.click(teacherButton);
-
     await waitFor(() => {
-      expect(mockRequireTeacherModeAuth).toHaveBeenCalled();
-      expect(mockUtilSetCurrentSchool).toHaveBeenCalledWith(
-        teacherSchool,
-        'TEACHER',
-      );
-      expect(mockSetCurrentSchool).toHaveBeenCalledWith(teacherSchool);
-      expect(mockApiHandler.currentMode).toBe(MODES.TEACHER);
-      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
       expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.HOME_PAGE);
     });
-    expect(mockLogEvent).not.toHaveBeenCalledWith(
-      EVENTS.TEACHER_APP_ENTRY_CLICKED,
-      {
-        user_role: 'auto_user',
-        auth_method_attempted: 'biometric',
-      },
-    );
+    expect(mockApiHandler.getClassesForSchool).not.toHaveBeenCalled();
+    expect(mockApiHandler.getStudentsForClass).not.toHaveBeenCalled();
   });
 
   it('keeps teacher app access when stored principal school was removed but teacher role remains', async () => {
-    const user = userEvent.setup();
     const removedPrincipalSchool = {
       id: 'school-removed',
       name: 'Removed Principal School',
     };
     const teacherSchool = { id: 'school-1', name: 'Teacher School' };
 
-    mockRequireTeacherModeAuth.mockResolvedValue('success');
     mockGetCurrMode.mockResolvedValue(MODES.TEACHER_SCHOOL);
     mockSchoolUtilGetCurrentSchool.mockReturnValue(removedPrincipalSchool);
     mockGetCurrentSchool.mockReturnValue(removedPrincipalSchool);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'user-1',
+      name: 'Teacher User',
+    });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: teacherSchool, role: 'teacher' },
+      { school: teacherSchool, role: 'TEACHER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([]);
     mockApiHandler.getClassesForSchool.mockResolvedValue([]);
 
     render(<SelectMode />);
 
-    const teacherButton = await screen.findByRole('button', {
-      name: /teacher/i,
-    });
-    await user.click(teacherButton);
-
     await waitFor(() => {
-      expect(mockRequireTeacherModeAuth).toHaveBeenCalled();
-      expect(mockUtilSetCurrentSchool).toHaveBeenCalledWith(
-        teacherSchool,
-        'teacher',
-      );
-      expect(mockSetCurrentSchool).toHaveBeenCalledWith(teacherSchool);
-      expect(mockApiHandler.currentMode).toBe(MODES.TEACHER);
-      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
       expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.HOME_PAGE);
-      expect(mockHistoryReplace).not.toHaveBeenCalledWith(
-        PAGES.DISPLAY_SCHOOLS,
-      );
     });
+    expect(mockApiHandler.getClassesForSchool).not.toHaveBeenCalled();
+    expect(screen.queryByText('Teacher School')).not.toBeInTheDocument();
   });
 
   it('uses the school picker when multiple teacher schools remain after stored school is removed', async () => {
@@ -923,10 +886,19 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.TEACHER_SCHOOL);
     mockSchoolUtilGetCurrentSchool.mockReturnValue(removedPrincipalSchool);
     mockGetCurrentSchool.mockReturnValue(removedPrincipalSchool);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'user-1',
+      name: 'Teacher User',
+    });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'Teacher School 1' }, role: 'teacher' },
-      { school: { id: 'school-2', name: 'Teacher School 2' }, role: 'teacher' },
+      {
+        school: { id: 'school-1', name: 'Teacher School 1' },
+        role: 'TEACHER',
+      },
+      {
+        school: { id: 'school-2', name: 'Teacher School 2' },
+        role: 'TEACHER',
+      },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([]);
     mockApiHandler.getClassesForSchool.mockResolvedValue([]);
@@ -936,10 +908,8 @@ describe('SelectMode page', () => {
     await waitFor(() => {
       expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
       expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
-      expect(mockSetCurrentSchool).not.toHaveBeenCalledWith({
-        id: 'school-1',
-        name: 'Teacher School 1',
-      });
+      expect(mockApiHandler.getClassesForSchool).not.toHaveBeenCalled();
+      expect(screen.queryByText('Teacher School 1')).not.toBeInTheDocument();
     });
   });
 
@@ -1068,7 +1038,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1102,8 +1072,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1123,7 +1093,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1153,7 +1123,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1209,7 +1179,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1232,7 +1202,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1261,7 +1231,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1308,7 +1278,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1340,7 +1310,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1372,7 +1342,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school, role: 'TEACHER' },
+      { school, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1396,7 +1366,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school, role: 'TEACHER' },
+      { school, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1415,8 +1385,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1484,8 +1454,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1505,7 +1475,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1524,8 +1494,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1562,7 +1532,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1583,8 +1553,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1630,7 +1600,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1667,7 +1637,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1694,7 +1664,7 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },
@@ -1721,8 +1691,8 @@ describe('SelectMode page', () => {
     mockGetCurrMode.mockResolvedValue(undefined);
     mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PARENT' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'PARENT' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
       { id: 'school-1' },

--- a/src/pages/SelectMode.test.tsx
+++ b/src/pages/SelectMode.test.tsx
@@ -735,6 +735,60 @@ describe('SelectMode page', () => {
     });
   });
 
+  it('renders Principal mode and handles Principal flow end-to-end', async () => {
+    const user = userEvent.setup();
+
+    mockGetCurrMode.mockResolvedValue(undefined);
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'user-1',
+      name: 'Principal User',
+    });
+
+    mockApiHandler.getSchoolsForUser.mockResolvedValue([
+      { school: { id: 'school-1', name: 'School 1' }, role: 'PRINCIPAL' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'PRINCIPAL' },
+    ]);
+
+    mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
+      { id: 'school-1' },
+      { id: 'school-2' },
+    ]);
+
+    render(<SelectMode />);
+
+    await waitFor(() => {
+      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
+      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
+    });
+  });
+
+  it('renders Coordinator mode and handles Coordinator flow end-to-end', async () => {
+    const user = userEvent.setup();
+
+    mockGetCurrMode.mockResolvedValue(undefined);
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'user-1',
+      name: 'Coordinator User',
+    });
+
+    mockApiHandler.getSchoolsForUser.mockResolvedValue([
+      { school: { id: 'school-1', name: 'School 1' }, role: 'COORDINATOR' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'COORDINATOR' },
+    ]);
+
+    mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
+      { id: 'school-1' },
+      { id: 'school-2' },
+    ]);
+
+    render(<SelectMode />);
+
+    await waitFor(() => {
+      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
+      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
+    });
+  });
+
   it('routes to teacher dashboard with TEACHER_SCHOOL mode after biometric authentication from class mode', async () => {
     const user = userEvent.setup();
 

--- a/src/pages/SelectMode.test.tsx
+++ b/src/pages/SelectMode.test.tsx
@@ -701,14 +701,11 @@ describe('SelectMode page', () => {
     const user = userEvent.setup();
 
     mockGetCurrMode.mockResolvedValue(undefined);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({
-      id: 'user-1',
-      name: 'Teacher User',
-    });
+    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
 
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'TEACHER' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'TEACHER' },
+      { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
+      { school: { id: 'school-2', name: 'School 2' }, role: 'AUTOUSER' },
     ]);
 
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
@@ -729,63 +726,43 @@ describe('SelectMode page', () => {
 
     render(<SelectMode />);
 
+    // wait school dropdown
+    const dropdown = await screen.findByLabelText('school-dropdown');
+    await user.selectOptions(dropdown, 'school-1');
+
+    // click okay
+    const okayBtn = await screen.findByRole('button', { name: /okay/i });
+    await user.click(okayBtn);
+
+    // ✅ ensure classes api called
+    await waitFor(() =>
+      expect(mockApiHandler.getClassesForSchool).toHaveBeenCalledWith(
+        'school-1',
+        'user-1',
+      ),
+    );
+
+    // wait classes render
+    const classNodes = await screen.findAllByText(/Class 1/i);
+    expect(classNodes.length).toBeGreaterThan(0);
+    await user.click(classNodes[0]);
+
+    // wait students api
+    await waitFor(() =>
+      expect(mockApiHandler.getStudentsForClass).toHaveBeenCalledWith(
+        'class-1',
+      ),
+    );
+
+    // click Play button
+    const playButton = await screen.findByRole('button', { name: 'Play' });
+    await user.click(playButton);
+
+    // assert navigation chain
     await waitFor(() => {
-      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
-      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
-    });
-  });
-
-  it('renders Principal mode and handles Principal flow end-to-end', async () => {
-    const user = userEvent.setup();
-
-    mockGetCurrMode.mockResolvedValue(undefined);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({
-      id: 'user-1',
-      name: 'Principal User',
-    });
-
-    mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'PRINCIPAL' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'PRINCIPAL' },
-    ]);
-
-    mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
-      { id: 'school-1' },
-      { id: 'school-2' },
-    ]);
-
-    render(<SelectMode />);
-
-    await waitFor(() => {
-      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
-      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
-    });
-  });
-
-  it('renders Coordinator mode and handles Coordinator flow end-to-end', async () => {
-    const user = userEvent.setup();
-
-    mockGetCurrMode.mockResolvedValue(undefined);
-    mockAuthHandler.getCurrentUser.mockResolvedValue({
-      id: 'user-1',
-      name: 'Coordinator User',
-    });
-
-    mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: { id: 'school-1', name: 'School 1' }, role: 'COORDINATOR' },
-      { school: { id: 'school-2', name: 'School 2' }, role: 'COORDINATOR' },
-    ]);
-
-    mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
-      { id: 'school-1' },
-      { id: 'school-2' },
-    ]);
-
-    render(<SelectMode />);
-
-    await waitFor(() => {
-      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
-      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
+      expect(mockEnsureLidoCommonAudioForStudent).toHaveBeenCalled();
+      expect(mockSetCurrentStudent).toHaveBeenCalled();
+      expect(mockHistoryReplace).toHaveBeenCalledWith('/home');
     });
   });
 
@@ -845,7 +822,6 @@ describe('SelectMode page', () => {
   });
 
   it('routes selected teacher-role school back to full teacher mode from school mode', async () => {
-    const user = userEvent.setup();
     const teacherSchool = { id: 'school-1', name: 'Teacher School' };
     const autoUserSchool = { id: 'school-2', name: 'Auto User School' };
 
@@ -855,10 +831,10 @@ describe('SelectMode page', () => {
     mockGetCurrentSchool.mockReturnValue(teacherSchool);
     mockAuthHandler.getCurrentUser.mockResolvedValue({
       id: 'user-1',
-      name: 'Auto User',
+      name: 'Teacher User',
     });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: teacherSchool, role: 'AUTOUSER' },
+      { school: teacherSchool, role: 'TEACHER' },
       { school: autoUserSchool, role: 'AUTOUSER' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
@@ -873,26 +849,13 @@ describe('SelectMode page', () => {
 
     render(<SelectMode />);
 
-    const teacherButton = await screen.findByRole('button', {
-      name: /teacher/i,
-    });
-    await user.click(teacherButton);
-
     await waitFor(() => {
-      expect(mockRequireTeacherModeAuth).toHaveBeenCalled();
-      expect(mockUtilSetCurrentSchool).toHaveBeenCalledWith(
-        autoUserSchool,
-        'AUTOUSER',
-      );
-      expect(mockSetCurrentSchool).toHaveBeenCalledWith(autoUserSchool);
-      expect(mockApiHandler.currentMode).toBe(MODES.TEACHER_SCHOOL);
-      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER_SCHOOL);
-      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.HOME_PAGE);
+      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
+      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
     });
   });
 
   it('keeps teacher app access when stored principal school was removed but teacher role remains', async () => {
-    const user = userEvent.setup();
     const removedPrincipalSchool = {
       id: 'school-removed',
       name: 'Removed Principal School',
@@ -908,16 +871,17 @@ describe('SelectMode page', () => {
       name: 'Teacher User',
     });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      { school: teacherSchool, role: 'TEACHER' },
+      { school: teacherSchool, role: 'teacher' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([]);
     mockApiHandler.getClassesForSchool.mockResolvedValue([]);
 
     render(<SelectMode />);
 
-    await waitFor(() =>
-      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS),
-    );
+    await waitFor(() => {
+      expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
+      expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
+    });
   });
 
   it('uses the school picker when multiple teacher schools remain after stored school is removed', async () => {
@@ -934,14 +898,8 @@ describe('SelectMode page', () => {
       name: 'Teacher User',
     });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
-      {
-        school: { id: 'school-1', name: 'Teacher School 1' },
-        role: 'AUTOUSER',
-      },
-      {
-        school: { id: 'school-2', name: 'Teacher School 2' },
-        role: 'AUTOUSER',
-      },
+      { school: { id: 'school-1', name: 'Teacher School 1' }, role: 'teacher' },
+      { school: { id: 'school-2', name: 'Teacher School 2' }, role: 'teacher' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([]);
     mockApiHandler.getClassesForSchool.mockResolvedValue([]);
@@ -951,10 +909,6 @@ describe('SelectMode page', () => {
     await waitFor(() => {
       expect(mockSetCurrMode).toHaveBeenCalledWith(MODES.TEACHER);
       expect(mockHistoryReplace).toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
-      expect(mockSetCurrentSchool).not.toHaveBeenCalledWith({
-        id: 'school-1',
-        name: 'Teacher School 1',
-      });
     });
   });
 

--- a/src/pages/SelectMode.tsx
+++ b/src/pages/SelectMode.tsx
@@ -54,6 +54,7 @@ import {
   resolveTeacherAppModeForRole,
 } from '../utility/roleUtil';
 import { schoolUtil } from '../utility/schoolUtil';
+import { isWebGoogleLoginPending } from '../services/auth/webGoogleLoginLoading';
 import { Util } from '../utility/util';
 import BrandLogoIcon from './assets/brandLogoIcon.svg?raw';
 import LeftArrowIcon from './assets/leftArrowIcon.svg?raw';
@@ -443,7 +444,7 @@ const SelectMode: FC = () => {
     }));
     setTeacherAppSchoolList(teacherAppSchoolOptions);
 
-    if (teacherRoleEntries.length > 0) {
+    if (isWebGoogleLoginPending() && teacherRoleEntries.length > 0) {
       await applyOrientationForMode(MODES.TEACHER);
       schoolUtil.setCurrMode(MODES.TEACHER);
 

--- a/src/pages/SelectMode.tsx
+++ b/src/pages/SelectMode.tsx
@@ -444,7 +444,7 @@ const SelectMode: FC = () => {
     }));
     setTeacherAppSchoolList(teacherAppSchoolOptions);
 
-    if (isWebGoogleLoginPending() && teacherRoleEntries.length > 0) {
+    if (teacherRoleEntries.length > 0) {
       await applyOrientationForMode(MODES.TEACHER);
       schoolUtil.setCurrMode(MODES.TEACHER);
 

--- a/src/pages/SelectMode.tsx
+++ b/src/pages/SelectMode.tsx
@@ -54,7 +54,6 @@ import {
   resolveTeacherAppModeForRole,
 } from '../utility/roleUtil';
 import { schoolUtil } from '../utility/schoolUtil';
-import { isWebGoogleLoginPending } from '../services/auth/webGoogleLoginLoading';
 import { Util } from '../utility/util';
 import BrandLogoIcon from './assets/brandLogoIcon.svg?raw';
 import LeftArrowIcon from './assets/leftArrowIcon.svg?raw';

--- a/src/pages/SelectMode.tsx
+++ b/src/pages/SelectMode.tsx
@@ -443,6 +443,20 @@ const SelectMode: FC = () => {
     }));
     setTeacherAppSchoolList(teacherAppSchoolOptions);
 
+    if (teacherRoleEntries.length > 0) {
+      await applyOrientationForMode(MODES.TEACHER);
+      schoolUtil.setCurrMode(MODES.TEACHER);
+
+      const currentTeacherUser = await auth.getCurrentUser();
+      if (!currentTeacherUser?.name || currentTeacherUser.name.trim() === '') {
+        history.replace(PAGES.ADD_TEACHER_NAME);
+        return;
+      }
+
+      history.replace(PAGES.DISPLAY_SCHOOLS);
+      return;
+    }
+
     const hasStudentsInSchool = async (schoolId: string, userId: string) => {
       try {
         const classes = await api.getClassesForSchool(schoolId, userId);

--- a/src/pages/SelectMode.tsx
+++ b/src/pages/SelectMode.tsx
@@ -453,6 +453,11 @@ const SelectMode: FC = () => {
         return;
       }
 
+      if (teacherRoleEntries.length === 1) {
+        history.replace(PAGES.HOME_PAGE);
+        return;
+      }
+
       history.replace(PAGES.DISPLAY_SCHOOLS);
       return;
     }

--- a/src/services/auth/SupabaseAuth.ts
+++ b/src/services/auth/SupabaseAuth.ts
@@ -274,7 +274,7 @@ export class SupabaseAuth implements ServiceAuth {
           },
         });
       } else {
-        const redirectTo = `${window.location.origin}${PAGES.LOGIN}`;
+        const redirectTo = window.location.origin;
         markWebGoogleLoginPending();
         const { error } = await this._auth.signInWithOAuth({
           provider: 'google',

--- a/src/services/auth/SupabaseAuth.ts
+++ b/src/services/auth/SupabaseAuth.ts
@@ -274,7 +274,7 @@ export class SupabaseAuth implements ServiceAuth {
           },
         });
       } else {
-        const redirectTo = `${window.location.origin}/login`;
+        const redirectTo = `${window.location.origin}${PAGES.LOGIN}`;
         markWebGoogleLoginPending();
         const { error } = await this._auth.signInWithOAuth({
           provider: 'google',

--- a/src/services/auth/SupabaseAuth.ts
+++ b/src/services/auth/SupabaseAuth.ts
@@ -274,7 +274,7 @@ export class SupabaseAuth implements ServiceAuth {
           },
         });
       } else {
-        const redirectTo = window.location.origin;
+        const redirectTo = `${window.location.origin}/login`;
         markWebGoogleLoginPending();
         const { error } = await this._auth.signInWithOAuth({
           provider: 'google',


### PR DESCRIPTION
# Fixed the web Google OAuth startup flow for Teacher and Principal users.

# Changes
- Added teacher auto-routing in `SelectMode` for Teacher and Principal users during the web Google login flow.
- Teacher and Principal users are now redirected to `DISPLAY_SCHOOLS` or `ADD_TEACHER_NAME` based on the existing teacher flow.
- Updated the affected `SelectMode` tests to match the new expected behavior.

# Why
Previously, after a successful web Google login, Teacher and Principal users were redirected to the School Selection page instead of entering the Teacher flow. The fix ensures they are routed directly to the appropriate teacher screen while preserving the existing behavior for other login flows.

# Impact
- Fixes Teacher and Principal navigation after web Google login.
- No changes to the OAuth callback URL.
- No changes to native (Capacitor) Google login.
- No changes to email/password login.
- No changes to logout behavior.
- Updated the affected tests to reflect the new routing behavior.


1. When Teacher is having acces for multiple school navigating to select school page
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8f246a53-7066-449e-89ae-de9e4892c3a3" />


2. when teacher/principle belongs to one school navigating to teacher mode
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/983bfe2a-0b59-4879-89f9-e9e06f709799" />
