### PR TITLE
Search Results Take Excessive Time to Load on the Campaign Listing

### DIFF
--- a/src/ops-console/components/SearchAndFilter.tsx
+++ b/src/ops-console/components/SearchAndFilter.tsx
@@ -24,6 +24,7 @@ interface SearchAndFilterProps {
   variantType?: 'outlined' | 'standard';
   filterIconSrc?: string;
   searchPlaceholder?: string;
+  debounceMs?: number;
 }
 
 const DEBOUNCE_MS = 800;
@@ -39,6 +40,7 @@ const SearchAndFilter: React.FC<SearchAndFilterProps> = ({
   variantType,
   filterIconSrc,
   searchPlaceholder,
+  debounceMs = DEBOUNCE_MS,
 }) => {
   const { t } = useTranslation();
   const isMobile = useMediaQuery('(max-width: 900px)');
@@ -55,15 +57,24 @@ const SearchAndFilter: React.FC<SearchAndFilterProps> = ({
   }, [searchTerm]);
 
   useEffect(() => {
+    if (debounceMs <= 0) {
+      if (inputValue !== searchTerm) {
+        onSearchChange({
+          target: { value: inputValue },
+        } as React.ChangeEvent<HTMLInputElement>);
+      }
+      return;
+    }
+
     const handler = setTimeout(() => {
       if (inputValue !== searchTerm) {
         onSearchChange({
           target: { value: inputValue },
         } as React.ChangeEvent<HTMLInputElement>);
       }
-    }, DEBOUNCE_MS);
+    }, debounceMs);
     return () => clearTimeout(handler);
-  }, [inputValue]);
+  }, [debounceMs, inputValue, onSearchChange, searchTerm]);
 
   const [showMobileSearch, setShowMobileSearch] = useState(forceOpenSearch);
 

