### PR TITLE
fix: update sidebar routing for coordinator pages

### DIFF
--- a/src/ops-console/pages/SidebarPage.tsx
+++ b/src/ops-console/pages/SidebarPage.tsx
@@ -129,10 +129,11 @@ const SidebarPage: React.FC = () => {
   const canAccessCampaignPage = userRoles.some((role) =>
     CAMPAIGN_ACCESS_ROLES.includes(role as RoleType),
   );
-  const canAccessRequestPage = userRoles.includes(RoleType.FIELD_COORDINATOR);
-  const canAccessDashboardPage = userRoles.includes(RoleType.FIELD_COORDINATOR);
-  const canAccessDevicesPage = userRoles.includes(RoleType.FIELD_COORDINATOR);
-  const canAccessResourcesPage = userRoles.includes(RoleType.FIELD_COORDINATOR);
+  const isFieldCoordinator = userRoles.includes(RoleType.FIELD_COORDINATOR);
+  const canAccessRequestPage = isFieldCoordinator;
+  const canAccessDashboardPage = isFieldCoordinator;
+  const canAccessDevicesPage = isFieldCoordinator;
+  const canAccessResourcesPage = isFieldCoordinator;
 
   useEffect(() => {
     fetchData();

--- a/src/ops-console/pages/SidebarPage.tsx
+++ b/src/ops-console/pages/SidebarPage.tsx
@@ -161,8 +161,7 @@ const SidebarPage: React.FC = () => {
           location.pathname.startsWith(campaignDetailsPrefix))) ||
       (canAccessRequestPage &&
         (location.pathname === requestListPath ||
-          location.pathname.startsWith(requestDetailsPrefix) ||
-          location.pathname === dashboardPath)) ||
+          location.pathname.startsWith(requestDetailsPrefix))) ||
       (canAccessDevicesPage && location.pathname === devicesPath) ||
       (canAccessResourcesPage && location.pathname === resourcesPath) ||
       (canAccessDashboardPage && location.pathname === dashboardPath);

--- a/src/ops-console/pages/SidebarPage.tsx
+++ b/src/ops-console/pages/SidebarPage.tsx
@@ -129,8 +129,7 @@ const SidebarPage: React.FC = () => {
   const canAccessCampaignPage = userRoles.some((role) =>
     CAMPAIGN_ACCESS_ROLES.includes(role as RoleType),
   );
-  const isFieldCoordinator = userRoles.includes(RoleType.FIELD_COORDINATOR);
-  const canAccessFieldCoordinatorPages = isFieldCoordinator;
+  const canAccessFieldCoordinatorPages = userRoles.includes(RoleType.FIELD_COORDINATOR);
 
   useEffect(() => {
     fetchData();

--- a/src/ops-console/pages/SidebarPage.tsx
+++ b/src/ops-console/pages/SidebarPage.tsx
@@ -130,6 +130,9 @@ const SidebarPage: React.FC = () => {
     CAMPAIGN_ACCESS_ROLES.includes(role as RoleType),
   );
   const canAccessRequestPage = userRoles.includes(RoleType.FIELD_COORDINATOR);
+  const canAccessDashboardPage = userRoles.includes(RoleType.FIELD_COORDINATOR);
+  const canAccessDevicesPage = userRoles.includes(RoleType.FIELD_COORDINATOR);
+  const canAccessResourcesPage = userRoles.includes(RoleType.FIELD_COORDINATOR);
 
   useEffect(() => {
     fetchData();
@@ -147,6 +150,7 @@ const SidebarPage: React.FC = () => {
     const requestDetailsPrefix = `${requestListPath}/`;
     const devicesPath = `${path}${PAGES.ADMIN_DEVICES}`;
     const resourcesPath = `${path}${PAGES.ADMIN_RESOURCES}`;
+    const dashboardPath = `${path}${PAGES.ADMIN_DASHBOARD}`;
     const isAllowedPath =
       location.pathname === schoolListPath ||
       location.pathname.startsWith(schoolDetailsPrefix) ||
@@ -156,9 +160,11 @@ const SidebarPage: React.FC = () => {
           location.pathname.startsWith(campaignDetailsPrefix))) ||
       (canAccessRequestPage &&
         (location.pathname === requestListPath ||
-          location.pathname.startsWith(requestDetailsPrefix))) ||
-      location.pathname === devicesPath ||
-      location.pathname === resourcesPath;
+          location.pathname.startsWith(requestDetailsPrefix) ||
+          location.pathname === dashboardPath)) ||
+      (canAccessDevicesPage && location.pathname === devicesPath) ||
+      (canAccessResourcesPage && location.pathname === resourcesPath) ||
+      (canAccessDashboardPage && location.pathname === dashboardPath);
 
     if (!isAllowedPath) {
       history.replace(schoolListPath);
@@ -166,6 +172,9 @@ const SidebarPage: React.FC = () => {
   }, [
     canAccessCampaignPage,
     canAccessProgramPage,
+    canAccessDashboardPage,
+    canAccessDevicesPage,
+    canAccessResourcesPage,
     canAccessRequestPage,
     history,
     isExternalUser,

--- a/src/ops-console/pages/SidebarPage.tsx
+++ b/src/ops-console/pages/SidebarPage.tsx
@@ -130,10 +130,7 @@ const SidebarPage: React.FC = () => {
     CAMPAIGN_ACCESS_ROLES.includes(role as RoleType),
   );
   const isFieldCoordinator = userRoles.includes(RoleType.FIELD_COORDINATOR);
-  const canAccessRequestPage = isFieldCoordinator;
-  const canAccessDashboardPage = isFieldCoordinator;
-  const canAccessDevicesPage = isFieldCoordinator;
-  const canAccessResourcesPage = isFieldCoordinator;
+  const canAccessFieldCoordinatorPages = isFieldCoordinator;
 
   useEffect(() => {
     fetchData();
@@ -159,12 +156,12 @@ const SidebarPage: React.FC = () => {
         (location.pathname === campaignsPath ||
           location.pathname === campaignCreatePath ||
           location.pathname.startsWith(campaignDetailsPrefix))) ||
-      (canAccessRequestPage &&
+      (canAccessFieldCoordinatorPages &&
         (location.pathname === requestListPath ||
-          location.pathname.startsWith(requestDetailsPrefix))) ||
-      (canAccessDevicesPage && location.pathname === devicesPath) ||
-      (canAccessResourcesPage && location.pathname === resourcesPath) ||
-      (canAccessDashboardPage && location.pathname === dashboardPath);
+          location.pathname.startsWith(requestDetailsPrefix) ||
+          location.pathname === devicesPath ||
+          location.pathname === resourcesPath ||
+          location.pathname === dashboardPath));
 
     if (!isAllowedPath) {
       history.replace(schoolListPath);
@@ -172,10 +169,7 @@ const SidebarPage: React.FC = () => {
   }, [
     canAccessCampaignPage,
     canAccessProgramPage,
-    canAccessDashboardPage,
-    canAccessDevicesPage,
-    canAccessResourcesPage,
-    canAccessRequestPage,
+    canAccessFieldCoordinatorPages,
     history,
     isExternalUser,
     location.pathname,


### PR DESCRIPTION
## Summary

This PR updates OPS sidebar routing for Field Coordinator users by fixing Dashboard navigation.

## Changes

- Prevented Dashboard from redirecting Field Coordinators to School List.
- Added Dashboard to the sidebar routing allowlist so it stays on the correct page.
- Cleaned up the coordinator routing check in `SidebarPage.tsx` for readability.

