### PR TITLE
Fix: Requests Menu Navigates to School Listing Instead of Requests Page for Field Coordinator.

### DIFF
--- a/src/ops-console/pages/SidebarPage.tsx
+++ b/src/ops-console/pages/SidebarPage.tsx
@@ -129,6 +129,7 @@ const SidebarPage: React.FC = () => {
   const canAccessCampaignPage = userRoles.some((role) =>
     CAMPAIGN_ACCESS_ROLES.includes(role as RoleType),
   );
+  const canAccessRequestPage = userRoles.includes(RoleType.FIELD_COORDINATOR);
 
   useEffect(() => {
     fetchData();
@@ -142,13 +143,19 @@ const SidebarPage: React.FC = () => {
     const campaignsPath = `${path}${PAGES.ADMIN_CAMPAIGNS}`;
     const campaignDetailsPrefix = `${campaignsPath}/`;
     const campaignCreatePath = `${path}${PAGES.ADMIN_CAMPAIGNS_NEW}`;
+    const requestListPath = `${path}${PAGES.REQUEST_LIST}`;
+    const devicesPath = `${path}${PAGES.ADMIN_DEVICES}`;
+    const resourcesPath = `${path}${PAGES.ADMIN_RESOURCES}`;
     const isAllowedPath =
       location.pathname === schoolListPath ||
       location.pathname.startsWith(schoolDetailsPrefix) ||
       (canAccessCampaignPage &&
         (location.pathname === campaignsPath ||
           location.pathname === campaignCreatePath ||
-          location.pathname.startsWith(campaignDetailsPrefix)));
+          location.pathname.startsWith(campaignDetailsPrefix))) ||
+      (canAccessRequestPage && location.pathname === requestListPath) ||
+      location.pathname === devicesPath ||
+      location.pathname === resourcesPath;
 
     if (!isAllowedPath) {
       history.replace(schoolListPath);
@@ -156,6 +163,7 @@ const SidebarPage: React.FC = () => {
   }, [
     canAccessCampaignPage,
     canAccessProgramPage,
+    canAccessRequestPage,
     history,
     isExternalUser,
     location.pathname,

--- a/src/ops-console/pages/SidebarPage.tsx
+++ b/src/ops-console/pages/SidebarPage.tsx
@@ -144,6 +144,7 @@ const SidebarPage: React.FC = () => {
     const campaignDetailsPrefix = `${campaignsPath}/`;
     const campaignCreatePath = `${path}${PAGES.ADMIN_CAMPAIGNS_NEW}`;
     const requestListPath = `${path}${PAGES.REQUEST_LIST}`;
+    const requestDetailsPrefix = `${requestListPath}/`;
     const devicesPath = `${path}${PAGES.ADMIN_DEVICES}`;
     const resourcesPath = `${path}${PAGES.ADMIN_RESOURCES}`;
     const isAllowedPath =
@@ -153,7 +154,9 @@ const SidebarPage: React.FC = () => {
         (location.pathname === campaignsPath ||
           location.pathname === campaignCreatePath ||
           location.pathname.startsWith(campaignDetailsPrefix))) ||
-      (canAccessRequestPage && location.pathname === requestListPath) ||
+      (canAccessRequestPage &&
+        (location.pathname === requestListPath ||
+          location.pathname.startsWith(requestDetailsPrefix))) ||
       location.pathname === devicesPath ||
       location.pathname === resourcesPath;
 


### PR DESCRIPTION
## Summary

This PR updates OPS sidebar routing to keep intended pages accessible for the right user roles.

## Changes

- Allows Field Coordinators to open the `Requests` page without being redirected to `School Listing`.
- Keeps `Devices` and `Resources` on their OPS routes instead of falling back to `School Listing`.
- Preserves the existing routing behavior for other OPS users and paths.

## Notes

- `Requests` remains accessible only for the intended role.
- `Devices` and `Resources` continue to behave as blank OPS pages for now.
- No new UI pages were added for `Devices` or `Resources`.