### PR TITLE
fix: improve iPhone browser footer and report header visibility

### DIFF
--- a/src/mobileWebBrowserFixes.css
+++ b/src/mobileWebBrowserFixes.css
@@ -386,6 +386,48 @@ body.mobile-web-browser *::after {
     overflow: auto;
   }
 
+  @supports (-webkit-touch-callout: none) {
+    @media (orientation: portrait) {
+      body.mobile-web-browser .showchapters-lesson-grid,
+      body.mobile-web-browser .search-lesson-results,
+      body.mobile-web-browser .lesson-details-body,
+      body.mobile-web-browser .teacher-library-assignments-body {
+        padding-bottom: calc(220px + env(safe-area-inset-bottom, 0px));
+        scroll-padding-bottom: calc(220px + env(safe-area-inset-bottom, 0px));
+      }
+
+      body.mobile-web-browser .assignments-container {
+        padding-bottom: calc(150px + env(safe-area-inset-bottom, 0px));
+        scroll-padding-bottom: calc(150px + env(safe-area-inset-bottom, 0px));
+      }
+
+      body.mobile-web-browser .assign-selected-button {
+        position: fixed;
+        left: 50%;
+        bottom: calc(72px + env(safe-area-inset-bottom, 0px));
+        width: min(82vw, 360px);
+        transform: translateX(-50%);
+        z-index: 1400;
+      }
+    }
+
+    body.mobile-web-browser .teacher-assignments-page {
+      height: calc(100dvh - 112px);
+      min-height: 0;
+      padding-bottom: calc(170px + env(safe-area-inset-bottom, 0px));
+    }
+
+    body.mobile-web-browser .teacher-assignments-page .assign-button {
+      position: fixed;
+      top: auto;
+      left: 20px;
+      bottom: calc(10vh + 16px + env(safe-area-inset-bottom, 0px));
+      width: calc(100vw - 40px);
+      margin: 0;
+      z-index: 1300;
+    }
+  }
+
   body.mobile-web-browser .join-class-parent-container {
     min-height: 100%;
     justify-content: flex-start;

--- a/src/startup/platformSetup.ts
+++ b/src/startup/platformSetup.ts
@@ -37,10 +37,18 @@ const applyMobileWebBrowserClass = () => {
   const userAgentData = (navigator as NavigatorWithUserAgentData).userAgentData;
   const isMobileBrowser =
     userAgentData?.mobile === true || /\bMobile\b/i.test(userAgent);
+  const isSafariMobileBrowser =
+    isMobileBrowser &&
+    /Safari/i.test(userAgent) &&
+    !/CriOS|FxiOS|EdgiOS/i.test(userAgent);
 
   document.body.classList.toggle(
     'mobile-web-browser',
     !isNativePlatform && isMobileBrowser,
+  );
+  document.body.classList.toggle(
+    'safari-mobile-web-browser',
+    !isNativePlatform && isSafariMobileBrowser,
   );
 };
 

--- a/src/teachers-module/components/library/AssigmentCount.css
+++ b/src/teachers-module/components/library/AssigmentCount.css
@@ -33,3 +33,17 @@
   align-items: center;
   color: white;
 }
+
+@supports (-webkit-touch-callout: none) {
+  @media (orientation: portrait) and (hover: none) and (pointer: coarse) {
+    .assignment-count-container {
+      position: fixed;
+      left: 5vw;
+      right: 5vw;
+      bottom: calc(104px + env(safe-area-inset-bottom, 0px));
+      width: 90vw;
+      transform: none;
+      z-index: 1400;
+    }
+  }
+}

--- a/src/teachers-module/components/reports/TableRightHeader.css
+++ b/src/teachers-module/components/reports/TableRightHeader.css
@@ -2,23 +2,27 @@
   position: relative;
   text-align: center;
   height: 120px;
-  overflow: hidden;
+  width: 52px;
+  min-width: 52px;
+  padding: 0;
+  overflow: visible;
 }
 
 .tableRightHeaderText {
   color: #4a4949;
   font-weight: 400;
-  writing-mode: vertical-rl;
-  width: fit-content;
-  height: 80%;
-  margin: 0 auto;
-
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 84px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   line-height: 1.2;
   font-size: 14px;
   font-style: normal;
+  transform: translate(-50%, -50%) rotate(90deg);
+  transform-origin: center;
 }
 
 .aboveText,


### PR DESCRIPTION
- Fix report table column header text visibility on iPhone browsers.
- Add mobile-web Safari detection for targeted browser fixes.
- Adjust assignment Next footer positioning for iPhone portrait browsers.
- Add bottom scroll spacing so content does not overlap fixed footers.
- Keep fixes scoped to mobile web/iOS browser behavior to avoid affecting native app layouts.
<img width="1179" height="2260" alt="IMG_1869" src="https://github.com/user-attachments/assets/cac20d89-5434-4c99-9489-6c5437b8f790" />
<img width="1179" height="2253" alt="IMG_1870" src="https://github.com/user-attachments/assets/03f157a3-af21-4745-9962-a41c1984d791" />

