### PR TITLE
Fix optional phone validation when phone field is cleared

### DIFF
--- a/src/ops-console/components/SchoolDetailsComponents/FormCard.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/FormCard.tsx
@@ -344,7 +344,11 @@ const FormCard: React.FC<EntityModalProps> = ({
           <PhoneInput
             defaultCountry="in"
             value={values[field.name] ?? ''}
-            onChange={(value) => handleChange(field.name, value)}
+            onChange={(value) => {
+              const digits = value.replace(/\D/g, '');
+              const isCountryCodeOnly = digits === '91';
+              handleChange(field.name, isCountryCodeOnly ? '' : value);
+            }}
             disabled={field.disabled}
             disableCountryGuess
             className="formcard-phone-input"

--- a/src/ops-console/components/SchoolDetailsComponents/FormCard.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/FormCard.tsx
@@ -344,9 +344,10 @@ const FormCard: React.FC<EntityModalProps> = ({
           <PhoneInput
             defaultCountry="in"
             value={values[field.name] ?? ''}
-            onChange={(value) => {
+            onChange={(value, meta) => {
               const digits = value.replace(/\D/g, '');
-              const isCountryCodeOnly = digits === '91';
+              const dialCode = meta?.country?.dialCode ?? '';
+              const isCountryCodeOnly = dialCode !== '' && digits === dialCode;
               handleChange(field.name, isCountryCodeOnly ? '' : value);
             }}
             disabled={field.disabled}


### PR DESCRIPTION
## Summary
Fixed an issue where clearing the optional phone number field still triggered the "Phone number must be 10 digits" validation.

## Root Cause
`PhoneInput` preserves the country dial code (`+91`) when the user clears the input. The shared phone handler stored this value directly in the form state, causing the submit flow to interpret it as a partially entered phone number.

## Fix
- Updated the shared phone handler in `FormCard.tsx`.
- When `PhoneInput` emits only the country code (e.g. `+91`) after the field is cleared, store an empty string (`''`) instead.
- Preserve all other phone number values unchanged.

This ensures optional phone fields are treated as empty when the user clears the input while keeping existing validation for partial or invalid phone numbers.

## Testing
- ✅ Added a principal with a valid 10-digit phone number.
- ✅ Cleared the phone number and successfully submitted the form without validation errors.
- ✅ Verified invalid (non-10-digit) phone numbers still show the appropriate validation error.
- ✅ Verified valid phone numbers continue to work as expected.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d08a08a9-746a-4c9e-9a28-49827c03979f" />
