### PR TITLE
Fix: Restrict program creation access for program managers

### DIFF
--- a/src/ops-console/components/ProgramActionsMenu.tsx
+++ b/src/ops-console/components/ProgramActionsMenu.tsx
@@ -12,10 +12,12 @@ import { Add } from '@mui/icons-material';
 import { t } from 'i18next';
 
 type ProgramActionsMenuProps = {
+  canCreateProgram: boolean;
   onNewProgram: () => void;
 };
 
 const ProgramActionsMenu: React.FC<ProgramActionsMenuProps> = ({
+  canCreateProgram,
   onNewProgram,
 }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -44,6 +46,10 @@ const ProgramActionsMenu: React.FC<ProgramActionsMenuProps> = ({
     handleClose();
     onNewProgram();
   }, [handleClose, onNewProgram]);
+
+  if (!canCreateProgram) {
+    return null;
+  }
 
   return (
     <>

--- a/src/ops-console/components/ProgramActionsMenu.tsx
+++ b/src/ops-console/components/ProgramActionsMenu.tsx
@@ -12,12 +12,10 @@ import { Add } from '@mui/icons-material';
 import { t } from 'i18next';
 
 type ProgramActionsMenuProps = {
-  canCreateProgram: boolean;
   onNewProgram: () => void;
 };
 
 const ProgramActionsMenu: React.FC<ProgramActionsMenuProps> = ({
-  canCreateProgram,
   onNewProgram,
 }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -46,10 +44,6 @@ const ProgramActionsMenu: React.FC<ProgramActionsMenuProps> = ({
     handleClose();
     onNewProgram();
   }, [handleClose, onNewProgram]);
-
-  if (!canCreateProgram) {
-    return null;
-  }
 
   return (
     <>

--- a/src/ops-console/components/ProgramListTable.tsx
+++ b/src/ops-console/components/ProgramListTable.tsx
@@ -89,10 +89,9 @@ const ProgramListControls: React.FC<ProgramListTableProps> = (props) => (
           isExporting={props.isExporting}
           onClick={props.onExport}
         />
-        <ProgramActionsMenu
-          canCreateProgram={props.canCreateProgram}
-          onNewProgram={props.onNewProgram}
-        />
+        {props.canCreateProgram ? (
+          <ProgramActionsMenu onNewProgram={props.onNewProgram} />
+        ) : null}
         <SchoolListDateRangeDropdown
           value={props.selectedDateRange}
           onChange={props.onDateRangeChange}

--- a/src/ops-console/components/ProgramListTable.tsx
+++ b/src/ops-console/components/ProgramListTable.tsx
@@ -40,6 +40,7 @@ type ProgramListTableProps = {
   isExportDisabled: boolean;
   isExporting: boolean;
   onExport: () => void | Promise<void>;
+  canCreateProgram: boolean;
   onNewProgram: () => void;
   columns: Column<ProgramListRow>[];
   rows: ProgramListRow[];
@@ -88,7 +89,10 @@ const ProgramListControls: React.FC<ProgramListTableProps> = (props) => (
           isExporting={props.isExporting}
           onClick={props.onExport}
         />
-        <ProgramActionsMenu onNewProgram={props.onNewProgram} />
+        <ProgramActionsMenu
+          canCreateProgram={props.canCreateProgram}
+          onNewProgram={props.onNewProgram}
+        />
         <SchoolListDateRangeDropdown
           value={props.selectedDateRange}
           onChange={props.onDateRangeChange}

--- a/src/ops-console/pages/ProgramPage.test.tsx
+++ b/src/ops-console/pages/ProgramPage.test.tsx
@@ -34,6 +34,7 @@ type MockProgramListTableProps = {
   isExportDisabled: boolean;
   isExporting: boolean;
   onExport: () => void | Promise<void>;
+  canCreateProgram: boolean;
   onNewProgram: () => void;
   columns: Column<ProgramListRow>[];
   rows: ProgramListRow[];
@@ -95,9 +96,11 @@ jest.mock('../components/ProgramListTable', () => {
         <button type="button" onClick={() => props.onExport()}>
           export
         </button>
-        <button type="button" onClick={props.onNewProgram}>
-          new program
-        </button>
+        {props.canCreateProgram ? (
+          <button type="button" onClick={props.onNewProgram}>
+            new program
+          </button>
+        ) : null}
         <button type="button" onClick={() => props.onSort('totalSchools')}>
           sort
         </button>
@@ -262,4 +265,16 @@ it('does not render Program page for non-admin roles', () => {
 
   expect(screen.queryByText('Programs')).not.toBeInTheDocument();
   expect(screen.queryByTestId('program-list-table')).not.toBeInTheDocument();
+});
+
+it('hides program creation for program managers', () => {
+  mockRoles = [RoleType.PROGRAM_MANAGER];
+
+  render(<ProgramPage />);
+
+  expect(screen.getByText('Programs')).toBeInTheDocument();
+  expect(screen.getByTestId('program-list-table')).toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: 'new program' }),
+  ).not.toBeInTheDocument();
 });

--- a/src/ops-console/pages/ProgramPage.tsx
+++ b/src/ops-console/pages/ProgramPage.tsx
@@ -13,6 +13,15 @@ import './SchoolList.css';
 
 const ProgramPageContent: React.FC = () => {
   const logic = useProgramPageLogic();
+  const { roles } = useAppSelector(
+    (state: RootState) => state.auth as AuthState,
+  );
+  const userRoles = roles || [];
+  const canCreateProgram = userRoles.some((role) =>
+    [RoleType.SUPER_ADMIN, RoleType.OPERATIONAL_DIRECTOR].includes(
+      role as RoleType,
+    ),
+  );
 
   return (
     <div className="program-page">
@@ -66,6 +75,7 @@ const ProgramPageContent: React.FC = () => {
         isExportDisabled={logic.isExportDisabled}
         isExporting={logic.isExporting}
         onExport={logic.handleExportPrograms}
+        canCreateProgram={canCreateProgram}
         onNewProgram={() => logic.history.push(logic.newProgramPath)}
         columns={logic.columns}
         rows={logic.rows}

--- a/src/ops-console/pages/ProgramPage.tsx
+++ b/src/ops-console/pages/ProgramPage.tsx
@@ -11,17 +11,14 @@ import type { AuthState } from '../../redux/slices/auth/authSlice';
 import './ProgramPage.css';
 import './SchoolList.css';
 
-const ProgramPageContent: React.FC = () => {
+type ProgramPageContentProps = {
+  canCreateProgram: boolean;
+};
+
+const ProgramPageContent: React.FC<ProgramPageContentProps> = ({
+  canCreateProgram,
+}) => {
   const logic = useProgramPageLogic();
-  const { roles } = useAppSelector(
-    (state: RootState) => state.auth as AuthState,
-  );
-  const userRoles = roles || [];
-  const canCreateProgram = userRoles.some((role) =>
-    [RoleType.SUPER_ADMIN, RoleType.OPERATIONAL_DIRECTOR].includes(
-      role as RoleType,
-    ),
-  );
 
   return (
     <div className="program-page">
@@ -111,13 +108,18 @@ const ProgramsPage: React.FC = () => {
       RoleType.PROGRAM_MANAGER,
     ].includes(role as RoleType),
   );
+  const canCreateProgram = userRoles.some((role) =>
+    [RoleType.SUPER_ADMIN, RoleType.OPERATIONAL_DIRECTOR].includes(
+      role as RoleType,
+    ),
+  );
 
   // Program listing is restricted to approved roles so blocked users do not see or fetch page data.
   if (!canViewProgramPage) {
     return null;
   }
 
-  return <ProgramPageContent />;
+  return <ProgramPageContent canCreateProgram={canCreateProgram} />;
 };
 
 export default ProgramsPage;

--- a/src/ops-console/pages/SidebarPage.tsx
+++ b/src/ops-console/pages/SidebarPage.tsx
@@ -126,6 +126,11 @@ const SidebarPage: React.FC = () => {
       RoleType.PROGRAM_MANAGER,
     ].includes(role as RoleType),
   );
+  const canCreateProgram = userRoles.some((role) =>
+    [RoleType.SUPER_ADMIN, RoleType.OPERATIONAL_DIRECTOR].includes(
+      role as RoleType,
+    ),
+  );
   const canAccessCampaignPage = userRoles.some((role) =>
     CAMPAIGN_ACCESS_ROLES.includes(role as RoleType),
   );
@@ -342,7 +347,11 @@ const SidebarPage: React.FC = () => {
               <ProgramDetailsRoute />
             </ProtectedRoute>
             <ProtectedRoute path={`${path}${PAGES.NEW_PROGRAM}`} exact={true}>
-              <NewProgram />
+              {canCreateProgram ? (
+                <NewProgram />
+              ) : (
+                <Redirect to={`${path}${PAGES.PROGRAM_PAGE}`} />
+              )}
             </ProtectedRoute>
             <ProtectedRoute path={`${path}${PAGES.USERS}`} exact={true}>
               <UsersPage />

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -9937,9 +9937,7 @@ export class SupabaseApi implements ServiceApi {
         return { data: [], totalCount: 0 };
       }
 
-      const shouldUseDatabasePagination = Boolean(
-        nativeSortColumn || shouldUseRelationSort,
-      );
+      const shouldUseDatabasePagination = Boolean(nativeSortColumn);
       const searchRelationSelect =
         normalizedSearchTerm.length > 0
           ? `,
@@ -9990,16 +9988,6 @@ export class SupabaseApi implements ServiceApi {
         if (nativeSortColumn) {
           campaignQuery.order(nativeSortColumn, {
             ascending: orderDir === 'asc',
-          });
-        } else if (orderBy === 'manager') {
-          campaignQuery.order('name', {
-            ascending: orderDir === 'asc',
-            foreignTable: TABLES.User,
-          });
-        } else if (orderBy === 'programName') {
-          campaignQuery.order('name', {
-            ascending: orderDir === 'asc',
-            foreignTable: TABLES.Program,
           });
         }
 

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -10278,6 +10278,7 @@ export class SupabaseApi implements ServiceApi {
       .from(TABLES.Assignment)
       .update({
         is_deleted: true,
+        ends_at: nowIso,
         updated_at: nowIso,
       })
       .eq('campaign_id', campaignId)


### PR DESCRIPTION
- Hide the New Program action on the Program Listing page for users with the program_manager role.
- Keep Program Listing page access unchanged for super_admin, operational_director, and program_manager.
- Add a separate canCreateProgram permission check so create access is limited to super_admin and operational_director.
- Block direct access to /new-program for program managers by redirecting them back to the Programs page.
- Update Program page tests to cover:existing page wiring
- page hidden for unauthorized roles
- create action hidden for program managers
- Fixed campaign listing sorting for manager and programName in the API layer.
- Restricted DB-side sorting to native campaign columns only.
- Routed relation-based sorting through existing API-side sorting logic after data mapping.