### PR TITLE
Chim 1187 selectmode school flow

### DIFF
--- a/src/pages/SelectMode.test.tsx
+++ b/src/pages/SelectMode.test.tsx
@@ -70,12 +70,16 @@ jest.mock('./assets/leftArrowIcon.svg', () => ({
 }));
 
 const mockHistoryReplace = jest.fn();
+let mockLocationState: { fromKidsAppLocationSchool?: boolean } | undefined;
 jest.mock('react-router', () => {
   const actual = jest.requireActual('react-router');
   return {
     ...actual,
     useHistory: () => ({
       replace: mockHistoryReplace,
+    }),
+    useLocation: () => ({
+      state: mockLocationState,
     }),
   };
 });
@@ -314,6 +318,7 @@ describe('SelectMode page', () => {
     jest.clearAllMocks();
     localStorage.clear();
     sessionStorage.clear();
+    mockLocationState = undefined;
 
     // Mock Redux hooks
     useAppDispatch.mockReturnValue(jest.fn());
@@ -551,9 +556,6 @@ describe('SelectMode page', () => {
     });
     mockApiHandler.getSchoolsForUser.mockResolvedValue([
       { school: { id: 'school-1', name: 'School 1' }, role: 'AUTOUSER' },
-    ]);
-    mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
-      { id: 'school-1' },
     ]);
     mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([]);
 
@@ -875,6 +877,41 @@ describe('SelectMode page', () => {
     });
     expect(mockApiHandler.getClassesForSchool).not.toHaveBeenCalled();
     expect(screen.queryByText('Teacher School')).not.toBeInTheDocument();
