### PR TITLE
Fix school name sync in listing

### DIFF
--- a/src/ops-console/pages/AddSchoolPage.tsx
+++ b/src/ops-console/pages/AddSchoolPage.tsx
@@ -429,6 +429,9 @@ const AddSchoolPage: React.FC = () => {
             RoleType.FIELD_COORDINATOR,
           );
         }
+
+        // Refresh derived school metrics so the listing picks up the renamed school.
+        await api.computeSchoolMetricsForSchool(editData.schoolData.id);
       } else {
         const school = await api.createSchool(
           schoolName,


### PR DESCRIPTION
- School edits now trigger a refresh of the derived school_metrics data so the updated school name can reflect in the listing/search flow.

- Fix keeps the school details page and school listing data in sync after rename operations, without changing the listing UI logic.