### PR TITLE
fix: Load grades dynamically based on selected schools

### DIFF
--- a/src/ops-console/components/campaignSetup/CampaignMultiSelect.tsx
+++ b/src/ops-console/components/campaignSetup/CampaignMultiSelect.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import {
   Autocomplete,
   Checkbox,
+  ClickAwayListener,
   TextField,
   useMediaQuery,
 } from '@mui/material';
@@ -40,80 +41,99 @@ export const CampaignMultiSelect = <T,>({
 }: CampaignMultiSelectProps<T>) => {
   const isMobileView = useMediaQuery('(max-width:48rem)');
   const shouldPreventKeyboard = preventMobileKeyboard && isMobileView;
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const handleClickAway = (event: MouseEvent | TouchEvent) => {
+    const target = event.target as Node | null;
+    if (target && rootRef.current?.contains(target)) {
+      return;
+    }
+
+    setOpen(false);
+  };
 
   return (
-    <Autocomplete
-      multiple
-      disableCloseOnSelect
-      disablePortal
-      openOnFocus
-      options={options}
-      value={value}
-      loading={loading}
-      getOptionLabel={getOptionLabel}
-      isOptionEqualToValue={isOptionEqualToValue}
-      slotProps={{
-        popper: {
-          placement: 'bottom-start',
-          modifiers: [
-            {
-              name: 'flip',
-              enabled: false,
+    <ClickAwayListener onClickAway={handleClickAway}>
+      <div ref={rootRef} className="campaign-multi-select-root">
+        <Autocomplete
+          multiple
+          disableCloseOnSelect
+          disablePortal
+          open={open}
+          openOnFocus
+          onOpen={() => setOpen(true)}
+          onClose={() => setOpen(false)}
+          options={options}
+          value={value}
+          loading={loading}
+          getOptionLabel={getOptionLabel}
+          isOptionEqualToValue={isOptionEqualToValue}
+          slotProps={{
+            popper: {
+              placement: 'bottom-start',
+              modifiers: [
+                {
+                  name: 'flip',
+                  enabled: false,
+                },
+                {
+                  name: 'preventOverflow',
+                  options: {
+                    altAxis: true,
+                    padding: 8,
+                    tether: true,
+                  },
+                },
+              ],
             },
-            {
-              name: 'preventOverflow',
-              options: {
-                altAxis: true,
-                padding: 8,
-                tether: true,
+            paper: {
+              sx: {
+                marginTop: 0.5,
               },
             },
-          ],
-        },
-        paper: {
-          sx: {
-            marginTop: 0.5,
-          },
-        },
-      }}
-      ListboxProps={{
-        style: {
-          maxHeight: '16rem',
-          overflowY: 'auto',
-        },
-      }}
-      renderOption={(props, option, { selected }) => {
-        const { key, ...optionProps } = props as AutocompleteOptionProps;
-        const label = getOptionLabel ? getOptionLabel(option) : String(option);
-        return (
-          <li key={key} {...optionProps}>
-            <Checkbox checked={selected} sx={{ marginRight: 1 }} />
-            {label}
-          </li>
-        );
-      }}
-      onChange={(_, nextValue) => onChange(nextValue)}
-      renderTags={(selected) =>
-        renderSelectedLabel
-          ? renderSelectedLabel(selected)
-          : CampaignCountPlaceholder(selected, placeholder)
-      }
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          placeholder={value.length ? '' : placeholder}
-          error={error}
-          helperText={helperText}
-          size="small"
-          inputProps={{
-            ...params.inputProps,
-            readOnly: shouldPreventKeyboard,
-            inputMode: shouldPreventKeyboard
-              ? 'none'
-              : params.inputProps.inputMode,
           }}
+          ListboxProps={{
+            style: {
+              maxHeight: '16rem',
+              overflowY: 'auto',
+            },
+          }}
+          renderOption={(props, option, { selected }) => {
+            const { key, ...optionProps } = props as AutocompleteOptionProps;
+            const label = getOptionLabel
+              ? getOptionLabel(option)
+              : String(option);
+            return (
+              <li key={key} {...optionProps}>
+                <Checkbox checked={selected} sx={{ marginRight: 1 }} />
+                {label}
+              </li>
+            );
+          }}
+          onChange={(_, nextValue) => onChange(nextValue)}
+          renderTags={(selected) =>
+            renderSelectedLabel
+              ? renderSelectedLabel(selected)
+              : CampaignCountPlaceholder(selected, placeholder)
+          }
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              placeholder={value.length ? '' : placeholder}
+              error={error}
+              helperText={helperText}
+              size="small"
+              inputProps={{
+                ...params.inputProps,
+                readOnly: shouldPreventKeyboard,
+                inputMode: shouldPreventKeyboard
+                  ? 'none'
+                  : params.inputProps.inputMode,
+              }}
+            />
+          )}
         />
-      )}
-    />
+      </div>
+    </ClickAwayListener>
   );
 };

--- a/src/ops-console/components/campaignSetup/TargetAudienceSection.tsx
+++ b/src/ops-console/components/campaignSetup/TargetAudienceSection.tsx
@@ -21,6 +21,7 @@ export const TargetAudienceSection: React.FC<TargetAudienceSectionProps> = ({
   savedGroups,
   selectedSavedGroupId,
   audienceOptions,
+  availableGrades,
   selectedBlocks,
   selectedSchools,
   selectedGrades,
@@ -29,6 +30,7 @@ export const TargetAudienceSection: React.FC<TargetAudienceSectionProps> = ({
   hasCustomGradeSelection,
   schoolsForSelectedBlocks,
   loadingAudience,
+  loadingGrades,
   selectedProgramName,
   summaryBlockCount,
   summarySchoolCount,
@@ -55,6 +57,23 @@ export const TargetAudienceSection: React.FC<TargetAudienceSectionProps> = ({
     () => new Map(programs.map((program) => [program.id, program.name])),
     [programs],
   );
+  const gradeSelectScopeKey = useMemo(() => {
+    const schoolKey =
+      selectedSchools.length === audienceOptions.schools.length
+        ? 'all-schools'
+        : selectedSchools
+            .map((school) => school.id)
+            .sort()
+            .join('|');
+    const gradeKey = availableGrades.map((grade) => grade.id).join('|');
+
+    return `${schoolKey}:${gradeKey}`;
+  }, [audienceOptions.schools.length, availableGrades, selectedSchools]);
+  const scopedSelectedGrades = useMemo(() => {
+    const availableGradeIds = new Set(availableGrades.map((grade) => grade.id));
+
+    return selectedGrades.filter((grade) => availableGradeIds.has(grade.id));
+  }, [availableGrades, selectedGrades]);
 
   return (
     <Box className="campaign-setup-section">
@@ -166,9 +185,10 @@ export const TargetAudienceSection: React.FC<TargetAudienceSectionProps> = ({
         <Box className="campaign-setup-field">
           <Typography className="campaign-setup-label">Grade</Typography>
           <CampaignMultiSelect
-            options={audienceOptions.grades}
-            value={selectedGrades}
-            loading={loadingAudience}
+            key={gradeSelectScopeKey}
+            options={availableGrades}
+            value={scopedSelectedGrades}
+            loading={loadingAudience || loadingGrades}
             placeholder="Select Grade"
             preventMobileKeyboard
             getOptionLabel={(option) => option.name}

--- a/src/ops-console/components/campaignSetup/types.ts
+++ b/src/ops-console/components/campaignSetup/types.ts
@@ -73,6 +73,7 @@ export type TargetAudienceSectionProps = {
   savedGroups: CampaignSavedAudienceGroup[];
   selectedSavedGroupId: string;
   audienceOptions: CampaignAudienceOptions;
+  availableGrades: CampaignOption[];
   selectedBlocks: string[];
   selectedSchools: CampaignSchoolOption[];
   selectedGrades: CampaignOption[];
@@ -81,6 +82,7 @@ export type TargetAudienceSectionProps = {
   hasCustomGradeSelection: boolean;
   schoolsForSelectedBlocks: CampaignSchoolOption[];
   loadingAudience: boolean;
+  loadingGrades: boolean;
   selectedProgramName: string;
   summaryBlockCount: number;
   summarySchoolCount: number;

--- a/src/ops-console/hooks/useCampaignAudienceSelection.ts
+++ b/src/ops-console/hooks/useCampaignAudienceSelection.ts
@@ -72,6 +72,8 @@ export const useCampaignAudienceSelection = ({
   const [hasCustomSchoolSelection, setHasCustomSchoolSelection] =
     useState(false);
   const [hasCustomGradeSelection, setHasCustomGradeSelection] = useState(false);
+  const [availableGrades, setAvailableGrades] = useState<CampaignOption[]>([]);
+  const [loadingGrades, setLoadingGrades] = useState(false);
   const [loadingAudience, setLoadingAudience] = useState(false);
 
   const resetAudienceSelection = () => {
@@ -82,9 +84,11 @@ export const useCampaignAudienceSelection = ({
     setHasCustomBlockSelection(false);
     setHasCustomSchoolSelection(false);
     setHasCustomGradeSelection(false);
+    setAvailableGrades([]);
     setAudienceOptions(emptyAudienceOptions);
     setAudienceSummary(emptyAudienceSummary);
     setLoadingAudience(false);
+    setLoadingGrades(false);
     setLoadingAudienceSummary(false);
     setSaveGroup(false);
     setMessage(null);
@@ -105,6 +109,8 @@ export const useCampaignAudienceSelection = ({
         setSelectedBlocks([]);
         setSelectedSchools([]);
         setSelectedGrades([]);
+        setAvailableGrades([]);
+        setLoadingGrades(false);
         setLoadingAudience(false);
         return;
       }
@@ -144,19 +150,10 @@ export const useCampaignAudienceSelection = ({
           : audienceOptions.blocks,
       );
     }
-
-    if (!hasCustomGradeSelection) {
-      setSelectedGrades((current) =>
-        areOptionIdArraysEqual(current, audienceOptions.grades)
-          ? current
-          : audienceOptions.grades,
-      );
-    }
   }, [
     audienceOptions,
     form.programId,
     hasCustomBlockSelection,
-    hasCustomGradeSelection,
     selectedSavedGroupId,
   ]);
 
@@ -195,18 +192,91 @@ export const useCampaignAudienceSelection = ({
     () => selectedSchools.map((school) => school.id),
     [selectedSchools],
   );
-  const selectedGradeIds = useMemo(
-    () => selectedGrades.map((grade) => grade.id),
-    [selectedGrades],
-  );
   const isAllSchools =
     selectedSchoolIds.length === 0 ||
     (allSchoolIds.length > 0 &&
       selectedSchoolIds.length === allSchoolIds.length);
+
+  useEffect(() => {
+    let isActive = true;
+
+    const fetchAvailableGrades = async () => {
+      if (!form.programId) {
+        setAvailableGrades([]);
+        setLoadingGrades(false);
+        return;
+      }
+
+      if (isAllSchools) {
+        setAvailableGrades((current) =>
+          areOptionIdArraysEqual(current, audienceOptions.grades)
+            ? current
+            : audienceOptions.grades,
+        );
+        setLoadingGrades(false);
+        return;
+      }
+
+      if (selectedSchoolIds.length === 0) {
+        setAvailableGrades([]);
+        setLoadingGrades(false);
+        return;
+      }
+
+      setLoadingGrades(true);
+      try {
+        const grades = await api.getCampaignGradesForSchools(selectedSchoolIds);
+        if (!isActive) return;
+        setAvailableGrades(grades);
+      } catch (error) {
+        if (!isActive) return;
+        logger.error('Failed to load campaign grades for schools:', error);
+        setAvailableGrades([]);
+        setMessage({
+          type: 'error',
+          text: 'Unable to load grades for the selected schools.',
+        });
+      } finally {
+        if (isActive) setLoadingGrades(false);
+      }
+    };
+
+    fetchAvailableGrades();
+
+    return () => {
+      isActive = false;
+    };
+  }, [
+    api,
+    audienceOptions.grades,
+    form.programId,
+    isAllSchools,
+    selectedSchoolIds,
+    setMessage,
+  ]);
+
+  useEffect(() => {
+    if (loadingGrades) return;
+
+    setSelectedGrades((current) => {
+      const availableGradeIds = new Set(
+        availableGrades.map((grade) => grade.id),
+      );
+      const nextGrades = hasCustomGradeSelection
+        ? current.filter((grade) => availableGradeIds.has(grade.id))
+        : availableGrades;
+
+      return areOptionIdArraysEqual(current, nextGrades) ? current : nextGrades;
+    });
+  }, [availableGrades, hasCustomGradeSelection, loadingGrades]);
+
+  const selectedGradeIds = useMemo(
+    () => selectedGrades.map((grade) => grade.id),
+    [selectedGrades],
+  );
   const isAllGrades =
-    selectedGradeIds.length === 0 ||
-    (audienceOptions.grades.length > 0 &&
-      selectedGradeIds.length === audienceOptions.grades.length);
+    availableGrades.length > 0 &&
+    selectedGradeIds.length === availableGrades.length;
 
   const selectedProgramName =
     programs.find((program) => program.id === form.programId)?.name || '-';
@@ -216,10 +286,8 @@ export const useCampaignAudienceSelection = ({
   );
   const summaryGradeIds = useMemo(
     () =>
-      isAllGrades
-        ? audienceOptions.grades.map((grade) => grade.id)
-        : selectedGradeIds,
-    [audienceOptions.grades, isAllGrades, selectedGradeIds],
+      isAllGrades ? availableGrades.map((grade) => grade.id) : selectedGradeIds,
+    [availableGrades, isAllGrades, selectedGradeIds],
   );
   const summaryBlockCount = isAllSchools
     ? audienceOptions.blocks.length
@@ -344,6 +412,7 @@ export const useCampaignAudienceSelection = ({
   return {
     audienceOptions,
     audienceSummary,
+    availableGrades,
     handleBlocksChange,
     handleGradesChange,
     handleProgramChange,
@@ -356,6 +425,7 @@ export const useCampaignAudienceSelection = ({
     isAllSchools,
     loadingAudience,
     loadingAudienceSummary,
+    loadingGrades,
     resetAudienceSelection,
     schoolsForSelectedBlocks,
     selectedBlocks,

--- a/src/ops-console/pages/CampaignSetupPage.test.tsx
+++ b/src/ops-console/pages/CampaignSetupPage.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -43,6 +44,7 @@ jest.mock('react-router-dom', () => ({
 const mockApiHandler = {
   getCampaignSetupOptions: jest.fn(),
   getCampaignAudienceOptions: jest.fn(),
+  getCampaignGradesForSchools: jest.fn(),
   getCampaignAudienceSummary: jest.fn(),
   createCampaignAudienceGroup: jest.fn(),
   createCampaignSetup: jest.fn(),
@@ -120,6 +122,9 @@ const setupApiMocks = () => {
     schools: [{ id: 'school-1', name: 'School One', block: 'Block A' }],
     grades: [{ id: 'grade-1', name: 'Grade 1' }],
   });
+  mockApiHandler.getCampaignGradesForSchools.mockResolvedValue([
+    { id: 'grade-1', name: 'Grade 1' },
+  ]);
   mockApiHandler.getCampaignAudienceSummary.mockResolvedValue({
     totalStudents: 10,
     grades: [{ gradeId: 'grade-1', gradeName: 'Grade 1', studentCount: 10 }],
@@ -332,6 +337,195 @@ describe('CampaignSetupPage', () => {
       name: 'School One',
     });
     expect(within(schoolOption).getByRole('checkbox')).toBeChecked();
+  });
+
+  it('refreshes grade options after narrowing the selected schools', async () => {
+    mockApiHandler.getCampaignAudienceOptions.mockResolvedValueOnce({
+      blocks: ['Block A'],
+      schools: [
+        { id: 'school-1', name: 'School One', block: 'Block A' },
+        { id: 'school-2', name: 'School Two', block: 'Block A' },
+      ],
+      grades: [
+        { id: 'grade-1', name: 'Grade 1' },
+        { id: 'grade-2', name: 'Grade 2' },
+      ],
+    });
+    mockApiHandler.getCampaignGradesForSchools.mockImplementation(
+      (schoolIds: string[]) =>
+        Promise.resolve(
+          schoolIds.includes('school-2')
+            ? [{ id: 'grade-1', name: 'Grade 1' }]
+            : [
+                { id: 'grade-1', name: 'Grade 1' },
+                { id: 'grade-2', name: 'Grade 2' },
+              ],
+        ),
+    );
+
+    render(<CampaignSetupPage />);
+
+    await screen.findByRole('heading', { name: 'New Campaign' });
+    await openSelectAndChoose('Select Program', 'Early Learning');
+
+    const schoolField = screen
+      .getByText('School')
+      .closest('.campaign-setup-field') as HTMLElement | null;
+    const schoolSelect = schoolField
+      ? within(schoolField).getByRole('combobox')
+      : null;
+
+    fireEvent.mouseDown(schoolSelect as HTMLElement);
+    fireEvent.click(await screen.findByRole('option', { name: 'School One' }));
+    fireEvent.keyDown(screen.getByRole('listbox'), {
+      key: 'Escape',
+      code: 'Escape',
+    });
+
+    await waitFor(() =>
+      expect(mockApiHandler.getCampaignGradesForSchools).toHaveBeenCalledWith([
+        'school-2',
+      ]),
+    );
+
+    const gradeField = screen
+      .getByText('Grade')
+      .closest('.campaign-setup-field') as HTMLElement | null;
+    const gradeSelect = gradeField
+      ? within(gradeField).getByRole('combobox')
+      : null;
+
+    fireEvent.mouseDown(gradeSelect as HTMLElement);
+
+    const gradeOneOption = await screen.findByRole('option', {
+      name: 'Grade 1',
+    });
+    expect(within(gradeOneOption).getByRole('checkbox')).toBeChecked();
+    expect(
+      screen.queryByRole('option', { name: 'Grade 2' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('preserves selected grades that remain available after a school refresh', async () => {
+    let resolveGrades:
+      | ((grades: Array<{ id: string; name: string }>) => void)
+      | undefined;
+
+    mockApiHandler.getCampaignAudienceOptions.mockResolvedValueOnce({
+      blocks: ['Block A'],
+      schools: [
+        { id: 'school-1', name: 'School One', block: 'Block A' },
+        { id: 'school-2', name: 'School Two', block: 'Block A' },
+      ],
+      grades: [
+        { id: 'grade-1', name: 'Grade 1' },
+        { id: 'grade-2', name: 'Grade 2' },
+      ],
+    });
+    mockApiHandler.getCampaignGradesForSchools.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGrades = resolve;
+        }),
+    );
+
+    render(<CampaignSetupPage />);
+
+    await screen.findByRole('heading', { name: 'New Campaign' });
+    await openSelectAndChoose('Select Program', 'Early Learning');
+    expect(await screen.findByText(/Grade 1/)).toBeInTheDocument();
+
+    const gradeField = screen
+      .getByText('Grade')
+      .closest('.campaign-setup-field') as HTMLElement | null;
+    const gradeSelect = gradeField
+      ? within(gradeField).getByRole('combobox')
+      : null;
+
+    fireEvent.mouseDown(gradeSelect as HTMLElement);
+    fireEvent.click(await screen.findByRole('option', { name: 'Grade 2' }));
+    fireEvent.keyDown(screen.getByRole('listbox'), {
+      key: 'Escape',
+      code: 'Escape',
+    });
+
+    const schoolField = screen
+      .getByText('School')
+      .closest('.campaign-setup-field') as HTMLElement | null;
+    const schoolSelect = schoolField
+      ? within(schoolField).getByRole('combobox')
+      : null;
+
+    fireEvent.mouseDown(schoolSelect as HTMLElement);
+    fireEvent.click(await screen.findByRole('option', { name: 'School One' }));
+
+    await waitFor(() =>
+      expect(mockApiHandler.getCampaignGradesForSchools).toHaveBeenCalledWith([
+        'school-2',
+      ]),
+    );
+
+    await act(async () => {
+      resolveGrades?.([{ id: 'grade-1', name: 'Grade 1' }]);
+    });
+
+    const refreshedGradeField = screen
+      .getByText('Grade')
+      .closest('.campaign-setup-field') as HTMLElement | null;
+    const refreshedGradeSelect = refreshedGradeField
+      ? within(refreshedGradeField).getByRole('combobox')
+      : null;
+
+    fireEvent.mouseDown(refreshedGradeSelect as HTMLElement);
+
+    const gradeOneOption = await screen.findByRole('option', {
+      name: 'Grade 1',
+    });
+    expect(within(gradeOneOption).getByRole('checkbox')).toBeChecked();
+  });
+
+  it('closes the grade dropdown after all grades are manually unchecked', async () => {
+    mockApiHandler.getCampaignAudienceOptions.mockResolvedValueOnce({
+      blocks: ['Block A'],
+      schools: [{ id: 'school-1', name: 'School One', block: 'Block A' }],
+      grades: [
+        { id: 'grade-1', name: 'Grade 1' },
+        { id: 'grade-2', name: 'Grade 2' },
+      ],
+    });
+    mockApiHandler.getCampaignAudienceSummary.mockResolvedValue({
+      totalStudents: 20,
+      grades: [
+        { gradeId: 'grade-1', gradeName: 'Grade 1', studentCount: 10 },
+        { gradeId: 'grade-2', gradeName: 'Grade 2', studentCount: 10 },
+      ],
+    });
+
+    render(<CampaignSetupPage />);
+
+    await screen.findByRole('heading', { name: 'New Campaign' });
+    await openSelectAndChoose('Select Program', 'Early Learning');
+    expect(await screen.findByText(/Grade 1/)).toBeInTheDocument();
+
+    const gradeField = screen
+      .getByText('Grade')
+      .closest('.campaign-setup-field') as HTMLElement | null;
+    const gradeSelect = gradeField
+      ? within(gradeField).getByRole('combobox')
+      : null;
+
+    fireEvent.mouseDown(gradeSelect as HTMLElement);
+    fireEvent.click(await screen.findByRole('option', { name: 'Grade 1' }));
+    fireEvent.click(await screen.findByRole('option', { name: 'Grade 2' }));
+    fireEvent.mouseDown(document.body);
+    fireEvent.click(document.body);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/Grade 1 -/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Grade 2 -/)).not.toBeInTheDocument();
+    expect(screen.getByText('0')).toBeInTheDocument();
   });
 
   it('switches dynamic objective fields when homepage pathway campaign is selected', async () => {

--- a/src/ops-console/pages/CampaignSetupPage.tsx
+++ b/src/ops-console/pages/CampaignSetupPage.tsx
@@ -140,7 +140,7 @@ const CampaignSetupPage: React.FC = () => {
         ? campaignSetup.audienceOptions.schools
         : campaignSetup.selectedSchools,
       selectedGrades: campaignSetup.isAllGrades
-        ? campaignSetup.audienceOptions.grades
+        ? campaignSetup.availableGrades
         : campaignSetup.selectedGrades,
       audienceSummary: campaignSetup.audienceSummary,
       assignmentDrafts: campaignSetup.assignmentDrafts,
@@ -156,7 +156,7 @@ const CampaignSetupPage: React.FC = () => {
       campaignReach,
       campaignSetup.assignmentConfigs,
       campaignSetup.assignmentDrafts,
-      campaignSetup.audienceOptions.grades,
+      campaignSetup.availableGrades,
       campaignSetup.audienceOptions.schools,
       campaignSetup.audienceSummary,
       campaignSetup.campaignRewards,
@@ -461,6 +461,7 @@ const CampaignSetupPage: React.FC = () => {
                 savedGroups={campaignSetup.savedGroups}
                 selectedSavedGroupId={campaignSetup.selectedSavedGroupId}
                 audienceOptions={campaignSetup.audienceOptions}
+                availableGrades={campaignSetup.availableGrades}
                 selectedBlocks={campaignSetup.selectedBlocks}
                 selectedSchools={campaignSetup.selectedSchools}
                 selectedGrades={campaignSetup.selectedGrades}
@@ -473,6 +474,7 @@ const CampaignSetupPage: React.FC = () => {
                   campaignSetup.schoolsForSelectedBlocks
                 }
                 loadingAudience={campaignSetup.loadingAudience}
+                loadingGrades={campaignSetup.loadingGrades}
                 selectedProgramName={campaignSetup.selectedProgramName}
                 summaryBlockCount={campaignSetup.summaryBlockCount}
                 summarySchoolCount={campaignSetup.summarySchoolCount}

--- a/src/services/api/ApiHandler.ts
+++ b/src/services/api/ApiHandler.ts
@@ -1602,6 +1602,12 @@ export class ApiHandler implements ServiceApi {
     return await this.s.getCampaignAudienceOptions(programId);
   }
 
+  public async getCampaignGradesForSchools(
+    schoolIds: string[],
+  ): Promise<CampaignOption[]> {
+    return await this.s.getCampaignGradesForSchools(schoolIds);
+  }
+
   public async getCampaignAudienceSummary(
     params: CampaignAudienceSummaryParams,
   ): Promise<CampaignAudienceSummary> {

--- a/src/services/api/ServiceApi.ts
+++ b/src/services/api/ServiceApi.ts
@@ -2406,6 +2406,13 @@ export interface ServiceApi {
   ): Promise<CampaignAudienceOptions>;
 
   /**
+   * Loads grades available for the selected schools.
+   * Grades are derived from active classes linked to those schools.
+   * @param {string[]} schoolIds - Selected school IDs.
+   */
+  getCampaignGradesForSchools(schoolIds: string[]): Promise<CampaignOption[]>;
+
+  /**
    * Returns a grade-wise student count summary for the selected schools and grades.
    * Used by the campaign setup audience summary box.
    * @param {CampaignAudienceSummaryParams} params - School and grade IDs to summarize.

--- a/src/services/api/SqliteApi.ts
+++ b/src/services/api/SqliteApi.ts
@@ -8030,6 +8030,12 @@ order by
     return await this._serverApi.getCampaignAudienceOptions(programId);
   }
 
+  async getCampaignGradesForSchools(
+    schoolIds: string[],
+  ): Promise<CampaignOption[]> {
+    return await this._serverApi.getCampaignGradesForSchools(schoolIds);
+  }
+
   async getCampaignAudienceSummary(
     params: CampaignAudienceSummaryParams,
   ): Promise<CampaignAudienceSummary> {

--- a/src/services/api/SupabaseApi.ts
+++ b/src/services/api/SupabaseApi.ts
@@ -10374,11 +10374,17 @@ export class SupabaseApi implements ServiceApi {
       new Set(schools.map((school) => school.block).filter(Boolean)),
     ).sort((a, b) => a.localeCompare(b));
 
-    const grades = await this.getCampaignGradesForSchools(
+    const grades = await this.getCampaignAudienceOptionGradesForSchools(
       schools.map((school) => school.id),
     );
 
     return { blocks, schools, grades };
+  }
+
+  async getCampaignGradesForSchools(
+    schoolIds: string[],
+  ): Promise<CampaignOption[]> {
+    return await this.fetchDistinctClassGradesForSchools(schoolIds);
   }
 
   async getCampaignAudienceSummary({
@@ -10977,7 +10983,36 @@ export class SupabaseApi implements ServiceApi {
     };
   }
 
-  private async getCampaignGradesForSchools(
+  private async fetchDistinctClassGradesForSchools(
+    schoolIds: string[],
+  ): Promise<{ id: string; name: string }[]> {
+    if (!this.supabase || schoolIds.length === 0) return [];
+
+    const { data: gradeRows, error: gradeError } = await this.supabase
+      .from('grade')
+      .select('id, name, sort_index, class!inner()')
+      .in('class.school_id', schoolIds)
+      .eq('class.is_deleted', false)
+      .eq('is_deleted', false);
+
+    if (gradeError) {
+      logger.error('Error fetching school grades for campaign:', gradeError);
+    }
+
+    return ((gradeRows ?? []) as CampaignGradeRow[])
+      .filter((grade) => grade.id && grade.name)
+      .sort(
+        (a, b) =>
+          Number(a.sort_index ?? 9999) - Number(b.sort_index ?? 9999) ||
+          String(a.name).localeCompare(String(b.name)),
+      )
+      .map((grade) => ({
+        id: String(grade.id),
+        name: String(grade.name),
+      }));
+  }
+
+  private async getCampaignAudienceOptionGradesForSchools(
     schoolIds: string[],
   ): Promise<{ id: string; name: string }[]> {
     if (!this.supabase || schoolIds.length === 0) return [];


### PR DESCRIPTION
Fetch available grades from classes linked to the selected schools instead of showing all program grades. This ensures users only see grade options that are actually available for their school selection.

Changes include:
- Added getCampaignGradesForSchools API method to fetch grades by school IDs
- Implemented lazy loading of grades when schools are selected
- Filter selected grades to only include available options after schools change
- Add close-on-click-away behavior to grade dropdown for better UX
- Update tests to verify grade filtering and selection behavior