+  });
+
+  it('keeps explicit kids school entry in school flow for teacher-role users', async () => {
+    const teacherSchool = { id: 'school-1', name: 'Teacher School' };
+    const classDoc = {
+      id: 'class-1',
+      name: 'Class 1',
+      school_id: teacherSchool.id,
+    };
+    mockLocationState = { fromKidsAppLocationSchool: true };
+    mockGetCurrMode.mockResolvedValue(MODES.TEACHER_SCHOOL);
+    mockAuthHandler.getCurrentUser.mockResolvedValue({
+      id: 'user-1',
+      name: 'Teacher User',
+    });
+    mockApiHandler.getSchoolsForUser.mockResolvedValue([
+      { school: teacherSchool, role: 'TEACHER' },
+    ]);
+    mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([]);
+    mockApiHandler.getClassesForSchool.mockResolvedValue([classDoc]);
+    mockApiHandler.getStudentsForClass.mockResolvedValue([
+      { id: 'student-1', name: 'Student 1' },
+    ]);
+
+    render(<SelectMode />);
+
+    await waitFor(() => {
+      expect(mockApiHandler.getClassesForSchool).toHaveBeenCalledWith(
+        teacherSchool.id,
+        'user-1',
+      );
+    });
+    expect(mockSetCurrMode).not.toHaveBeenCalledWith(MODES.TEACHER);
+    expect(mockHistoryReplace).not.toHaveBeenCalledWith(PAGES.HOME_PAGE);
+    expect(mockHistoryReplace).not.toHaveBeenCalledWith(PAGES.DISPLAY_SCHOOLS);
   });
 
   it('uses the school picker when multiple teacher schools remain after stored school is removed', async () => {

--- a/src/pages/SelectMode.tsx
+++ b/src/pages/SelectMode.tsx
@@ -5,7 +5,7 @@ import { t } from 'i18next';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { GiTeacher } from 'react-icons/gi';
 import { IoMdPeople } from 'react-icons/io';
-import { useHistory } from 'react-router';
+import { useHistory, useLocation } from 'react-router';
 import {
   AVATARS,
   CURRENT_CLASS_NAME,
@@ -97,6 +97,10 @@ interface SchoolModeOption {
   displayName: string;
   school: TableTypes<'school'>;
   role: RoleType;
+}
+
+interface SelectModeLocationState {
+  fromKidsAppLocationSchool?: boolean;
 }
 
 const SUPPORTED_LANGUAGE_CODES = new Set<string>(Object.values(LANG));
@@ -212,6 +216,7 @@ const SelectMode: FC = () => {
   const api = ServiceConfig.getI().apiHandler;
   const auth = ServiceConfig.getI().authHandler;
   const history = useHistory();
+  const location = useLocation<SelectModeLocationState | undefined>();
   const { setGbUpdated } = useGbContext();
   const [stage, setStage] = useState(STAGES.MODE);
   const [isOkayButtonDisabled, setIsOkayButtonDisabled] = useState(true);
@@ -443,8 +448,12 @@ const SelectMode: FC = () => {
     }));
     setTeacherAppSchoolList(teacherAppSchoolOptions);
 
+    const shouldSuppressTeacherAutoEntry =
+      currentMode === MODES.TEACHER_SCHOOL &&
+      location.state?.fromKidsAppLocationSchool === true;
     const shouldAutoEnterTeacherApp =
-      currentMode !== MODES.TEACHER_SCHOOL && teacherRoleEntries.length > 0;
+      teacherRoleEntries.length > 0 && !shouldSuppressTeacherAutoEntry;
+    const shouldUseEmptySchoolFallback = !shouldSuppressTeacherAutoEntry;
 
     if (shouldAutoEnterTeacherApp) {
       await applyOrientationForMode(MODES.TEACHER);
@@ -600,7 +609,7 @@ const SelectMode: FC = () => {
         schoolUtil.setCurrMode(MODES.TEACHER);
         history.replace(PAGES.DISPLAY_SCHOOLS);
         return;
-      } else if (shouldAutoEnterTeacherApp) {
+      } else if (shouldUseEmptySchoolFallback) {
         // Teacher logic
         await applyOrientationForMode(MODES.TEACHER);
         schoolUtil.setCurrMode(MODES.TEACHER);

--- a/src/pages/SelectMode.tsx
+++ b/src/pages/SelectMode.tsx
@@ -443,7 +443,9 @@ const SelectMode: FC = () => {
     }));
     setTeacherAppSchoolList(teacherAppSchoolOptions);
 
-    if (teacherRoleEntries.length > 0) {
+    const shouldAutoEnterTeacherApp = currentMode === MODES.TEACHER;
+
+    if (shouldAutoEnterTeacherApp && teacherRoleEntries.length > 0) {
       await applyOrientationForMode(MODES.TEACHER);
       schoolUtil.setCurrMode(MODES.TEACHER);
 
@@ -581,7 +583,7 @@ const SelectMode: FC = () => {
         }
       } else if (allSchool.length === 0) {
         onParentSelect();
-      } else if (teacherRoleEntries.length === 1) {
+      } else if (shouldAutoEnterTeacherApp && teacherRoleEntries.length === 1) {
         const fallbackTeacherSchool = teacherRoleEntries[0];
         setCurrentSchool(fallbackTeacherSchool.school);
         setCurrentSchoolRole(fallbackTeacherSchool.role);
@@ -592,12 +594,12 @@ const SelectMode: FC = () => {
         );
         setCurrentSchoolName(fallbackTeacherSchool.school.name);
         setStage(STAGES.MODE);
-      } else if (teacherRoleEntries.length > 1) {
+      } else if (shouldAutoEnterTeacherApp && teacherRoleEntries.length > 1) {
         await applyOrientationForMode(MODES.TEACHER);
         schoolUtil.setCurrMode(MODES.TEACHER);
         history.replace(PAGES.DISPLAY_SCHOOLS);
         return;
-      } else {
+      } else if (shouldAutoEnterTeacherApp) {
         // Teacher logic
         await applyOrientationForMode(MODES.TEACHER);
         schoolUtil.setCurrMode(MODES.TEACHER);

--- a/src/pages/SelectMode.tsx
+++ b/src/pages/SelectMode.tsx
@@ -443,9 +443,10 @@ const SelectMode: FC = () => {
     }));
     setTeacherAppSchoolList(teacherAppSchoolOptions);
 
-    const shouldAutoEnterTeacherApp = currentMode === MODES.TEACHER;
+    const shouldAutoEnterTeacherApp =
+      currentMode !== MODES.TEACHER_SCHOOL && teacherRoleEntries.length > 0;
 
-    if (shouldAutoEnterTeacherApp && teacherRoleEntries.length > 0) {
+    if (shouldAutoEnterTeacherApp) {
       await applyOrientationForMode(MODES.TEACHER);
       schoolUtil.setCurrMode(MODES.TEACHER);
 

--- a/src/teachers-module/pages/KidsAppLocation.test.tsx
+++ b/src/teachers-module/pages/KidsAppLocation.test.tsx
@@ -140,7 +140,9 @@ describe('KidsAppLocation', () => {
       ),
     );
     expect(setCurrModeMock).toHaveBeenCalledWith(MODES.TEACHER_SCHOOL);
-    expect(mockReplace).toHaveBeenCalledWith(PAGES.SELECT_MODE);
+    expect(mockReplace).toHaveBeenCalledWith(PAGES.SELECT_MODE, {
+      fromKidsAppLocationSchool: true,
+    });
   });
 
   test('does not show location options when access is blocked', () => {

--- a/src/teachers-module/pages/KidsAppLocation.tsx
+++ b/src/teachers-module/pages/KidsAppLocation.tsx
@@ -84,7 +84,7 @@ const KidsAppLocation: FC = () => {
     // Clear all school mode data for a completely fresh selection
     clearSchoolModeData(false);
     schoolUtil.setCurrMode(MODES.TEACHER_SCHOOL);
-    history.replace(PAGES.SELECT_MODE);
+    history.replace(PAGES.SELECT_MODE, { fromKidsAppLocationSchool: true });
   };
 
   if (isCheckingAccess || !isAccessAllowed) {


### PR DESCRIPTION
Fix TEACHER_SCHOOL flow redirecting to teacher dashboard

- Prevent teacher auto-entry when current mode is TEACHER_SCHOOL
- Keep TEACHER_SCHOOL in kids school/class/student selection flow
- Preserve teacher auto-routing for other modes