### PR TITLE
Disable Next while submitting on step 4

### DIFF
--- a/src/ops-console/components/campaignSetup/CampaignSetupActions.tsx
+++ b/src/ops-console/components/campaignSetup/CampaignSetupActions.tsx
@@ -34,7 +34,9 @@ export const CampaignSetupActions: React.FC<CampaignSetupActionsProps> = ({
       ? !isFormValid || isSubmitting
       : activeStep === 1
         ? !isAssignmentComplete
-        : false;
+        : activeStep === 4
+          ? isSubmitting
+          : false;
 
   const handleNextClick = () => {
     if (activeStep === 0) {


### PR DESCRIPTION
Update CampaignSetupActions disableNext logic to handle activeStep === 4. Previously other steps defaulted to false, which allowed advancing during submission on step 4. Now disableNext uses isSubmitting for step 4 to prevent duplicate submits. (File: src/ops-console/components/campaignSetup/CampaignSetupActions.tsx)