### PR TITLE
Allow adding parent phone number while editing at-home and hybrid

### DIFF
--- a/src/ops-console/components/SchoolDetailsComponents/SchoolStudents.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolStudents.tsx
@@ -1708,7 +1708,7 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
       ...baseArgs,
       user.student_id || user.student_id!,
       selectedClassId,
-      values.phone,
+      normalizePhone10(values.phone),
     );
 
     setIsEditStudentModalOpen(false);

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolStudents.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolStudents.tsx
@@ -1598,6 +1598,9 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
     }
   }, [issTotal, classOptions, isAtSchool, baseStudents]);
 
+  const hasContact =
+    !!editStudentData?.parent?.phone || !!editStudentData?.parent?.email;
+
   const editStudentFields: FieldConfig[] = [
     {
       name: 'studentName',
@@ -1653,12 +1656,13 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
     },
 
     // 6️⃣ Phone – full width
+
     {
       name: 'phone',
-      label: 'Phone / Email',
-      kind: 'chips',
+      label: hasContact ? 'Phone / Email' : 'Phone Number',
+      kind: !isAtSchool && !hasContact ? 'phone' : 'chips',
       column: 2,
-      disabled: true,
+      required: !hasContact,
     },
   ];
 
@@ -1704,6 +1708,7 @@ const SchoolStudents: React.FC<SchoolStudentsProps> = ({
       ...baseArgs,
       user.student_id || user.student_id!,
       selectedClassId,
+      values.phone,
     );
 
     setIsEditStudentModalOpen(false);

--- a/src/services/api/apihandler/ApiHandler.profiles.ts
+++ b/src/services/api/apihandler/ApiHandler.profiles.ts
@@ -120,6 +120,7 @@ export class ApiHandlerUserProfiles {
     languageDocId: string,
     student_id: string,
     newClassId: string,
+    phoneNumber?: string,
   ): Promise<TableTypes<'user'>> {
     return await this.s.updateStudentFromSchoolMode(
       student,
@@ -133,6 +134,7 @@ export class ApiHandlerUserProfiles {
       languageDocId,
       student_id,
       newClassId,
+      phoneNumber,
     );
   }
 

--- a/src/services/api/serviceapi/ServiceApi.profiles.ts
+++ b/src/services/api/serviceapi/ServiceApi.profiles.ts
@@ -61,6 +61,7 @@ export interface ServiceApiUserProfiles {
     languageDocId: string,
     student_id: string,
     newClassId: string,
+    phoneNumber?: string,
   ): Promise<TableTypes<'user'>>;
 
   updateUserProfile(

--- a/src/services/api/supabase/SupabaseApi.results.studentProfiles.ts
+++ b/src/services/api/supabase/SupabaseApi.results.studentProfiles.ts
@@ -162,6 +162,7 @@ export class SupabaseApiResultsStudentProfiles extends SupabaseApiResultsResultU
     languageDocId: string,
     student_id: string,
     newClassId: string,
+    phoneNumber?: string,
   ): Promise<TableTypes<'user'>> {
     if (!this.supabase) return student;
     const now = new Date().toISOString();
@@ -224,6 +225,73 @@ export class SupabaseApiResultsStudentProfiles extends SupabaseApiResultsResultU
 
         await this.supabase.from(TABLES.ClassUser).insert(newClassUser);
         await this.addParentToNewClass(newClassId, student.id);
+      }
+
+      if (phoneNumber) {
+        const { data, error } = await this.supabase.functions.invoke(
+          'get_or_create_user',
+          {
+            body: {
+              name,
+              phone: phoneNumber,
+            },
+          },
+        );
+
+        if (error) {
+          throw error;
+        }
+
+        const parentUser = data.user;
+        logger.info('Parent User:', parentUser);
+
+        const { data: existingParentUser } = await this.supabase
+          .from(TABLES.ParentUser)
+          .select('id')
+          .eq('parent_id', parentUser.id)
+          .eq('student_id', student.id)
+          .eq('is_deleted', false)
+          .maybeSingle();
+
+        logger.info('Existing Parent User:', existingParentUser);
+
+        if (!existingParentUser) {
+          await this.supabase.from(TABLES.ParentUser).insert({
+            id: uuidv4(),
+            parent_id: parentUser.id,
+            student_id: student.id,
+            created_at: now,
+            updated_at: now,
+            is_deleted: false,
+            is_firebase: null,
+            is_ops: null,
+            ops_created_by: null,
+          });
+        }
+
+        const { data: existingClassUser } = await this.supabase
+          .from(TABLES.ClassUser)
+          .select('id')
+          .eq('is_deleted', false)
+          .eq('user_id', parentUser.id)
+          .eq('class_id', newClassId)
+          .eq('role', RoleType.PARENT)
+          .maybeSingle();
+
+        if (!existingClassUser) {
+          await this.supabase.from(TABLES.ClassUser).insert({
+            id: uuidv4(),
+            class_id: newClassId,
+            user_id: parentUser.id,
+            role: RoleType.PARENT,
+            created_at: now,
+            updated_at: now,
+            is_deleted: false,
+            is_firebase: null,
+            is_ops: null,
+            ops_created_by: null,
+          });
+        }
       }
 
       return updatedStudent;


### PR DESCRIPTION
#### Changes

* Enabled editing of the parent contact field for at-home and hybrid students only when no existing phone/email is linked.
* Added support to pass the parent phone number to `updateStudentFromSchoolMode`.
* Integrated the `get_or_create_user` Edge Function to:

  * Reuse an existing parent user if the phone number already exists.
  * Create a new auth user and `user` record if no matching phone number exists.
* Created `parent_user` mapping when an active mapping does not already exist.
* Created `class_user` mapping with the **Parent** role when an active mapping does not already exist.
* Preserved existing active mappings to avoid duplicates.

#### Behavior

* Students with an existing parent phone/email continue to see the contact as read-only.
* Students without any linked contact can add a parent phone number.
* Existing parent accounts are reused based on phone number instead of creating duplicate users.
* Parent-to-student and parent-to-class relationships are created automatically after a phone number is added.
