### PR TITLE
fix/prevent-whatsapp-invite-input-autofocus

### DIFF
--- a/src/ops-console/components/SchoolDetailsComponents/WhatsAppInviteLinkInput.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/WhatsAppInviteLinkInput.tsx
@@ -26,7 +26,6 @@ const WhatsAppInviteLinkInput: React.FC<Props> = ({
     <div className="wa-info-invite-link-div" id="wa-info-invite-link-id">
       <input
         className="wa-input"
-        autoFocus
         value={inviteInput}
         onChange={(e) => setInviteInput(e.target.value)}
         placeholder="https://chat.whatsapp.com/..."


### PR DESCRIPTION
## Description

Removed automatic focus from the WhatsApp invite-link input on the class details page.

## Fix

- Prevents unwanted scrolling to the input on mobile devices.
- Prevents the mobile keyboard from opening automatically.
- Keeps focus behavior unchanged for user-triggered edit actions.