--- a/src/ops-console/pages/CampaignListing.fetcher.test.ts
+++ b/src/ops-console/pages/CampaignListing.fetcher.test.ts
@@ -1,0 +1,235 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ServiceApi } from '../../services/api/ServiceApi';
+import {
+  buildCampaignListingRequest,
+  useCampaignListingData,
+} from './CampaignListing.fetcher';
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useHistory: () => ({ replace: jest.fn() }),
+  useLocation: () => ({ search: '' }),
+}));
+
+type CampaignListingResponse = {
+  data: Array<{ campaignId: string; campaign: { name: string } }>;
+  totalCount: number;
+};
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+};
+
+describe('CampaignListing.fetcher', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('trims the search term before sending the API request', () => {
+    expect(
+      buildCampaignListingRequest({
+        page: 2,
+        pageSize: 8,
+        orderBy: 'campaignName',
+        orderDir: 'desc',
+        searchTerm: '  summer  ',
+      }),
+    ).toEqual({
+      page: 2,
+      pageSize: 8,
+      orderBy: 'name',
+      orderDir: 'desc',
+      searchTerm: 'summer',
+    });
+  });
+
+  it('keeps previous rows visible while a refreshed search is in flight and ignores stale responses', async () => {
+    const initialResponse: CampaignListingResponse = {
+      data: [{ campaignId: 'campaign-1', campaign: { name: 'Initial' } }],
+      totalCount: 1,
+    };
+    const staleResponse: CampaignListingResponse = {
+      data: [{ campaignId: 'campaign-2', campaign: { name: 'Stale' } }],
+      totalCount: 1,
+    };
+    const latestResponse: CampaignListingResponse = {
+      data: [{ campaignId: 'campaign-3', campaign: { name: 'Latest' } }],
+      totalCount: 1,
+    };
+    const initialRequest = createDeferred<CampaignListingResponse>();
+    const staleRequest = createDeferred<CampaignListingResponse>();
+    const latestRequest = createDeferred<CampaignListingResponse>();
+    const getCampaignListing = jest
+      .fn()
+      .mockReturnValueOnce(initialRequest.promise)
+      .mockReturnValueOnce(staleRequest.promise)
+      .mockReturnValueOnce(latestRequest.promise);
+    const getCampaignListingMetrics = jest.fn().mockResolvedValue(new Map());
+    const api = {
+      getCampaignListing,
+      getCampaignListingMetrics,
+    } as unknown as ServiceApi;
+
+    const { result, rerender } = renderHook(
+      ({ searchTerm }) =>
+        useCampaignListingData({
+          api,
+          page: 1,
+          pageSize: 8,
+          orderBy: 'campaignName',
+          orderDir: 'asc',
+          searchTerm,
+        }),
+      {
+        initialProps: { searchTerm: '' },
+      },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      initialRequest.resolve(initialResponse);
+    });
+
+    await waitFor(() => {
+      expect(result.current.campaigns).toEqual(initialResponse.data);
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isRefreshing).toBe(false);
+
+    rerender({ searchTerm: 'summer' });
+
+    await waitFor(() => {
+      expect(result.current.isRefreshing).toBe(true);
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.campaigns).toEqual(initialResponse.data);
+
+    rerender({ searchTerm: 'summer camp' });
+
+    await act(async () => {
+      latestRequest.resolve(latestResponse);
+    });
+
+    await waitFor(() => {
+      expect(result.current.campaigns).toEqual(latestResponse.data);
+    });
+    expect(result.current.isRefreshing).toBe(false);
+
+    await act(async () => {
+      staleRequest.resolve(staleResponse);
+    });
+
+    expect(result.current.campaigns).toEqual(latestResponse.data);
+    expect(getCampaignListing).toHaveBeenCalledTimes(3);
+    expect(getCampaignListingMetrics).toHaveBeenCalled();
+  });
+
+  it('loads listing rows without metrics first for non-metric sorts', async () => {
+    const response: CampaignListingResponse = {
+      data: [{ campaignId: 'campaign-1', campaign: { name: 'Silver Oaks' } }],
+      totalCount: 1,
+    };
+    const getCampaignListing = jest.fn().mockResolvedValue(response);
+    const getCampaignListingMetrics = jest.fn().mockResolvedValue(
+      new Map([
+        [
+          'campaign-1',
+          {
+            campaign_id: 'campaign-1',
+            active_students: 5,
+            average_weekly_engagement_time: 12.5,
+          },
+        ],
+      ]),
+    );
+    const api = {
+      getCampaignListing,
+      getCampaignListingMetrics,
+    } as unknown as ServiceApi;
+
+    const { result } = renderHook(() =>
+      useCampaignListingData({
+        api,
+        page: 1,
+        pageSize: 8,
+        orderBy: 'campaignName',
+        orderDir: 'asc',
+        searchTerm: 'silver',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(getCampaignListing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeMetrics: false,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getCampaignListingMetrics).toHaveBeenCalledWith(['campaign-1']);
+    });
+  });
+
+  it('reuses cached metrics when the same campaign row is loaded again', async () => {
+    const response: CampaignListingResponse = {
+      data: [{ campaignId: 'campaign-1', campaign: { name: 'Silver Oaks' } }],
+      totalCount: 1,
+    };
+    const getCampaignListing = jest.fn().mockResolvedValue(response);
+    const getCampaignListingMetrics = jest.fn().mockResolvedValue(
+      new Map([
+        [
+          'campaign-1',
+          {
+            campaign_id: 'campaign-1',
+            active_students: 5,
+            average_weekly_engagement_time: 12.5,
+          },
+        ],
+      ]),
+    );
+    const api = {
+      getCampaignListing,
+      getCampaignListingMetrics,
+    } as unknown as ServiceApi;
+
+    const { result, rerender } = renderHook(
+      ({ searchTerm }) =>
+        useCampaignListingData({
+          api,
+          page: 1,
+          pageSize: 8,
+          orderBy: 'campaignName',
+          orderDir: 'asc',
+          searchTerm,
+        }),
+      {
+        initialProps: { searchTerm: 'silver' },
+      },
+    );
+
+    await waitFor(() => {
+      expect(getCampaignListingMetrics).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ searchTerm: 'silver oaks' });
+
+    await waitFor(() => {
+      expect(result.current.isRefreshing).toBe(false);
+    });
+
+    expect(getCampaignListing).toHaveBeenCalledTimes(2);
+    expect(getCampaignListingMetrics).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ops-console/pages/CampaignListing.fetcher.ts
+++ b/src/ops-console/pages/CampaignListing.fetcher.ts
@@ -8,6 +8,7 @@ import {
 } from '../../services/api/ServiceApi';
 import { CampaignListingStatus } from '../../common/constants';
 import {
+  CAMPAIGN_LISTING_ORDER_BY,
   CAMPAIGN_LISTING_PAGE_SIZE,
   CampaignSortColumn,
   getCampaignListingPageCount,
@@ -87,8 +88,8 @@ export const useCampaignListingData = ({
   searchTerm: string;
 }) => {
   const shouldDeferMetrics =
-    orderBy !== 'avgWeeklyActiveUsers' &&
-    orderBy !== 'avgWeeklyEngagementTimeMinutes';
+    orderBy !== CAMPAIGN_LISTING_ORDER_BY.AVG_WEEKLY_ACTIVE_USERS &&
+    orderBy !== CAMPAIGN_LISTING_ORDER_BY.AVG_WEEKLY_ENGAGEMENT_TIME_MINUTES;
   const [campaigns, setCampaigns] = useState<
     Awaited<ReturnType<ServiceApi['getCampaignListing']>>['data']
   >([]);

--- a/src/ops-console/pages/CampaignListing.fetcher.ts
+++ b/src/ops-console/pages/CampaignListing.fetcher.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useHistory, useLocation } from 'react-router';
 import {
   CampaignListingItem,
@@ -356,12 +356,17 @@ export const useCampaignListingPageState = (api: ServiceApi) => {
     setPage(1);
   };
 
-  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const nextSearchTerm = normalizeCampaignSearchTerm(event.target.value);
-    setSearchTerm((currentSearchTerm) =>
-      currentSearchTerm === nextSearchTerm ? currentSearchTerm : nextSearchTerm,
-    );
-  };
+  const handleSearchChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const nextSearchTerm = normalizeCampaignSearchTerm(event.target.value);
+      setSearchTerm((currentSearchTerm) =>
+        currentSearchTerm === nextSearchTerm
+          ? currentSearchTerm
+          : nextSearchTerm,
+      );
+    },
+    [],
+  );
 
   const handleOpenMenu = (
     event: React.MouseEvent<HTMLButtonElement>,

--- a/src/ops-console/pages/CampaignListing.fetcher.ts
+++ b/src/ops-console/pages/CampaignListing.fetcher.ts
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useHistory, useLocation } from 'react-router';
 import {
+  CampaignListingItem,
   CampaignListingParams,
+  CampaignDashboardMetric,
   ServiceApi,
 } from '../../services/api/ServiceApi';
 import { CampaignListingStatus } from '../../common/constants';
@@ -21,6 +23,8 @@ type CampaignListingApiRequest = {
   orderDir: 'asc' | 'desc';
   searchTerm: string;
 };
+
+const normalizeCampaignSearchTerm = (value: string) => value.trim();
 
 const ORDER_BY_MAP: Record<
   string,
@@ -64,7 +68,7 @@ export const buildCampaignListingRequest = ({
   pageSize,
   orderBy: ORDER_BY_MAP[orderBy] ?? orderBy,
   orderDir,
-  searchTerm,
+  searchTerm: normalizeCampaignSearchTerm(searchTerm),
 });
 
 export const useCampaignListingData = ({
@@ -82,52 +86,150 @@ export const useCampaignListingData = ({
   orderDir: 'asc' | 'desc';
   searchTerm: string;
 }) => {
+  const shouldDeferMetrics =
+    orderBy !== 'avgWeeklyActiveUsers' &&
+    orderBy !== 'avgWeeklyEngagementTimeMinutes';
   const [campaigns, setCampaigns] = useState<
     Awaited<ReturnType<ServiceApi['getCampaignListing']>>['data']
   >([]);
   const [total, setTotal] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isMetricsRefreshing, setIsMetricsRefreshing] = useState(false);
+  const requestIdRef = useRef(0);
+  const metricsRequestIdRef = useRef(0);
+  const lastRequestKeyRef = useRef<string | null>(null);
+  const lastMetricsRequestKeyRef = useRef<string | null>(null);
+  const metricsCacheRef = useRef<Map<string, CampaignDashboardMetric>>(
+    new Map(),
+  );
+
+  const mergeMetricsIntoCampaigns = (
+    currentCampaigns: CampaignListingItem[],
+    metricsMap: Map<string, CampaignDashboardMetric>,
+  ) =>
+    currentCampaigns.map((campaign) => {
+      const metric = metricsMap.get(campaign.campaignId) ?? null;
+      if (metric == null) {
+        return campaign;
+      }
+
+      return {
+        ...campaign,
+        dashboardMetrics: metric,
+        avgWeeklyActiveUsers: metric.active_students ?? null,
+        avgWeeklyEngagementTimeMinutes:
+          metric.average_weekly_engagement_time ?? null,
+      };
+    });
 
   useEffect(() => {
-    let active = true;
+    const request = buildCampaignListingRequest({
+      page,
+      pageSize,
+      orderBy,
+      orderDir,
+      searchTerm,
+    });
+    const listingRequest = {
+      ...request,
+      includeMetrics: !shouldDeferMetrics,
+    };
+    const requestKey = JSON.stringify(listingRequest);
+
+    if (lastRequestKeyRef.current === requestKey) {
+      return;
+    }
+
+    lastRequestKeyRef.current = requestKey;
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    const hasExistingRows = campaigns.length > 0;
 
     const fetchData = async () => {
-      // Keep the async fetch cancellable so stale responses do not replace newer results.
-      setIsLoading(true);
+      // Keep previous rows rendered while the next search is loading.
+      setIsLoading(!hasExistingRows);
+      setIsRefreshing(hasExistingRows);
       try {
-        const response = await api.getCampaignListing(
-          buildCampaignListingRequest({
-            page,
-            pageSize,
-            orderBy,
-            orderDir,
-            searchTerm,
-          }),
+        const response = await api.getCampaignListing(listingRequest);
+
+        if (requestId !== requestIdRef.current) return;
+
+        lastMetricsRequestKeyRef.current = null;
+        setCampaigns(
+          mergeMetricsIntoCampaigns(
+            response.data || [],
+            metricsCacheRef.current,
+          ),
         );
-
-        if (!active) return;
-
-        setCampaigns(response.data || []);
         setTotal(response.totalCount || 0);
       } catch {
-        if (!active) return;
+        if (requestId !== requestIdRef.current) return;
         setCampaigns([]);
         setTotal(0);
       } finally {
-        if (active) {
-          setIsLoading(false);
-        }
+        if (requestId !== requestIdRef.current) return;
+        setIsLoading(false);
+        setIsRefreshing(false);
       }
     };
 
     fetchData();
+  }, [
+    api,
+    campaigns.length,
+    orderBy,
+    orderDir,
+    page,
+    pageSize,
+    searchTerm,
+    shouldDeferMetrics,
+  ]);
 
-    return () => {
-      active = false;
+  useEffect(() => {
+    if (!shouldDeferMetrics || campaigns.length === 0) {
+      setIsMetricsRefreshing(false);
+      return;
+    }
+
+    const pendingCampaignIds = campaigns
+      .filter((campaign) => !metricsCacheRef.current.has(campaign.campaignId))
+      .map((campaign) => campaign.campaignId);
+    const metricsRequestKey = pendingCampaignIds.join(',');
+
+    if (pendingCampaignIds.length === 0) {
+      lastMetricsRequestKeyRef.current = null;
+      setIsMetricsRefreshing(false);
+      return;
+    }
+
+    if (lastMetricsRequestKeyRef.current === metricsRequestKey) {
+      return;
+    }
+
+    const metricsRequestId = metricsRequestIdRef.current + 1;
+    metricsRequestIdRef.current = metricsRequestId;
+    lastMetricsRequestKeyRef.current = metricsRequestKey;
+    setIsMetricsRefreshing(true);
+
+    const loadMetrics = async () => {
+      const metricsMap =
+        await api.getCampaignListingMetrics(pendingCampaignIds);
+      if (metricsRequestId !== metricsRequestIdRef.current) return;
+
+      metricsMap.forEach((metric, campaignId) => {
+        metricsCacheRef.current.set(campaignId, metric);
+      });
+      setCampaigns((currentCampaigns) =>
+        mergeMetricsIntoCampaigns(currentCampaigns, metricsCacheRef.current),
+      );
+      setIsMetricsRefreshing(false);
     };
-  }, [api, orderBy, orderDir, page, pageSize, searchTerm]);
 
-  return { campaigns, total, isLoading };
+    loadMetrics();
+  }, [api, campaigns, shouldDeferMetrics]);
+
+  return { campaigns, total, isLoading, isRefreshing, isMetricsRefreshing };
 };
 
 export const useCampaignListingPageState = (api: ServiceApi) => {
@@ -137,10 +239,11 @@ export const useCampaignListingPageState = (api: ServiceApi) => {
     () => new URLSearchParams(location.search),
     [location.search],
   );
-  const [searchTerm, setSearchTerm] = useState(
-    () => queryParams.get('search') || '',
+  const [searchTerm, setSearchTerm] = useState(() =>
+    normalizeCampaignSearchTerm(queryParams.get('search') || ''),
   );
   const debouncedSearchTerm = useDebouncedValue(searchTerm, 500);
+  const isSearchPending = searchTerm !== debouncedSearchTerm;
   const [page, setPage] = useState(() => {
     const pageParam = Number.parseInt(queryParams.get('page') || '', 10);
     return Number.isNaN(pageParam) || pageParam < 1 ? 1 : pageParam;
@@ -180,15 +283,16 @@ export const useCampaignListingPageState = (api: ServiceApi) => {
   >({});
   const isFirstSearchRenderRef = useRef(true);
 
-  const { campaigns, total, isLoading } = useCampaignListingData({
-    api,
-    page,
-    pageSize: CAMPAIGN_LISTING_PAGE_SIZE,
-    orderBy: sortBy,
-    orderDir: sortOrder,
-    // Debounce keystrokes so the listing does not hit Supabase on every character typed.
-    searchTerm: debouncedSearchTerm,
-  });
+  const { campaigns, total, isLoading, isRefreshing, isMetricsRefreshing } =
+    useCampaignListingData({
+      api,
+      page,
+      pageSize: CAMPAIGN_LISTING_PAGE_SIZE,
+      orderBy: sortBy,
+      orderDir: sortOrder,
+      // Debounce keystrokes so the listing does not hit Supabase on every character typed.
+      searchTerm: debouncedSearchTerm,
+    });
 
   useEffect(() => {
     if (isFirstSearchRenderRef.current) {
@@ -253,8 +357,10 @@ export const useCampaignListingPageState = (api: ServiceApi) => {
   };
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchTerm(event.target.value);
-    setPage(1);
+    const nextSearchTerm = normalizeCampaignSearchTerm(event.target.value);
+    setSearchTerm((currentSearchTerm) =>
+      currentSearchTerm === nextSearchTerm ? currentSearchTerm : nextSearchTerm,
+    );
   };
 
   const handleOpenMenu = (
@@ -307,6 +413,9 @@ export const useCampaignListingPageState = (api: ServiceApi) => {
   return {
     campaigns: campaignsWithStatusOverrides,
     isLoading,
+    isRefreshing,
+    isMetricsRefreshing,
+    isSearchPending,
     page,
     pageCount: getCampaignListingPageCount(total, CAMPAIGN_LISTING_PAGE_SIZE),
     sortBy,

--- a/src/ops-console/pages/CampaignListingPage.css
+++ b/src/ops-console/pages/CampaignListingPage.css
@@ -114,6 +114,8 @@
 .campaign-listing-table-shell {
   display: flex;
   flex: 1 1 auto;
+  flex-direction: column;
+  gap: 8px;
   min-height: 0;
   padding: 0 20px;
 }

--- a/src/ops-console/pages/CampaignListingPage.tsx
+++ b/src/ops-console/pages/CampaignListingPage.tsx
@@ -137,6 +137,7 @@ const CampaignListingPage: React.FC = () => {
               isFilter={false}
               variantType="outlined"
               searchPlaceholder={String(t('Search Campaigns'))}
+              debounceMs={0}
             />
           </Box>
         </Box>

--- a/src/services/api/ApiHandler.ts
+++ b/src/services/api/ApiHandler.ts
@@ -4,6 +4,7 @@ import {
   CampaignCancellationDetails,
   CampaignAssignmentOptions,
   CampaignAssignmentOptionsParams,
+  CampaignDashboardMetric,
   CampaignListingItem,
   CampaignListingParams,
   CampaignAudienceOptions,
@@ -1633,6 +1634,12 @@ export class ApiHandler implements ServiceApi {
     params: CampaignListingParams,
   ): Promise<PaginatedResponse<CampaignListingItem>> {
     return await this.s.getCampaignListing(params);
+  }
+
+  public async getCampaignListingMetrics(
+    campaignIds: string[],
+  ): Promise<Map<string, CampaignDashboardMetric>> {
+    return await this.s.getCampaignListingMetrics(campaignIds);
   }
 
   public async cancelCampaign(

--- a/src/services/api/ServiceApi.ts
+++ b/src/services/api/ServiceApi.ts
@@ -415,6 +415,9 @@ export type CampaignListingItem = {
   status: CampaignListingStatus;
 };
 
+export type CampaignDashboardMetric =
+  Database['public']['Functions']['get_campaign_dashboard_metrics']['Returns'][number];
+
 export type CampaignCancellationDetails = {
   canceledBy: string | null;
   canceledOn: string | null;
@@ -434,6 +437,7 @@ export type CampaignListingParams = {
     | 'startDate'
     | 'endDate';
   orderDir?: 'asc' | 'desc';
+  includeMetrics?: boolean;
 };
 export type CampaignAssignmentFilters = {
   page: number;
@@ -2452,6 +2456,10 @@ export interface ServiceApi {
   getCampaignListing(
     params: CampaignListingParams,
   ): Promise<PaginatedResponse<CampaignListingItem>>;
+
+  getCampaignListingMetrics(
+    campaignIds: string[],
+  ): Promise<Map<string, CampaignDashboardMetric>>;
 
   /**
    * Cancels an existing campaign and persists the inactive status update in the database.

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -104,6 +104,7 @@ import {
   CampaignCancellationDetails,
   CampaignAssignmentOptions,
   CampaignAssignmentOptionsParams,
+  CampaignDashboardMetric,
   CampaignListingItem,
   CampaignListingParams,
   CampaignAudienceOptions,
@@ -8050,6 +8051,12 @@ order by
     params: CampaignListingParams,
   ): Promise<PaginatedResponse<CampaignListingItem>> {
     return await this._serverApi.getCampaignListing(params);
+  }
+
+  async getCampaignListingMetrics(
+    campaignIds: string[],
+  ): Promise<Map<string, CampaignDashboardMetric>> {
+    return await this._serverApi.getCampaignListingMetrics(campaignIds);
   }
 
   async cancelCampaign(campaignId: string, reason: string): Promise<void> {

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -127,6 +127,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { ServiceConfig } from '../ServiceConfig';
 import { SqliteApi } from './SqliteApi';
 import {
+  CAMPAIGN_LISTING_ORDER_BY,
   mapCampaignListingItem,
   sortCampaignListingItems,
 } from './campaignListingHelpers';
@@ -10034,8 +10035,9 @@ export class SupabaseApi implements ServiceApi {
       let totalCount = 0;
       const shouldIncludeMetrics =
         includeMetrics ||
-        orderBy === 'avgWeeklyActiveUsers' ||
-        orderBy === 'avgWeeklyEngagementTimeMinutes';
+        orderBy === CAMPAIGN_LISTING_ORDER_BY.AVG_WEEKLY_ACTIVE_USERS ||
+        orderBy ===
+          CAMPAIGN_LISTING_ORDER_BY.AVG_WEEKLY_ENGAGEMENT_TIME_MINUTES;
       const campaignMetricsMap = shouldIncludeMetrics
         ? await this.getCampaignListingMetrics(
             visibleCampaigns.map((campaign) => campaign.id),

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -10099,7 +10099,8 @@ export class SupabaseApi implements ServiceApi {
         await this.supabase
           .from('campaign_target_audience_school')
           .select('target_audience_id')
-          .in('school_id', accessibleSchoolIds);
+          .in('school_id', accessibleSchoolIds)
+          .eq('is_deleted', false);
 
       if (audienceAccessError) {
         logger.error(

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -70,6 +70,7 @@ import {
   AssignmentDateRangeData,
   CampaignAssignmentOptions,
   CampaignAssignmentOptionsParams,
+  CampaignDashboardMetric,
   CampaignListingItem,
   CampaignListingParams,
   CampaignAudienceOptions,
@@ -368,6 +369,11 @@ type CampaignAccessSchoolRow = Pick<TableTypes<'school_user'>, 'school_id'> & {
     | null;
 };
 
+type CampaignAudienceAccessRow = Pick<
+  TableTypes<'campaign_target_audience_school'>,
+  'target_audience_id'
+>;
+
 const getSingleRelationValue = <T>(value: T | T[] | null | undefined) =>
   Array.isArray(value) ? (value[0] ?? null) : (value ?? null);
 
@@ -378,6 +384,10 @@ const CAMPAIGN_LISTING_NATIVE_SORT_COLUMNS: Partial<
   startDate: 'start_date',
   endDate: 'end_date',
 };
+
+const isCampaignListingRelationSort = (
+  orderBy: NonNullable<CampaignListingParams['orderBy']>,
+) => orderBy === 'manager' || orderBy === 'programName';
 
 type CampaignSchoolRow = Pick<TableTypes<'school'>, 'id' | 'name' | 'group3'>;
 
@@ -9801,6 +9811,7 @@ export class SupabaseApi implements ServiceApi {
     searchTerm = '',
     orderBy = 'startDate',
     orderDir = 'desc',
+    includeMetrics = true,
   }: CampaignListingParams): Promise<{
     data: CampaignListingItem[];
     totalCount: number;
@@ -9813,53 +9824,25 @@ export class SupabaseApi implements ServiceApi {
     const supabase = this.supabase;
     const normalizedSearchTerm = searchTerm.trim();
     const now = new Date();
-    const fetchCampaignListingMetrics = async (
-      campaignIds: string[],
-    ): Promise<Map<string, CampaignListingItem['dashboardMetrics']>> => {
-      if (campaignIds.length === 0) {
-        return new Map();
-      }
-
-      try {
-        const { data: metricsData, error: metricsError } = await supabase.rpc(
-          'get_campaign_dashboard_metrics',
-          {
-            p_campaign_ids: campaignIds,
-          },
-        );
-
-        if (metricsError) {
-          logger.error(
-            'Error fetching campaign dashboard metrics for listing:',
-            metricsError,
-          );
-          return new Map();
-        }
-
-        return new Map(
-          (metricsData ?? []).map((metric) => [metric.campaign_id, metric]),
-        );
-      } catch (metricsError) {
-        logger.error(
-          'Unexpected error fetching campaign dashboard metrics for listing:',
-          metricsError,
-        );
-        return new Map();
-      }
-    };
 
     try {
-      const {
-        data: { user: authUser },
-      } = await supabase.auth.getUser();
+      const authState = store.getState().auth;
+      const authUserId =
+        authState.authUser?.id ||
+        (await supabase.auth.getUser()).data.user?.id ||
+        '';
 
-      if (!authUser?.id) {
+      if (!authUserId) {
         logger.error('Current user is not available for campaign listing');
         return { data: [], totalCount: 0 };
       }
 
-      // Campaign listing access is role-based: admins/managers see all, field coordinators are scoped.
-      const specialRoles = await this.getUserSpecialRoles(authUser.id);
+      // Prefer already-loaded Redux roles so the listing does not refetch special_users on every search.
+      const storeRoles = authState.roles ?? [];
+      const specialRoles =
+        storeRoles.length > 0
+          ? storeRoles
+          : await this.getUserSpecialRoles(authUserId);
       const hasGlobalCampaignAccess = specialRoles.some((role) =>
         [
           RoleType.SUPER_ADMIN,
@@ -9877,12 +9860,12 @@ export class SupabaseApi implements ServiceApi {
             supabase
               .from(TABLES.SchoolUser)
               .select('school_id, school:school_id(program_id)')
-              .eq('user_id', authUser.id)
+              .eq('user_id', authUserId)
               .eq('is_deleted', false),
             supabase
               .from(TABLES.ProgramUser)
               .select('program_id')
-              .eq('user', authUser.id)
+              .eq('user', authUserId)
               .eq('role', RoleType.FIELD_COORDINATOR)
               .eq('is_deleted', false),
           ])
@@ -9941,52 +9924,37 @@ export class SupabaseApi implements ServiceApi {
         return { data: [], totalCount: 0 };
       }
 
-      // Search is supported across campaign name, manager name, and program name.
-      const [managerSearchResponse, programSearchResponse] =
-        normalizedSearchTerm.length > 0
-          ? await Promise.all([
-              this.supabase
-                .from(TABLES.User)
-                .select('id')
-                .ilike('name', `%${normalizedSearchTerm}%`)
-                .eq('is_deleted', false)
-                .limit(50),
-              this.supabase
-                .from(TABLES.Program)
-                .select('id')
-                .ilike('name', `%${normalizedSearchTerm}%`)
-                .eq('is_deleted', false)
-                .limit(50),
-            ])
-          : [
-              { data: [], error: null },
-              { data: [], error: null },
-            ];
-
-      if (managerSearchResponse.error) {
-        logger.error(
-          'Error searching campaign managers for listing:',
-          managerSearchResponse.error,
-        );
-      }
-
-      if (programSearchResponse.error) {
-        logger.error(
-          'Error searching campaign programs for listing:',
-          programSearchResponse.error,
-        );
-      }
-
-      const managerIds = (managerSearchResponse.data ?? []).map(
-        (row) => row.id,
-      );
-      const programIds = (programSearchResponse.data ?? []).map(
-        (row) => row.id,
-      );
       const nativeSortColumn = CAMPAIGN_LISTING_NATIVE_SORT_COLUMNS[orderBy];
-      const shouldUseDatabasePagination =
-        !isFieldCoordinator && Boolean(nativeSortColumn);
-      const campaignListingSelect = `*, manager:manager_id(*), program:program_id(*),
+      const shouldUseRelationSort = isCampaignListingRelationSort(orderBy);
+      const allowedCampaignIds = isFieldCoordinator
+        ? await this.getFieldCoordinatorAccessibleCampaignIds({
+            accessibleSchoolIds: Array.from(accessibleSchoolIds),
+            accessibleProgramIds: Array.from(accessibleProgramIds),
+            directProgramIds: Array.from(fieldCoordinatorProgramIds),
+          })
+        : null;
+
+      if (
+        isFieldCoordinator &&
+        (!allowedCampaignIds || allowedCampaignIds.length === 0)
+      ) {
+        return { data: [], totalCount: 0 };
+      }
+
+      const shouldUseDatabasePagination = Boolean(
+        nativeSortColumn || shouldUseRelationSort,
+      );
+      const searchRelationSelect =
+        normalizedSearchTerm.length > 0
+          ? `,
+        manager_search:user!campaign_manager_id_fkey(),
+        program_search:program!campaign_program_id_fkey()`
+          : '';
+      const campaignListingSelect = `id, name, objective, start_date, end_date,
+        campaign_status, manager_id, program_id, target_audience_id,
+        created_at, updated_at, is_deleted, target_type, target_value, rewards,
+        manager:user!campaign_manager_id_fkey(id, name),
+        program:program!campaign_program_id_fkey(id, name)${searchRelationSelect},
         target_audience:target_audience_id(
           id,
           is_all_schools,
@@ -10000,22 +9968,47 @@ export class SupabaseApi implements ServiceApi {
         })
         .eq('is_deleted', false);
 
-      if (normalizedSearchTerm.length > 0) {
-        // Escape quoted search text before building the PostgREST OR filter expression.
-        const escapedSearchTerm = normalizedSearchTerm.replace(/"/g, '\\"');
-        const orFilters = [`name.ilike."%${escapedSearchTerm}%"`];
-        if (managerIds.length > 0) {
-          orFilters.push(`manager_id.in.(${managerIds.join(',')})`);
-        }
-        if (programIds.length > 0) {
-          orFilters.push(`program_id.in.(${programIds.join(',')})`);
-        }
-        campaignQuery.or(orFilters.join(','));
+      if (allowedCampaignIds) {
+        campaignQuery.in('id', allowedCampaignIds);
       }
 
-      if (shouldUseDatabasePagination && nativeSortColumn) {
+      if (normalizedSearchTerm.length > 0) {
+        const escapedSearchTerm = normalizedSearchTerm
+          .replace(/\\/g, '\\\\')
+          .replace(/,/g, '\\,')
+          .replace(/\(/g, '\\(')
+          .replace(/\)/g, '\\)');
         campaignQuery
-          .order(nativeSortColumn, { ascending: orderDir === 'asc' })
+          .ilike('manager_search.name', `%${normalizedSearchTerm}%`)
+          .ilike('program_search.name', `%${normalizedSearchTerm}%`);
+        campaignQuery.or(
+          [
+            `name.ilike.%${escapedSearchTerm}%`,
+            'manager_search.not.is.null',
+            'program_search.not.is.null',
+          ].join(','),
+        );
+      }
+
+      if (shouldUseDatabasePagination) {
+        if (nativeSortColumn) {
+          campaignQuery.order(nativeSortColumn, {
+            ascending: orderDir === 'asc',
+          });
+        } else if (orderBy === 'manager') {
+          campaignQuery.order('name', {
+            ascending: orderDir === 'asc',
+            foreignTable: TABLES.User,
+          });
+        } else if (orderBy === 'programName') {
+          campaignQuery.order('name', {
+            ascending: orderDir === 'asc',
+            foreignTable: TABLES.Program,
+          });
+        }
+
+        campaignQuery
+          .order('id', { ascending: orderDir === 'asc' })
           .range(
             (Math.max(page, 1) - 1) * Math.max(pageSize, 1),
             Math.max(page, 1) * Math.max(pageSize, 1) - 1,
@@ -10029,48 +10022,25 @@ export class SupabaseApi implements ServiceApi {
         return { data: [], totalCount: 0 };
       }
 
-      const mappedCampaigns = (data ?? []) as CampaignListingQueryRow[];
+      const mappedCampaigns = (data ??
+        []) as unknown as CampaignListingQueryRow[];
 
-      // Apply field-coordinator visibility after the base campaign query so audience links can be inspected.
-      const visibleCampaigns = shouldUseDatabasePagination
-        ? mappedCampaigns
-        : isFieldCoordinator
-          ? mappedCampaigns.filter((campaign) => {
-              const targetAudience = getSingleRelationValue(
-                campaign.target_audience,
-              );
-              const audienceSchoolIds = (
-                targetAudience?.campaign_target_audience_school ?? []
-              )
-                .map((row) => row.school_id)
-                .filter((id): id is string => !!id);
-              const hasProgramAccess =
-                !!campaign.program_id &&
-                accessibleProgramIds.has(campaign.program_id);
-              const hasSchoolAccess = audienceSchoolIds.some((schoolId) =>
-                accessibleSchoolIds.has(schoolId),
-              );
-              const hasDirectProgramAssignment =
-                !!campaign.program_id &&
-                fieldCoordinatorProgramIds.has(campaign.program_id);
-
-              return (
-                hasSchoolAccess ||
-                (hasProgramAccess &&
-                  (Boolean(targetAudience?.is_all_schools) ||
-                    hasDirectProgramAssignment))
-              );
-            })
-          : mappedCampaigns;
+      const visibleCampaigns = mappedCampaigns;
       const currentPage = Math.max(page, 1);
       const currentPageSize = Math.max(pageSize, 1);
       const from = (currentPage - 1) * currentPageSize;
 
       let listingItems: CampaignListingItem[] = [];
       let totalCount = 0;
-      const campaignMetricsMap = await fetchCampaignListingMetrics(
-        visibleCampaigns.map((campaign) => campaign.id),
-      );
+      const shouldIncludeMetrics =
+        includeMetrics ||
+        orderBy === 'avgWeeklyActiveUsers' ||
+        orderBy === 'avgWeeklyEngagementTimeMinutes';
+      const campaignMetricsMap = shouldIncludeMetrics
+        ? await this.getCampaignListingMetrics(
+            visibleCampaigns.map((campaign) => campaign.id),
+          )
+        : new Map<string, CampaignDashboardMetric>();
 
       if (shouldUseDatabasePagination) {
         listingItems = visibleCampaigns.map((campaign) =>
@@ -10104,6 +10074,162 @@ export class SupabaseApi implements ServiceApi {
     } catch (error) {
       logger.error('Unexpected error fetching campaign listing:', error);
       return { data: [], totalCount: 0 };
+    }
+  }
+
+  private async getFieldCoordinatorAccessibleCampaignIds({
+    accessibleSchoolIds,
+    accessibleProgramIds,
+    directProgramIds,
+  }: {
+    accessibleSchoolIds: string[];
+    accessibleProgramIds: string[];
+    directProgramIds: string[];
+  }): Promise<string[]> {
+    if (!this.supabase) {
+      return [];
+    }
+
+    const allowedCampaignIds = new Set<string>();
+
+    if (accessibleSchoolIds.length > 0) {
+      const { data: audienceAccessRows, error: audienceAccessError } =
+        await this.supabase
+          .from('campaign_target_audience_school')
+          .select('target_audience_id')
+          .in('school_id', accessibleSchoolIds);
+
+      if (audienceAccessError) {
+        logger.error(
+          'Error fetching field coordinator audience access rows:',
+          audienceAccessError,
+        );
+        return [];
+      }
+
+      const audienceIds = Array.from(
+        new Set(
+          ((audienceAccessRows ?? []) as CampaignAudienceAccessRow[])
+            .map((row) => row.target_audience_id)
+            .filter((id): id is string => !!id),
+        ),
+      );
+
+      if (audienceIds.length > 0) {
+        const { data: schoolCampaignRows, error: schoolCampaignError } =
+          await this.supabase
+            .from('campaign')
+            .select('id')
+            .eq('is_deleted', false)
+            .in('target_audience_id', audienceIds);
+
+        if (schoolCampaignError) {
+          logger.error(
+            'Error fetching field coordinator school-access campaign ids:',
+            schoolCampaignError,
+          );
+          return [];
+        }
+
+        ((schoolCampaignRows ?? []) as Array<{ id?: string | null }>).forEach(
+          (row) => {
+            if (row.id) {
+              allowedCampaignIds.add(row.id);
+            }
+          },
+        );
+      }
+    }
+
+    if (accessibleProgramIds.length > 0) {
+      const { data: allSchoolsCampaignRows, error: allSchoolsCampaignError } =
+        await this.supabase
+          .from('campaign')
+          .select(
+            'id, target_audience:target_audience_id!inner(is_all_schools)',
+          )
+          .eq('is_deleted', false)
+          .in('program_id', accessibleProgramIds)
+          .eq('target_audience.is_all_schools', true);
+
+      if (allSchoolsCampaignError) {
+        logger.error(
+          'Error fetching field coordinator all-schools campaign ids:',
+          allSchoolsCampaignError,
+        );
+        return [];
+      }
+
+      ((allSchoolsCampaignRows ?? []) as Array<{ id?: string | null }>).forEach(
+        (row) => {
+          if (row.id) {
+            allowedCampaignIds.add(row.id);
+          }
+        },
+      );
+    }
+
+    if (directProgramIds.length > 0) {
+      const { data: directProgramCampaignRows, error: directProgramError } =
+        await this.supabase
+          .from('campaign')
+          .select('id')
+          .eq('is_deleted', false)
+          .in('program_id', directProgramIds);
+
+      if (directProgramError) {
+        logger.error(
+          'Error fetching field coordinator direct-program campaign ids:',
+          directProgramError,
+        );
+        return [];
+      }
+
+      (
+        (directProgramCampaignRows ?? []) as Array<{ id?: string | null }>
+      ).forEach((row) => {
+        if (row.id) {
+          allowedCampaignIds.add(row.id);
+        }
+      });
+    }
+
+    return Array.from(allowedCampaignIds);
+  }
+
+  async getCampaignListingMetrics(
+    campaignIds: string[],
+  ): Promise<Map<string, CampaignDashboardMetric>> {
+    if (!this.supabase || campaignIds.length === 0) {
+      return new Map();
+    }
+
+    try {
+      const { data: metricsData, error: metricsError } =
+        await this.supabase.rpc('get_campaign_dashboard_metrics', {
+          p_campaign_ids: campaignIds,
+        });
+
+      if (metricsError) {
+        logger.error(
+          'Error fetching campaign dashboard metrics for listing:',
+          metricsError,
+        );
+        return new Map();
+      }
+
+      return new Map(
+        ((metricsData ?? []) as CampaignDashboardMetric[]).map((metric) => [
+          metric.campaign_id,
+          metric,
+        ]),
+      );
+    } catch (metricsError) {
+      logger.error(
+        'Unexpected error fetching campaign dashboard metrics for listing:',
+        metricsError,
+      );
+      return new Map();
     }
   }
 

--- a/src/services/api/campaignListingHelpers.ts
+++ b/src/services/api/campaignListingHelpers.ts
@@ -14,7 +14,7 @@ import type { Column } from '../../ops-console/components/DataTableBody';
 import type { CampaignsOverviewApiResponse } from '../../ops-console/components/campaignsOverview/CampaignsOverviewLogic';
 import CampaignsOverviewInfoTooltip from '../../ops-console/components/campaignsOverview/CampaignsOverviewInfoTooltip';
 
-const CAMPAIGN_LISTING_ORDER_BY = {
+export const CAMPAIGN_LISTING_ORDER_BY = {
   NAME: 'name',
   MANAGER: 'manager',
   PROGRAM_NAME: 'programName',


### PR DESCRIPTION
Search is faster and more stable now.
We added debounce, ignored old/stale API responses, and stabilized the search handler so typing does not keep resetting the debounce logic.

Campaign data loads more efficiently.
The page now loads base campaign rows first, then loads metrics separately only when needed, and reuses cached metrics for campaigns already seen.

Filtering and sorting are pushed closer to the database.
Field coordinator access is filtered before large result sets come back, and Manager / Program sorting now happens in the database with pagination instead of fetching many rows and sorting them in JavaScript.