### PR TITLE
Fix: chim-1158 sidebar routing

### DIFF
--- a/src/ops-console/pages/SidebarPage.tsx
+++ b/src/ops-console/pages/SidebarPage.tsx
@@ -129,7 +129,9 @@ const SidebarPage: React.FC = () => {
   const canAccessCampaignPage = userRoles.some((role) =>
     CAMPAIGN_ACCESS_ROLES.includes(role as RoleType),
   );
-  const canAccessRequestPage = userRoles.includes(RoleType.FIELD_COORDINATOR);
+  const canAccessCoordinatorPages = userRoles.includes(
+    RoleType.FIELD_COORDINATOR,
+  );
 
   useEffect(() => {
     fetchData();
@@ -154,11 +156,12 @@ const SidebarPage: React.FC = () => {
         (location.pathname === campaignsPath ||
           location.pathname === campaignCreatePath ||
           location.pathname.startsWith(campaignDetailsPrefix))) ||
-      (canAccessRequestPage &&
+      (canAccessCoordinatorPages &&
         (location.pathname === requestListPath ||
-          location.pathname.startsWith(requestDetailsPrefix))) ||
-      location.pathname === devicesPath ||
-      location.pathname === resourcesPath;
+          location.pathname.startsWith(requestDetailsPrefix) ||
+          location.pathname === devicesPath ||
+          location.pathname === resourcesPath ||
+          location.pathname === `${path}${PAGES.ADMIN_DASHBOARD}`));
 
     if (!isAllowedPath) {
       history.replace(schoolListPath);
@@ -166,7 +169,7 @@ const SidebarPage: React.FC = () => {
   }, [
     canAccessCampaignPage,
     canAccessProgramPage,
-    canAccessRequestPage,
+    canAccessCoordinatorPages,
     history,
     isExternalUser,
     location.pathname,

--- a/src/ops-console/pages/SidebarPage.tsx
+++ b/src/ops-console/pages/SidebarPage.tsx
@@ -149,6 +149,7 @@ const SidebarPage: React.FC = () => {
     const requestDetailsPrefix = `${requestListPath}/`;
     const devicesPath = `${path}${PAGES.ADMIN_DEVICES}`;
     const resourcesPath = `${path}${PAGES.ADMIN_RESOURCES}`;
+    const dashboardPath = `${path}${PAGES.ADMIN_DASHBOARD}`;
     const isAllowedPath =
       location.pathname === schoolListPath ||
       location.pathname.startsWith(schoolDetailsPrefix) ||
@@ -161,7 +162,7 @@ const SidebarPage: React.FC = () => {
           location.pathname.startsWith(requestDetailsPrefix) ||
           location.pathname === devicesPath ||
           location.pathname === resourcesPath ||
-          location.pathname === `${path}${PAGES.ADMIN_DASHBOARD}`));
+          location.pathname === dashboardPath));
 
     if (!isAllowedPath) {
       history.replace(schoolListPath);


### PR DESCRIPTION
## Summary

This PR simplifies OPS sidebar routing for Field Coordinator users.

## Changes

- Replaced multiple coordinator permission flags with a single shared flag in `SidebarPage.tsx`.
- Grouped coordinator-only routes under one allowlist check.
- Kept the current routing behavior intact while making the logic easier to maintain.
