### PR TITLE
Skip saving unconfigured missing-date placeholders

### DIFF
--- a/src/ops-console/components/campaignMessages/CampaignMessages.test.tsx
+++ b/src/ops-console/components/campaignMessages/CampaignMessages.test.tsx
@@ -606,4 +606,76 @@ describe('CampaignMessagesLogic', () => {
       },
     ]);
   });
+
+  it('does not create a record for a missing date with only time changes', () => {
+    const currentRow: CampaignMessageRow = {
+      id: '2099-06-11-2',
+      scheduledDate: '2099-06-11',
+      dayLabel: 'Day 2',
+      dateLabel: '11 June',
+      message: '',
+      mediaLink: '',
+      messageTimeIso: '2099-06-11T15:00:00.000Z',
+      pollTimeIso: '2099-06-11T10:00:00.000Z',
+      pollQuestion: '',
+      pollOptions: [],
+      messageStatus: '',
+      pollStatus: '',
+      messageEditable: true,
+      pollEditable: true,
+      isEditable: true,
+      isPersisted: false,
+    };
+    const nextRow: CampaignMessageRow = {
+      ...currentRow,
+      messageTimeIso: '2099-06-11T16:00:00.000Z',
+      pollTimeIso: '2099-06-11T11:00:00.000Z',
+    };
+
+    expect(
+      buildCampaignMessageSavePayload('campaign-1', [currentRow], [nextRow]),
+    ).toEqual([]);
+  });
+
+  it('creates a record for a configured missing date', () => {
+    const currentRow: CampaignMessageRow = {
+      id: '2099-06-11-2',
+      scheduledDate: '2099-06-11',
+      dayLabel: 'Day 2',
+      dateLabel: '11 June',
+      message: '',
+      mediaLink: '',
+      messageTimeIso: '2099-06-11T15:00:00.000Z',
+      pollTimeIso: '2099-06-11T10:00:00.000Z',
+      pollQuestion: '',
+      pollOptions: [],
+      messageStatus: '',
+      pollStatus: '',
+      messageEditable: true,
+      pollEditable: true,
+      isEditable: true,
+      isPersisted: false,
+    };
+    const nextRow: CampaignMessageRow = {
+      ...currentRow,
+      message: 'Configured message',
+    };
+
+    expect(
+      buildCampaignMessageSavePayload('campaign-1', [currentRow], [nextRow]),
+    ).toEqual([
+      {
+        campaignId: 'campaign-1',
+        id: undefined,
+        message: 'Configured message',
+        mediaLink: '',
+        messageTime: '2099-06-11T15:00:00.000Z',
+        pollTime: '2099-06-11T10:00:00.000Z',
+        pollQuestion: '',
+        pollOptions: [],
+        messageStatus: null,
+        pollStatus: null,
+      },
+    ]);
+  });
 });

--- a/src/ops-console/components/campaignMessages/CampaignMessagesLogic.ts
+++ b/src/ops-console/components/campaignMessages/CampaignMessagesLogic.ts
@@ -573,6 +573,13 @@ const areCampaignMessageRowsEqual = (
     normalizePollOptions(nextRow.pollOptions),
   );
 
+// Missing timeline dates are display placeholders and must not create time-only records.
+const hasConfiguredContent = (row: CampaignMessageRow): boolean =>
+  normalizeText(row.message).length > 0 ||
+  normalizeText(row.mediaLink).length > 0 ||
+  normalizeText(row.pollQuestion).length > 0 ||
+  normalizePollOptions(row.pollOptions).length > 0;
+
 export const buildCampaignMessageSavePayload = (
   campaignId: string,
   currentRows: readonly CampaignMessageRow[],
@@ -590,6 +597,7 @@ export const buildCampaignMessageSavePayload = (
 
   return nextRows
     .filter((row) => row.isEditable && row.id.trim().length > 0)
+    .filter((row) => row.isPersisted || hasConfiguredContent(row))
     .filter((row) => {
       const currentRow = currentRowsById[row.id];
       if (!currentRow) return true;

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -17555,8 +17555,6 @@ export class SupabaseApi implements ServiceApi {
         String(row.id ?? '').trim().length > 0 ||
         String(row.message ?? '').trim().length > 0 ||
         String(row.mediaLink ?? '').trim().length > 0 ||
-        String(row.messageTime ?? '').trim().length > 0 ||
-        String(row.pollTime ?? '').trim().length > 0 ||
         String(row.pollQuestion ?? '').trim().length > 0 ||
         row.pollOptions.some(
           (option) => String(option ?? '').trim().length > 0,


### PR DESCRIPTION
Missing timeline dates are display placeholders that should not create records when only time values change. Added `hasConfiguredContent()` to filter out unpersisted rows that lack message, media, poll question, or poll options. Also removed redundant messageTime and pollTime validation from SupabaseApi.