### PR TITLE
Include uniqueSubjects in campaign assignments

### DIFF
--- a/src/ops-console/pages/CampaignAssignmentTab.test.tsx
+++ b/src/ops-console/pages/CampaignAssignmentTab.test.tsx
@@ -139,7 +139,7 @@ describe('CampaignAssignmentTab', () => {
     );
 
     expect(api.getAllGrades).toHaveBeenCalledTimes(1);
-    expect(screen.getByTestId('data-table')).toBeInTheDocument();
+    expect(await screen.findByTestId('data-table')).toBeInTheDocument();
     expect(screen.getByText('Lesson Alpha')).toBeInTheDocument();
   });
 

--- a/src/ops-console/pages/CampaignAssignmentTab.test.tsx
+++ b/src/ops-console/pages/CampaignAssignmentTab.test.tsx
@@ -62,7 +62,6 @@ jest.mock('../components/DataTablePagination', () => ({
 describe('CampaignAssignmentTab', () => {
   const api = {
     getAllGrades: jest.fn(),
-    getCampaignSubjectsByCampaignId: jest.fn(),
     getCampaignAssignments: jest.fn(),
   };
 
@@ -85,41 +84,38 @@ describe('CampaignAssignmentTab', () => {
     },
   ];
 
+  const defaultUniqueSubjects = defaultSubjects;
+
   const renderTab = (campaignId?: string) =>
     render(<CampaignAssignmentTab campaignId={campaignId} />);
 
   const primeApi = ({
     grades = defaultGrades,
-    subjects = defaultSubjects,
     assignments = defaultAssignments,
+    uniqueSubjects = defaultUniqueSubjects,
     total = 1,
     gradeError = null,
-    subjectError = null,
     assignmentError = null,
   }: {
     grades?: Array<{ id: string; name: string }>;
-    subjects?: Array<{ id: string; name: string }>;
     assignments?: Array<{
       assignmentDate: string;
       gradeName: string;
       subjectName: string;
       lessonName: string;
     }>;
+    uniqueSubjects?: Array<{ id: string; name: string }>;
     total?: number;
     gradeError?: Error | null;
-    subjectError?: Error | null;
     assignmentError?: Error | null;
   } = {}) => {
     api.getAllGrades.mockImplementation(() =>
       gradeError ? Promise.reject(gradeError) : Promise.resolve(grades),
     );
-    api.getCampaignSubjectsByCampaignId.mockImplementation(() =>
-      subjectError ? Promise.reject(subjectError) : Promise.resolve(subjects),
-    );
     api.getCampaignAssignments.mockImplementation(() =>
       assignmentError
         ? Promise.reject(assignmentError)
-        : Promise.resolve({ assignments, total }),
+        : Promise.resolve({ assignments, uniqueSubjects, total }),
     );
   };
 
@@ -135,11 +131,6 @@ describe('CampaignAssignmentTab', () => {
 
     renderTab('campaign-1');
 
-    await waitFor(() =>
-      expect(api.getCampaignSubjectsByCampaignId).toHaveBeenCalledWith(
-        'campaign-1',
-      ),
-    );
     await waitFor(() =>
       expect(api.getCampaignAssignments).toHaveBeenCalledWith('campaign-1', {
         page: 1,
@@ -173,7 +164,6 @@ describe('CampaignAssignmentTab', () => {
 
     expect(await screen.findByText('No Assignments Found')).toBeInTheDocument();
     expect(api.getAllGrades).not.toHaveBeenCalled();
-    expect(api.getCampaignSubjectsByCampaignId).not.toHaveBeenCalled();
     expect(api.getCampaignAssignments).not.toHaveBeenCalled();
   });
 
@@ -270,9 +260,6 @@ describe('CampaignAssignmentTab', () => {
 
   it('shows the loading spinner while requests are pending', () => {
     api.getAllGrades.mockImplementation(() => new Promise(() => undefined));
-    api.getCampaignSubjectsByCampaignId.mockImplementation(
-      () => new Promise(() => undefined),
-    );
     api.getCampaignAssignments.mockImplementation(
       () => new Promise(() => undefined),
     );

--- a/src/ops-console/pages/CampaignAssignmentTab.tsx
+++ b/src/ops-console/pages/CampaignAssignmentTab.tsx
@@ -75,10 +75,7 @@ const CampaignAssignmentTab: React.FC<CampaignAssignmentTabProps> = ({
 
       setIsLoadingFilters(true);
       try {
-        const [nextGrades, nextSubjects] = await Promise.all([
-          api.getAllGrades(),
-          api.getCampaignSubjectsByCampaignId(campaignId),
-        ]);
+        const nextGrades = await api.getAllGrades();
 
         if (cancelled) return;
 
@@ -86,12 +83,6 @@ const CampaignAssignmentTab: React.FC<CampaignAssignmentTabProps> = ({
           nextGrades.map((grade) => ({
             id: String(grade.id),
             name: String(grade.name),
-          })),
-        );
-        setSubjects(
-          nextSubjects.map((subject) => ({
-            id: String(subject.id),
-            name: String(subject.name),
           })),
         );
       } catch (err) {
@@ -131,11 +122,13 @@ const CampaignAssignmentTab: React.FC<CampaignAssignmentTabProps> = ({
         if (cancelled) return;
 
         setAssignments(response.assignments ?? []);
+        setSubjects(response.uniqueSubjects ?? []);
         setTotal(response.total ?? 0);
       } catch (err) {
         logger.error('Failed to load campaign assignments:', err);
         if (!cancelled) {
           setAssignments([]);
+          setSubjects([]);
           setTotal(0);
         }
       } finally {

--- a/src/services/api/ServiceApi.ts
+++ b/src/services/api/ServiceApi.ts
@@ -457,8 +457,11 @@ export type CampaignAssignmentSummaryRow = {
   lessonName: string;
 };
 
+export type CampaignAssignmentUniqueSubject = CampaignOption;
+
 export type CampaignAssignmentsResponse = {
   assignments: CampaignAssignmentSummaryRow[];
+  uniqueSubjects: CampaignAssignmentUniqueSubject[];
   total: number;
 };
 

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -10844,9 +10844,26 @@ export class SupabaseApi implements ServiceApi {
     if (!this.supabase || !campaignId) {
       return {
         assignments: [],
+        uniqueSubjects: [],
         total: 0,
       };
     }
+
+    type CampaignAssignmentRpcRow = {
+      assignment_id: string;
+      assignment_date: string;
+      grade_id: string;
+      grade_name: string;
+      subject_id: string;
+      subject_name: string;
+      lesson_id: string;
+      lesson_name: string;
+      unique_subjects?: Array<{
+        subject_id: string;
+        subject_name: string;
+      }> | null;
+      total_count: string | number;
+    };
 
     const { data, error } = await this.supabase.rpc(
       'get_campaign_assignments',
@@ -10867,9 +10884,18 @@ export class SupabaseApi implements ServiceApi {
       throw error;
     }
 
+    const rpcRows = data as CampaignAssignmentRpcRow[] | null | undefined;
+    const firstRow = rpcRows?.[0];
+    const uniqueSubjects = Array.isArray(firstRow?.unique_subjects)
+      ? firstRow.unique_subjects.map((subject) => ({
+          id: String(subject.subject_id),
+          name: String(subject.subject_name),
+        }))
+      : [];
+
     return {
       assignments:
-        data?.map((row) => ({
+        rpcRows?.map((row) => ({
           assignmentId: row.assignment_id,
           assignmentDate: row.assignment_date,
 
@@ -10882,7 +10908,8 @@ export class SupabaseApi implements ServiceApi {
           lessonId: row.lesson_id,
           lessonName: row.lesson_name,
         })) ?? [],
-      total: data?.length ? Number(data[0].total_count) : 0,
+      uniqueSubjects,
+      total: rpcRows?.length ? Number(firstRow?.total_count ?? 0) : 0,
     };
   }
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -7844,6 +7844,10 @@ export type Database = {
           subject_name: string;
           lesson_id: string;
           lesson_name: string;
+          unique_subjects: {
+            subject_id: string;
+            subject_name: string;
+          }[];
           total_count: number;
         }[];
       };


### PR DESCRIPTION
Return uniqueSubjects as part of the campaign assignments response and consume it in the UI. CampaignAssignmentTab no longer calls getCampaignSubjectsByCampaignId; it uses response.uniqueSubjects and clears subjects on error. ServiceApi types updated to include uniqueSubjects. SupabaseApi parses unique_subjects from the RPC result, maps them, and adjusts total calculation. Database types updated for unique_subjects. Tests updated to reflect the new payload shape and behavior.