### PR TITLE
Optimize performance with lazy loading and batch queries

### DIFF
--- a/src/ops-console/components/SchoolDetailsComponents/ClassDetailsPage.test.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/ClassDetailsPage.test.tsx
@@ -90,8 +90,15 @@ describe('ClassDetailsPage', () => {
 
     await waitFor(() => expect(mockSchoolStudents).toHaveBeenCalled());
 
+    await waitFor(() =>
+      expect(mockApiHandler.getActiveStudentsCountByClass).toHaveBeenCalledWith(
+        'class-1',
+      ),
+    );
+    expect(mockApiHandler.getStudentInfoBySchoolId).not.toHaveBeenCalled();
     expect(mockSchoolStudents.mock.calls[0][0]).toEqual(
       expect.objectContaining({
+        optionalClassId: 'class-1',
         data: expect.objectContaining({
           classData: classRows,
         }),

--- a/src/ops-console/components/SchoolDetailsComponents/ClassDetailsPage.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/ClassDetailsPage.tsx
@@ -7,7 +7,7 @@ import SchoolStudents from './SchoolStudents';
 import { ServiceConfig } from '../../../services/ServiceConfig';
 import './ClassDetailsPage.css';
 import { t } from 'i18next';
-import { StudentInfo, TableTypes } from '../../../common/constants';
+import { TableTypes } from '../../../common/constants';
 import { ClassRow, SchoolDetailsData } from './SchoolClass';
 import AddNoteModal from '../SchoolDetailsComponents/AddNoteModal'; // <<-- imported
 import { NOTES_UPDATED_EVENT } from '../../../common/constants';
@@ -18,9 +18,6 @@ import { RoleType } from '../../../interface/modelInterfaces';
 import { useAppSelector } from '../../../redux/hooks';
 import { RootState } from '../../../redux/store';
 import { AuthState } from '../../../redux/slices/auth/authSlice';
-
-type ApiStudent = StudentInfo;
-const ROWS_PER_PAGE = 20;
 
 type Props = {
   data?: SchoolDetailsData;
@@ -48,8 +45,6 @@ const ClassDetailsPage: React.FC<Props> = ({
   const onlyClassRow =
     classDataArray.find((r) => r?.id === classId) ?? classRow ?? null;
 
-  const [initialStudents, setInitialStudents] = useState<ApiStudent[]>([]);
-  const [initialTotal, setInitialTotal] = useState<number>(0);
   const [activeStudentCount, setActiveStudentCount] = useState<number>(0);
 
   const [showAddModal, setShowAddModal] = useState(false); // <<-- modal state
@@ -81,28 +76,22 @@ const ClassDetailsPage: React.FC<Props> = ({
   );
 
   useEffect(() => {
+    let cancelled = false;
+
     (async () => {
       try {
         const api = ServiceConfig.getI().apiHandler;
-        const res = await api.getStudentInfoBySchoolId(
-          schoolId,
-          1,
-          ROWS_PER_PAGE,
-          classId,
-        );
-        logger.info('Loaded class details:', {
-          students: res?.data,
-          total: res?.total,
-        });
-        setInitialStudents(res?.data || []);
-        setInitialTotal(res?.total || 0);
         const active = await api.getActiveStudentsCountByClass(classId);
-        setActiveStudentCount(Number(active) || 0);
+        if (!cancelled) setActiveStudentCount(Number(active) || 0);
       } catch (e) {
         logger.error('Failed to load class details:', e);
-        setActiveStudentCount(0);
+        if (!cancelled) setActiveStudentCount(0);
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [schoolId, classId]);
 
   const finalClassCode =
@@ -212,10 +201,8 @@ const ClassDetailsPage: React.FC<Props> = ({
         <SchoolStudents
           data={{
             schoolData: data?.schoolData,
-            students: initialStudents,
-            totalStudentCount: initialTotal,
             classData: classDataArray,
-            totalCount: initialTotal,
+            totalCount: totalStudentsOverride,
           }}
           schoolId={schoolId}
           isMobile={isMobile}

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolClass.test.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolClass.test.tsx
@@ -245,6 +245,7 @@ describe('SchoolClasses class metrics', () => {
     expect(within(row).getByText('12')).toBeInTheDocument();
     expect(within(row).getByText('3.5')).toBeInTheDocument();
     expect(within(row).getByText('8.1')).toBeInTheDocument();
+    expect(mockApiHandler.getClassCodeById).not.toHaveBeenCalled();
   });
 
   it('refetches class metrics when the date range changes', async () => {

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolClass.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolClass.tsx
@@ -13,6 +13,7 @@ import { t } from 'i18next';
 import ClassForm from '../ClassForm';
 import FormCard from './FormCard';
 import { RoleType } from '../../../interface/modelInterfaces';
+import type { TableTypes } from '../../../common/constants';
 import { useAppSelector } from '../../../redux/hooks';
 import { RootState } from '../../../redux/store';
 import { AuthState } from '../../../redux/slices/auth/authSlice';
@@ -33,7 +34,11 @@ import { useSchoolClassAddStudent } from './useSchoolClassAddStudent';
 import { useSchoolClassMetrics } from './useSchoolClassMetrics';
 import type { ClassRow, SchoolDetailsData } from './SchoolClass.types';
 
-export type { ClassRow, SchoolData, SchoolDetailsData } from './SchoolClass.types';
+export type {
+  ClassRow,
+  SchoolData,
+  SchoolDetailsData,
+} from './SchoolClass.types';
 
 interface Props {
   data: SchoolDetailsData;
@@ -62,6 +67,9 @@ const SchoolClasses: React.FC<Props> = ({
   const [showForm, setShowForm] = useState<boolean>(false);
   const [groupIdOverrides, setGroupIdOverrides] = useState<
     Record<string, string>
+  >({});
+  const [classDetailsById, setClassDetailsById] = useState<
+    Record<string, ClassRow>
   >({});
   const [editingClass, setEditingClass] = useState<ClassRow | null>(null);
   const [selectedDateRange, setSelectedDateRange] =
@@ -140,6 +148,94 @@ const SchoolClasses: React.FC<Props> = ({
         : null,
     [selectedClassId, effectiveClasses],
   );
+  const selectedClassRow = selectedClassId
+    ? (classDetailsById[selectedClassId] ?? selectedRow)
+    : selectedRow;
+
+  useEffect(() => {
+    if (!selectedClassId || !selectedRow || classDetailsById[selectedClassId]) {
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const links = (await api.getCoursesByClassId(selectedClassId)) ?? [];
+        const detailArrays = await Promise.all(
+          links.map((link: { course_id: string }) =>
+            api.getCourse(link.course_id),
+          ),
+        );
+        const courses: TableTypes<'course'>[] = detailArrays
+          .flatMap(
+            (
+              courseRows:
+                | TableTypes<'course'>
+                | TableTypes<'course'>[]
+                | undefined,
+            ) => (Array.isArray(courseRows) ? courseRows : [courseRows]),
+          )
+          .filter((course): course is TableTypes<'course'> =>
+            Boolean(course?.id),
+          );
+        const curriculumIds = [
+          ...new Set(
+            courses
+              .map((course) => course.curriculum_id)
+              .filter(
+                (courseId: unknown): courseId is string =>
+                  typeof courseId === 'string' && courseId.length > 0,
+              ),
+          ),
+        ];
+        const curriculums: TableTypes<'curriculum'>[] = curriculumIds.length
+          ? await api.getCurriculumsByIds(curriculumIds)
+          : [];
+        const subjectsNames = [
+          ...new Set(
+            courses
+              .map((course) =>
+                typeof course?.name === 'string' ? course.name.trim() : '',
+              )
+              .filter((subjectName: string) => subjectName.length > 0),
+          ),
+        ].join(', ');
+        const curriculumNames = [
+          ...new Set(
+            curriculums
+              .map((curriculum) => curriculum.name?.trim() ?? '')
+              .filter((name: string) => name.length > 0),
+          ),
+        ].join(', ');
+
+        if (!cancelled) {
+          setClassDetailsById((prev) => ({
+            ...prev,
+            [selectedClassId]: {
+              ...selectedRow,
+              course_links: links,
+              courses,
+              curriculum: curriculums,
+              subjects: courses,
+              subjectsNames,
+              curriculumNames,
+            },
+          }));
+        }
+      } catch {
+        if (!cancelled) {
+          setClassDetailsById((prev) => ({
+            ...prev,
+            [selectedClassId]: selectedRow,
+          }));
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [api, classDetailsById, selectedClassId, selectedRow]);
 
   const handleGroupLinked = (classId: string, groupId: string) => {
     const classIdValue = String(classId ?? '').trim();
@@ -153,18 +249,23 @@ const SchoolClasses: React.FC<Props> = ({
     if (!selectedClassId) return undefined;
     const fromCodes = codes[selectedClassId] ?? null;
     const fromMetrics = classMetrics[selectedClassId]?.class_code;
-    const fromRow = selectedRow?.code == null ? null : String(selectedRow.code);
+    const fromRow =
+      selectedClassRow?.code == null ? null : String(selectedClassRow.code);
     return (fromCodes || fromMetrics || fromRow) === null
       ? undefined
       : String(fromCodes || fromMetrics || fromRow);
-  }, [selectedClassId, codes, classMetrics, selectedRow]);
+  }, [selectedClassId, codes, classMetrics, selectedClassRow]);
 
   const selectedTotalStudents = useMemo(() => {
-    if (!selectedRow) return undefined;
-    return Number.isFinite(selectedRow.studentCount)
-      ? Number(selectedRow.studentCount)
-      : undefined;
-  }, [selectedRow]);
+    if (!selectedClassId || !selectedClassRow) return undefined;
+    const fromMetrics = classMetrics[selectedClassId]?.onboarded_students;
+    const fromRow = selectedClassRow.studentCount;
+    return Number.isFinite(fromRow)
+      ? Number(fromRow)
+      : Number.isFinite(fromMetrics)
+        ? Number(fromMetrics)
+        : undefined;
+  }, [selectedClassId, selectedClassRow, classMetrics]);
 
   const handleEditClass = (classRow: ClassRow) => {
     setMode('edit');
@@ -184,7 +285,7 @@ const SchoolClasses: React.FC<Props> = ({
       data={data}
       schoolId={schoolId}
       classId={selectedClassId}
-      classRow={selectedRow}
+      classRow={selectedClassRow}
       classCodeOverride={selectedClassCode}
       totalStudentsOverride={selectedTotalStudents}
       onGroupLinked={handleGroupLinked}

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolClassTable.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolClassTable.tsx
@@ -15,10 +15,7 @@ import {
 } from './SchoolClassMetrics';
 import { getSchoolClassColumns } from './SchoolClassColumns';
 import type { ClassMetricsForClassListingRow } from '../../../services/api/ServiceApi';
-import type {
-  ClassRow,
-  SchoolClassTableRowData,
-} from './SchoolClass.types';
+import type { ClassRow, SchoolClassTableRowData } from './SchoolClass.types';
 
 type SchoolClassTableProps = {
   classMetrics: Record<string, ClassMetricsForClassListingRow>;
@@ -53,7 +50,7 @@ export default function SchoolClassTable({
       const metrics = classMetrics[c.id];
       const metricValues = getClassMetricValues(metrics, c.studentCount);
 
-      const rawCodeVal = codes[c.id] ?? metrics?.class_code ?? null;
+      const rawCodeVal = c.code ?? codes[c.id] ?? metrics?.class_code ?? null;
       const codeVal =
         rawCodeVal === null || rawCodeVal === undefined
           ? null

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolDetailsTabsComponent.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolDetailsTabsComponent.tsx
@@ -22,6 +22,7 @@ interface SchoolDetailsTabsComponentProps {
   refreshClasses?: () => void;
   goToClassesTab?: boolean;
   onTabChange?: (tab: SchoolTabs) => void;
+  onLoadTabData?: (tab: SchoolTabs) => void;
 }
 
 const SchoolDetailsTabsComponent: React.FC<SchoolDetailsTabsComponentProps> = ({
@@ -31,6 +32,7 @@ const SchoolDetailsTabsComponent: React.FC<SchoolDetailsTabsComponentProps> = ({
   refreshClasses,
   goToClassesTab,
   onTabChange,
+  onLoadTabData,
 }) => {
   const [activeTab, setActiveTab] = useState<SchoolTabs>(SchoolTabs.Overview);
 
@@ -55,6 +57,10 @@ const SchoolDetailsTabsComponent: React.FC<SchoolDetailsTabsComponentProps> = ({
   useEffect(() => {
     if (onTabChange) onTabChange(activeTab);
   }, [activeTab, onTabChange]);
+
+  useEffect(() => {
+    onLoadTabData?.(activeTab);
+  }, [activeTab, onLoadTabData]);
 
   return (
     <div className="school-detail-role-tabs-wrapper">

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolTeachers.test.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolTeachers.test.tsx
@@ -35,7 +35,10 @@ type SchoolClassLink = {
 type ApiHandlerMock = {
   searchTeachersInSchool: jest.Mock<Promise<ApiResponse<TeacherInfo>>, []>;
   getTeacherInfoBySchoolId: jest.Mock<Promise<ApiResponse<TeacherInfo>>, []>;
-  getRecentAssignmentCountByTeacher: jest.Mock<Promise<number>, []>;
+  getRecentAssignmentCountsByTeachers: jest.Mock<
+    Promise<Record<string, number | null>>,
+    [Array<{ teacherId: string; classId: string }>]
+  >;
   getClassesForSchool: jest.Mock<Promise<SchoolClassLink[]>, []>;
   addTeacherToClass: jest.Mock<Promise<void>, []>;
   deleteUserFromClass: jest.Mock<Promise<boolean>, []>;
@@ -46,7 +49,7 @@ type ApiHandlerMock = {
 const mockApiHandler: ApiHandlerMock = {
   searchTeachersInSchool: jest.fn(),
   getTeacherInfoBySchoolId: jest.fn(),
-  getRecentAssignmentCountByTeacher: jest.fn(),
+  getRecentAssignmentCountsByTeachers: jest.fn(),
   getClassesForSchool: jest.fn(),
   addTeacherToClass: jest.fn(),
   deleteUserFromClass: jest.fn(),
@@ -235,7 +238,9 @@ describe('SchoolTeachers', () => {
       data: [teacher],
       total: 1,
     });
-    mockApiHandler.getRecentAssignmentCountByTeacher.mockResolvedValue(0);
+    mockApiHandler.getRecentAssignmentCountsByTeachers.mockResolvedValue({
+      'teacher-1:class-1': 0,
+    });
     mockApiHandler.getClassesForSchool.mockResolvedValue([
       { id: 'class-1', name: '6A' },
     ]);
@@ -270,6 +275,20 @@ describe('SchoolTeachers', () => {
       ),
     );
   };
+
+  it('loads teacher assignment performance with one bulk request', async () => {
+    renderComponent();
+
+    await waitFor(() =>
+      expect(
+        mockApiHandler.getRecentAssignmentCountsByTeachers,
+      ).toHaveBeenCalledWith([{ teacherId: 'teacher-1', classId: 'class-1' }]),
+    );
+
+    expect(
+      mockApiHandler.getRecentAssignmentCountsByTeachers,
+    ).toHaveBeenCalledTimes(1);
+  });
 
   it('opens edit modal with assignment-only editable fields', async () => {
     await openEditModal();

--- a/src/ops-console/components/SchoolDetailsComponents/useSchoolClassMetrics.ts
+++ b/src/ops-console/components/SchoolDetailsComponents/useSchoolClassMetrics.ts
@@ -27,6 +27,7 @@ export function useSchoolClassMetrics({
     Record<string, ClassMetricsForClassListingRow>
   >({});
   const [classMetricsLoading, setClassMetricsLoading] = useState(false);
+  const [hasLoadedClassMetrics, setHasLoadedClassMetrics] = useState(false);
   const [codes, setCodes] = useState<Record<string, string | null>>({});
   const [loadingIds, setLoadingIds] = useState<Record<string, boolean>>({});
 
@@ -34,6 +35,7 @@ export function useSchoolClassMetrics({
     let cancelled = false;
 
     (async () => {
+      setHasLoadedClassMetrics(false);
       setClassMetricsLoading(true);
       try {
         const metricRows = await api.getClassMetricsForClassListing({
@@ -59,7 +61,10 @@ export function useSchoolClassMetrics({
         logger.error('Failed to fetch class listing metrics:', error);
         if (!cancelled) setClassMetrics({});
       } finally {
-        if (!cancelled) setClassMetricsLoading(false);
+        if (!cancelled) {
+          setClassMetricsLoading(false);
+          setHasLoadedClassMetrics(true);
+        }
       }
     })();
 
@@ -73,13 +78,19 @@ export function useSchoolClassMetrics({
       setCodes({});
       return;
     }
+    if (!hasLoadedClassMetrics) return;
 
     let cancelled = false;
     (async () => {
       const seeded: Record<string, string | null> = {};
       for (const c of safeClasses) {
         const v = c.code == null ? null : String(c.code);
-        if (v) seeded[c.id] = v;
+        const metricCode = classMetrics[c.id]?.class_code;
+        if (v) {
+          seeded[c.id] = v;
+        } else if (metricCode !== null && metricCode !== undefined) {
+          seeded[c.id] = String(metricCode);
+        }
       }
       const missingIds = safeClasses
         .map((c) => c.id)
@@ -119,7 +130,13 @@ export function useSchoolClassMetrics({
     return () => {
       cancelled = true;
     };
-  }, [api, safeClasses, shouldShowClassCode]);
+  }, [
+    api,
+    classMetrics,
+    hasLoadedClassMetrics,
+    safeClasses,
+    shouldShowClassCode,
+  ]);
 
   const handleGenerateCode = async (classId: string) => {
     try {

--- a/src/ops-console/components/SchoolDetailsComponents/useSchoolTeachersPerformance.ts
+++ b/src/ops-console/components/SchoolDetailsComponents/useSchoolTeachersPerformance.ts
@@ -23,6 +23,28 @@ type UseSchoolTeachersPerformanceProps = {
   sortedTeachers: TeacherInfo[];
 };
 
+type AssignmentCountPair = {
+  teacherId: string;
+  classId: string;
+};
+
+const getTeacherClassPair = (
+  apiTeacher: TeacherInfo,
+): AssignmentCountPair | null => {
+  const teacherId = apiTeacher.user?.id;
+  const classId =
+    (apiTeacher as { classId?: string }).classId ??
+    apiTeacher.classWithidname?.id ??
+    '';
+
+  if (!teacherId || !classId) return null;
+
+  return { teacherId, classId };
+};
+
+const getAssignmentPairKey = ({ teacherId, classId }: AssignmentCountPair) =>
+  `${teacherId}:${classId}`;
+
 const toDisplayTeacher = (
   apiTeacher: TeacherInfo,
   performance: EnumType<'fc_support_level'>,
@@ -89,45 +111,51 @@ export const useSchoolTeachersPerformance = ({
     }
     let cancelled = false;
     async function loadPerformance() {
-      const enriched: DisplayTeacher[] = await Promise.all(
-        sortedTeachers.map(async (apiTeacher) => {
-          const teacherId = apiTeacher.user?.id;
-          const classId =
-            (apiTeacher as { classId?: string }).classId ??
-            apiTeacher.classWithidname?.id ??
-            '';
+      const pairByKey = new Map<string, AssignmentCountPair>();
+      sortedTeachers.forEach((apiTeacher) => {
+        const pair = getTeacherClassPair(apiTeacher);
+        if (pair) {
+          pairByKey.set(getAssignmentPairKey(pair), pair);
+        }
+      });
 
-          if (!teacherId || !classId) {
-            return toDisplayTeacher(
-              apiTeacher,
-              PerformanceLevel.NOT_ASSIGNING as EnumType<'fc_support_level'>,
-              '',
-            );
-          }
+      const countsByPair: Record<string, number | null> = {};
+      const activeApi = ServiceConfig.getI().apiHandler;
+      const pairs = Array.from(pairByKey.values());
 
-          let perfLevel = PerformanceLevel.NOT_TRACKED;
-          try {
-            const activeApi = ServiceConfig.getI().apiHandler;
-            const count = await activeApi.getRecentAssignmentCountByTeacher(
-              teacherId,
-              classId,
-            );
-            perfLevel = mapCountToPerformance(count);
-          } catch (error) {
-            logger.error('Failed to load teacher performance count:', {
-              teacherId,
-              classId,
-              error,
-            });
-          }
+      if (pairs.length > 0) {
+        try {
+          Object.assign(
+            countsByPair,
+            await activeApi.getRecentAssignmentCountsByTeachers(pairs),
+          );
+        } catch (error) {
+          logger.error('Failed to load teacher performance counts:', {
+            error,
+          });
+        }
+      }
 
+      const enriched: DisplayTeacher[] = sortedTeachers.map((apiTeacher) => {
+        const pair = getTeacherClassPair(apiTeacher);
+
+        if (!pair) {
           return toDisplayTeacher(
             apiTeacher,
-            perfLevel as EnumType<'fc_support_level'>,
-            classId,
+            PerformanceLevel.NOT_ASSIGNING as EnumType<'fc_support_level'>,
+            '',
           );
-        }),
-      );
+        }
+
+        const pairKey = getAssignmentPairKey(pair);
+        const perfLevel = mapCountToPerformance(countsByPair[pairKey] ?? null);
+
+        return toDisplayTeacher(
+          apiTeacher,
+          perfLevel as EnumType<'fc_support_level'>,
+          pair.classId,
+        );
+      });
 
       if (!cancelled) {
         setTeachersWithPerformance(enriched);

--- a/src/ops-console/components/SubjectCurriculumCard.tsx
+++ b/src/ops-console/components/SubjectCurriculumCard.tsx
@@ -33,13 +33,14 @@ const SubjectCurriculumCard: React.FC<SubjectCurriculumCardProps> = ({
 
         /*Fetch school → courses */
         const schoolCourses = (await api.getCoursesBySchoolId(schoolId)) ?? [];
-        const courseArrays = await Promise.all(
-          schoolCourses.map((ln) => api.getCourse(ln.course_id)),
+        const courseIds = Array.from(
+          new Set(
+            schoolCourses
+              .map((ln) => ln.course_id)
+              .filter((courseId): courseId is string => Boolean(courseId)),
+          ),
         );
-
-        const courses = courseArrays
-          .flatMap((c: any) => (Array.isArray(c) ? c : [c]))
-          .filter(Boolean);
+        const courses = courseIds.length ? await api.getCourses(courseIds) : [];
 
         /* Collect curriculumIds & gradeIds */
         const curriculumIds = new Set<string>();

--- a/src/ops-console/components/campaignSetup/CampaignCommunicationTimelineStep.tsx
+++ b/src/ops-console/components/campaignSetup/CampaignCommunicationTimelineStep.tsx
@@ -11,7 +11,6 @@ import {
   getCampaignDurationDays,
 } from './campaignCommunicationUtils';
 import { CampaignCommunicationTimelineStepProps } from './campaignCommunicationTypes';
-import { useCampaignReach } from './useCampaignReach';
 import './CampaignCommunicationTimelineStep.css';
 
 const CampaignCommunicationTimelineStep: React.FC<
@@ -20,7 +19,8 @@ const CampaignCommunicationTimelineStep: React.FC<
   form,
   frequency,
   assignmentDrafts,
-  selectedSchoolIds,
+  campaignReach,
+  loadingReach,
   communicationState,
   communicationValidation,
   showValidation,
@@ -35,7 +35,6 @@ const CampaignCommunicationTimelineStep: React.FC<
     () => buildCommunicationTimelineDates(assignmentDrafts, form, frequency),
     [assignmentDrafts, form, frequency],
   );
-  const { campaignReach, loadingReach } = useCampaignReach(selectedSchoolIds);
 
   const getRow = (date: string) =>
     communicationState.rows[date] ?? createEmptyCommunicationRow();

--- a/src/ops-console/components/campaignSetup/campaignCommunicationTypes.ts
+++ b/src/ops-console/components/campaignSetup/campaignCommunicationTypes.ts
@@ -10,7 +10,8 @@ export type CampaignCommunicationTimelineStepProps = {
   form: CampaignSetupFormState;
   frequency: Frequency;
   assignmentDrafts: CampaignAssignmentDraft[];
-  selectedSchoolIds: string[];
+  campaignReach: CampaignReachSummary;
+  loadingReach: boolean;
   communicationState: CampaignCommunicationState;
   communicationValidation: CampaignCommunicationValidation;
   showValidation: boolean;

--- a/src/ops-console/components/campaignSetup/useCampaignReach.ts
+++ b/src/ops-console/components/campaignSetup/useCampaignReach.ts
@@ -8,7 +8,10 @@ const emptyReach: CampaignReachSummary = {
   memberCount: 0,
 };
 
-export const useCampaignReach = (selectedSchoolIds: string[]) => {
+export const useCampaignReach = (
+  selectedSchoolIds: string[],
+  enabled = true,
+) => {
   const api = ServiceConfig.getI().apiHandler;
   const [campaignReach, setCampaignReach] =
     useState<CampaignReachSummary>(emptyReach);
@@ -19,11 +22,13 @@ export const useCampaignReach = (selectedSchoolIds: string[]) => {
 
     const loadReach = async () => {
       if (
+        !enabled ||
         selectedSchoolIds.length === 0 ||
         !api.getParentWhatsappClassesBySchoolId ||
         !api.getCampaignParentsInGroupBySchoolIds
       ) {
         setCampaignReach(emptyReach);
+        setLoadingReach(false);
         return;
       }
 
@@ -56,7 +61,7 @@ export const useCampaignReach = (selectedSchoolIds: string[]) => {
     return () => {
       mounted = false;
     };
-  }, [api, selectedSchoolIds]);
+  }, [api, enabled, selectedSchoolIds]);
 
   return {
     campaignReach,

--- a/src/ops-console/hooks/useCampaignAssignmentTab.ts
+++ b/src/ops-console/hooks/useCampaignAssignmentTab.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type React from 'react';
 import { type SelectChangeEvent } from '@mui/material';
 import { ServiceConfig } from '../../services/ServiceConfig';
@@ -30,6 +30,7 @@ export const useCampaignAssignmentTab = (campaignId?: string) => {
   const [total, setTotal] = useState(0);
   const [isLoadingFilters, setIsLoadingFilters] = useState(true);
   const [isLoadingAssignments, setIsLoadingAssignments] = useState(true);
+  const lastAssignmentsRequestKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     const handleResize = () => setViewportWidth(getViewportWidth());
@@ -78,14 +79,30 @@ export const useCampaignAssignmentTab = (campaignId?: string) => {
   }, [api, campaignId]);
 
   useEffect(() => {
-    setSelectedGrades([]);
-    setSelectedSubjects([]);
-    setSubjects([]);
-    setPage(1);
+    lastAssignmentsRequestKeyRef.current = null;
+    setSelectedGrades((current) => (current.length > 0 ? [] : current));
+    setSelectedSubjects((current) => (current.length > 0 ? [] : current));
+    setSubjects((current) => (current.length > 0 ? [] : current));
+    setPage((current) => (current === 1 ? current : 1));
   }, [campaignId]);
+
+  const selectedGradesKey = useMemo(
+    () => selectedGrades.join(','),
+    [selectedGrades],
+  );
+  const selectedSubjectsKey = useMemo(
+    () => selectedSubjects.join(','),
+    [selectedSubjects],
+  );
 
   useEffect(() => {
     let cancelled = false;
+    const requestKey = JSON.stringify({
+      campaignId,
+      page,
+      selectedGrades,
+      selectedSubjects,
+    });
 
     async function loadAssignments() {
       if (!campaignId) {
@@ -94,6 +111,11 @@ export const useCampaignAssignmentTab = (campaignId?: string) => {
         setIsLoadingAssignments(false);
         return;
       }
+
+      if (lastAssignmentsRequestKeyRef.current === requestKey) {
+        return;
+      }
+      lastAssignmentsRequestKeyRef.current = requestKey;
 
       setIsLoadingAssignments(true);
       try {
@@ -127,7 +149,15 @@ export const useCampaignAssignmentTab = (campaignId?: string) => {
     return () => {
       cancelled = true;
     };
-  }, [api, campaignId, page, selectedGrades, selectedSubjects]);
+  }, [
+    api,
+    campaignId,
+    page,
+    selectedGrades,
+    selectedGradesKey,
+    selectedSubjects,
+    selectedSubjectsKey,
+  ]);
 
   const isSmallScreen = viewportWidth <= 600;
   const isMediumScreen = viewportWidth > 600 && viewportWidth <= 900;

--- a/src/ops-console/hooks/useCampaignSetupForm.ts
+++ b/src/ops-console/hooks/useCampaignSetupForm.ts
@@ -218,11 +218,14 @@ export const useCampaignSetupForm = () => {
 
     const loadAssignmentOptions = async () => {
       if (
+        activeStep !== 1 ||
+        form.objective === CAMPAIGN_OBJECTIVE.HOMEPAGE_LEARNING_PATHWAY ||
         !form.programId ||
         selectedAssignmentSchoolIds.length === 0 ||
         audience.selectedGrades.length === 0 ||
         assignmentOptionsCacheRef.current[assignmentOptionsCacheKey]
       ) {
+        setLoadingAssignmentOptions(false);
         return;
       }
 
@@ -254,8 +257,10 @@ export const useCampaignSetupForm = () => {
     };
   }, [
     api,
+    activeStep,
     assignmentOptionsCacheKey,
     audience.selectedGrades,
+    form.objective,
     form.programId,
     selectedAssignmentSchoolIds,
   ]);

--- a/src/ops-console/hooks/useCampaignSetupPage.ts
+++ b/src/ops-console/hooks/useCampaignSetupPage.ts
@@ -77,7 +77,10 @@ export const useCampaignSetupPage = () => {
     [communicationState.rows, communicationTimelineDates],
   );
 
-  const { campaignReach } = useCampaignReach(selectedAssignmentSchoolIds);
+  const { campaignReach, loadingReach } = useCampaignReach(
+    selectedAssignmentSchoolIds,
+    campaignSetup.activeStep >= 3,
+  );
 
   const targetAudienceStudentCount = useMemo(
     () =>
@@ -433,6 +436,7 @@ export const useCampaignSetupPage = () => {
     isAssignmentComplete,
     launchMessage,
     launching,
+    loadingReach,
     reviewData,
     selectedAssignmentSchoolIds,
     setActiveStepSafe,

--- a/src/ops-console/hooks/useSchoolDetailsPage.test.ts
+++ b/src/ops-console/hooks/useSchoolDetailsPage.test.ts
@@ -1,0 +1,145 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { SchoolTabs } from '../../interface/modelInterfaces';
+import { useSchoolDetailsPage } from './useSchoolDetailsPage';
+
+jest.mock('@capacitor/toast', () => ({
+  Toast: {
+    show: jest.fn(),
+  },
+}));
+
+jest.mock('i18next', () => ({
+  t: (key: string) => key,
+}));
+
+jest.mock('react-router', () => ({
+  useHistory: () => ({
+    goBack: jest.fn(),
+    replace: jest.fn(),
+  }),
+}));
+
+jest.mock('../../redux/hooks', () => ({
+  useAppSelector: () => ({ roles: [] }),
+}));
+
+jest.mock('../../utility/logger', () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+}));
+
+const mockApiHandler = {
+  getSchoolById: jest.fn(),
+  getProgramForSchool: jest.fn(),
+  getProgramManagersForSchool: jest.fn(),
+  getPrincipalsForSchoolPaginated: jest.fn(),
+  getCoordinatorsForSchoolPaginated: jest.fn(),
+  school_activity_stats: jest.fn(),
+  getSchoolStatsForSchool: jest.fn(),
+  getLastSchoolVisit: jest.fn(),
+  getTeacherInfoBySchoolId: jest.fn(),
+  getStudentInfoBySchoolId: jest.fn(),
+  getClassesBySchoolId: jest.fn(),
+  getStudentsForClass: jest.fn(),
+  getCoursesByClassId: jest.fn(),
+  getCourse: jest.fn(),
+  getCurriculumsByIds: jest.fn(),
+};
+
+jest.mock('../../services/ServiceConfig', () => ({
+  ServiceConfig: {
+    getI: () => ({
+      apiHandler: mockApiHandler,
+    }),
+  },
+}));
+
+describe('useSchoolDetailsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockApiHandler.getSchoolById.mockResolvedValue({
+      id: 'school-1',
+      name: 'Test School',
+    });
+    mockApiHandler.getProgramForSchool.mockResolvedValue({
+      id: 'program-1',
+      name: 'Program',
+    });
+    mockApiHandler.getProgramManagersForSchool.mockResolvedValue([]);
+    mockApiHandler.getPrincipalsForSchoolPaginated.mockResolvedValue({
+      data: [],
+      total: 0,
+    });
+    mockApiHandler.getCoordinatorsForSchoolPaginated.mockResolvedValue({
+      data: [],
+      total: 0,
+    });
+    mockApiHandler.school_activity_stats.mockResolvedValue({
+      active_student_percentage: 0,
+      active_teacher_percentage: 0,
+      avg_weekly_time_minutes: 0,
+    });
+    mockApiHandler.getSchoolStatsForSchool.mockResolvedValue({
+      visits: 0,
+      calls_made: 0,
+      tech_issues: 0,
+      parents_interacted: 0,
+      parents_reached: 0,
+      students_interacted: 0,
+      teachers_interacted: 0,
+    });
+    mockApiHandler.getLastSchoolVisit.mockResolvedValue(null);
+    mockApiHandler.getClassesBySchoolId.mockResolvedValue([
+      { id: 'class-1', school_id: 'school-1', name: '6A' },
+    ]);
+    mockApiHandler.getStudentsForClass.mockResolvedValue([]);
+    mockApiHandler.getCoursesByClassId.mockResolvedValue([
+      { course_id: 'course-1' },
+    ]);
+    mockApiHandler.getCourse.mockResolvedValue({
+      id: 'course-1',
+      name: 'Math',
+      curriculum_id: 'curriculum-1',
+    });
+    mockApiHandler.getCurriculumsByIds.mockResolvedValue([
+      { id: 'curriculum-1', name: 'NCERT' },
+    ]);
+  });
+
+  it('loads only overview data on initial render', async () => {
+    renderHook(() => useSchoolDetailsPage('school-1'));
+
+    await waitFor(() =>
+      expect(mockApiHandler.getSchoolById).toHaveBeenCalledWith('school-1'),
+    );
+
+    expect(mockApiHandler.getTeacherInfoBySchoolId).not.toHaveBeenCalled();
+    expect(mockApiHandler.getStudentInfoBySchoolId).not.toHaveBeenCalled();
+    expect(mockApiHandler.getClassesBySchoolId).not.toHaveBeenCalled();
+    expect(mockApiHandler.getStudentsForClass).not.toHaveBeenCalled();
+    expect(mockApiHandler.getCoursesByClassId).not.toHaveBeenCalled();
+    expect(mockApiHandler.getCourse).not.toHaveBeenCalled();
+    expect(mockApiHandler.getCurriculumsByIds).not.toHaveBeenCalled();
+  });
+
+  it('loads only class rows once when a class-dependent tab is requested', async () => {
+    const { result } = renderHook(() => useSchoolDetailsPage('school-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.loadSchoolDetailsTabData(SchoolTabs.Classes);
+    });
+
+    await act(async () => {
+      await result.current.loadSchoolDetailsTabData(SchoolTabs.Teachers);
+    });
+
+    expect(mockApiHandler.getClassesBySchoolId).toHaveBeenCalledTimes(1);
+    expect(mockApiHandler.getStudentsForClass).not.toHaveBeenCalled();
+    expect(mockApiHandler.getCoursesByClassId).not.toHaveBeenCalled();
+    expect(mockApiHandler.getCourse).not.toHaveBeenCalled();
+    expect(mockApiHandler.getCurriculumsByIds).not.toHaveBeenCalled();
+  });
+});

--- a/src/ops-console/hooks/useSchoolDetailsPage.ts
+++ b/src/ops-console/hooks/useSchoolDetailsPage.ts
@@ -1,6 +1,6 @@
 import { Toast } from '@capacitor/toast';
 import { t } from 'i18next';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router';
 import {
   NOTES_UPDATED_EVENT,
@@ -69,6 +69,34 @@ const useIsMobile = () => {
   return isMobile;
 };
 
+const resolveSettled = <T>(
+  label: string,
+  settled: PromiseSettledResult<T>,
+  fallback: T,
+): T => {
+  if (settled.status === 'fulfilled') return settled.value;
+  logger.error(`SchoolDetailsPage fetch failed: ${label}`, settled.reason);
+  return fallback;
+};
+
+const emptyPaged = { data: [], total: 0 };
+
+const emptySchoolActivityStats: SchoolStats = {
+  active_student_percentage: 0,
+  active_teacher_percentage: 0,
+  avg_weekly_time_minutes: 0,
+};
+
+const emptyInteractionStats: FCSchoolStats = {
+  visits: 0,
+  calls_made: 0,
+  tech_issues: 0,
+  parents_interacted: 0,
+  parents_reached: 0,
+  students_interacted: 0,
+  teachers_interacted: 0,
+};
+
 export const useSchoolDetailsPage = (id: string) => {
   const [data, setData] = useState<{
     schoolData?: any;
@@ -113,6 +141,8 @@ export const useSchoolDetailsPage = (id: string) => {
   const [activeVisitType, setActiveVisitType] = useState<
     SchoolVisitType | undefined
   >(undefined);
+  const loadedTabsRef = useRef<Set<SchoolTabs>>(new Set());
+  const loadingTabsRef = useRef<Set<SchoolTabs>>(new Set());
   const openMenu = Boolean(anchorEl);
 
   const handleAddNoteHeader = async (payload: {
@@ -269,30 +299,6 @@ export const useSchoolDetailsPage = (id: string) => {
   const fetchAll = useCallback(async () => {
     setLoading(true);
     const api = ServiceConfig.getI().apiHandler;
-    const resolveSettled = <T>(
-      label: string,
-      settled: PromiseSettledResult<T>,
-      fallback: T,
-    ): T => {
-      if (settled.status === 'fulfilled') return settled.value;
-      logger.error(`SchoolDetailsPage fetch failed: ${label}`, settled.reason);
-      return fallback;
-    };
-    const emptyPaged = { data: [], total: 0 };
-    const emptySchoolActivityStats: SchoolStats = {
-      active_student_percentage: 0,
-      active_teacher_percentage: 0,
-      avg_weekly_time_minutes: 0,
-    };
-    const emptyInteractionStats: FCSchoolStats = {
-      visits: 0,
-      calls_made: 0,
-      tech_issues: 0,
-      parents_interacted: 0,
-      parents_reached: 0,
-      students_interacted: 0,
-      teachers_interacted: 0,
-    };
 
     try {
       const [
@@ -301,9 +307,6 @@ export const useSchoolDetailsPage = (id: string) => {
         programManagersSettled,
         principalsResponseSettled,
         coordinatorsResponseSettled,
-        teachersResponseSettled,
-        studentsResponseSettled,
-        classResponseSettled,
       ] = await Promise.allSettled([
         api.getSchoolById(id),
         api.getProgramForSchool(id),
@@ -312,9 +315,6 @@ export const useSchoolDetailsPage = (id: string) => {
           ? Promise.resolve(emptyPaged)
           : api.getPrincipalsForSchoolPaginated(id, 1, 20),
         api.getCoordinatorsForSchoolPaginated(id, 1, 20),
-        api.getTeacherInfoBySchoolId(id, 1, 20),
-        api.getStudentInfoBySchoolId(id, 1, 20),
-        api.getClassesBySchoolId(id),
       ]);
 
       const school = resolveSettled('getSchoolById', schoolSettled, undefined);
@@ -338,21 +338,6 @@ export const useSchoolDetailsPage = (id: string) => {
         coordinatorsResponseSettled,
         emptyPaged,
       );
-      const teachersResponse = resolveSettled(
-        'getTeacherInfoBySchoolId',
-        teachersResponseSettled,
-        emptyPaged,
-      );
-      const studentsResponse = resolveSettled(
-        'getStudentInfoBySchoolId',
-        studentsResponseSettled,
-        emptyPaged,
-      );
-      const classResponse = resolveSettled(
-        'getClassesBySchoolId',
-        classResponseSettled,
-        [],
-      );
       const [schoolActivityStatsSettled, interactionStatsSettled] =
         await Promise.allSettled([
           api.school_activity_stats(id),
@@ -373,91 +358,9 @@ export const useSchoolDetailsPage = (id: string) => {
       const stats = Array.isArray(interactionStat)
         ? interactionStat[0]
         : interactionStat;
-      const classData = Array.isArray(classResponse) ? classResponse : [];
-      const classDataWithDetails = await Promise.all(
-        classData.map(async (clasS) => {
-          try {
-            let classwiseTotal = 0;
-            try {
-              const raw = await api.getStudentsForClass(clasS.id);
-              const total = Number(raw.length);
-              classwiseTotal = Number.isFinite(total) ? total : 0;
-            } catch {
-              classwiseTotal = 0;
-            }
-            const links = (await api.getCoursesByClassId(clasS.id)) ?? [];
-            const detailArrays = await Promise.all(
-              links.map((link) =>
-                api.getCourse((link as { course_id: string }).course_id),
-              ),
-            );
-            const courses = detailArrays
-              .flatMap((courseRows) =>
-                Array.isArray(courseRows) ? courseRows : [courseRows],
-              )
-              .filter(Boolean);
-            const curIds = [
-              ...new Set(
-                courses
-                  .map((course) => course?.curriculum_id)
-                  .filter(
-                    (courseId): courseId is string =>
-                      typeof courseId === 'string' && courseId.length > 0,
-                  ),
-              ),
-            ];
-            const curriculum: TableTypes<'curriculum'>[] = [];
-            if (curIds.length > 0) {
-              const fetched = await api.getCurriculumsByIds(curIds);
-              const seen = new Set<string>();
-              for (const row of Array.isArray(fetched) ? fetched : []) {
-                const curriculumId = row?.id;
-                if (
-                  typeof curriculumId === 'string' &&
-                  !seen.has(curriculumId)
-                ) {
-                  seen.add(curriculumId);
-                  curriculum.push(row);
-                }
-              }
-            }
-            const subjectsNames = [
-              ...new Set(
-                courses
-                  .map((course) =>
-                    typeof course?.name === 'string' ? course.name.trim() : '',
-                  )
-                  .filter((subjectName: string) => subjectName.length > 0),
-              ),
-            ].join(', ');
-            const curriculumNames = [
-              ...new Set(
-                curriculum
-                  .map((curriculumRow) =>
-                    typeof curriculumRow?.name === 'string'
-                      ? curriculumRow.name.trim()
-                      : '',
-                  )
-                  .filter((name: string) => name.length > 0),
-              ),
-            ].join(', ');
-            return {
-              ...clasS,
-              subjects: courses,
-              subjectsNames,
-              curriculumNames,
-              course_links: links,
-              courses,
-              curriculum,
-              studentCount: classwiseTotal,
-            };
-          } catch {
-            return { ...clasS };
-          }
-        }),
-      );
 
-      setData({
+      setData((prev) => ({
+        ...prev,
         schoolData: school,
         programData: program,
         programManagers,
@@ -465,10 +368,6 @@ export const useSchoolDetailsPage = (id: string) => {
         totalPrincipalCount: principalsResponse?.total ?? 0,
         coordinators: coordinatorsResponse?.data ?? [],
         totalCoordinatorCount: coordinatorsResponse?.total ?? 0,
-        teachers: teachersResponse?.data ?? [],
-        totalTeacherCount: teachersResponse?.total ?? 0,
-        students: studentsResponse?.data ?? [],
-        totalStudentCount: studentsResponse?.total ?? 0,
         schoolStats: {
           active_student_percentage:
             schoolStatsResult?.active_student_percentage ?? 0,
@@ -477,8 +376,6 @@ export const useSchoolDetailsPage = (id: string) => {
           avg_weekly_time_minutes:
             schoolStatsResult?.avg_weekly_time_minutes ?? 0,
         },
-        classData: classDataWithDetails,
-        totalClassCount: classData.length,
         interactionStats: {
           visits: stats?.visits ?? 0,
           calls_made: stats?.calls_made ?? 0,
@@ -488,11 +385,60 @@ export const useSchoolDetailsPage = (id: string) => {
           students_interacted: stats?.students_interacted ?? 0,
           teachers_interacted: stats?.teachers_interacted ?? 0,
         },
-      });
+      }));
     } finally {
       setLoading(false);
     }
   }, [id, isExternalUser]);
+
+  const fetchClassesData = useCallback(
+    async (force = false) => {
+      if (!force && loadedTabsRef.current.has(SchoolTabs.Classes)) return;
+      if (loadingTabsRef.current.has(SchoolTabs.Classes)) return;
+
+      loadingTabsRef.current.add(SchoolTabs.Classes);
+      const api = ServiceConfig.getI().apiHandler;
+
+      try {
+        const classResponse = await api.getClassesBySchoolId(id);
+        const classData = Array.isArray(classResponse) ? classResponse : [];
+
+        loadedTabsRef.current.add(SchoolTabs.Classes);
+        setData((prev) => ({
+          ...prev,
+          classData,
+          totalClassCount: classData.length,
+        }));
+      } catch (error) {
+        logger.error(
+          'SchoolDetailsPage fetch failed: getClassesBySchoolId',
+          error,
+        );
+      } finally {
+        loadingTabsRef.current.delete(SchoolTabs.Classes);
+      }
+    },
+    [id],
+  );
+
+  const loadSchoolDetailsTabData = useCallback(
+    async (tab: SchoolTabs, options?: { force?: boolean }) => {
+      if (
+        tab === SchoolTabs.Classes ||
+        tab === SchoolTabs.Students ||
+        tab === SchoolTabs.Teachers
+      ) {
+        await fetchClassesData(options?.force ?? false);
+      }
+    },
+    [fetchClassesData],
+  );
+
+  useEffect(() => {
+    loadedTabsRef.current.clear();
+    loadingTabsRef.current.clear();
+    setData({});
+  }, [id]);
 
   useEffect(() => {
     void fetchAll();
@@ -518,6 +464,7 @@ export const useSchoolDetailsPage = (id: string) => {
     isFirstTimeCheckIn,
     isMobile,
     loading,
+    loadSchoolDetailsTabData,
     openMenu,
     schoolLocation,
     selectedVisitType,

--- a/src/ops-console/pages/CampaignAssignmentTab.test.tsx
+++ b/src/ops-console/pages/CampaignAssignmentTab.test.tsx
@@ -143,6 +143,7 @@ describe('CampaignAssignmentTab', () => {
     );
 
     expect(api.getAllGrades).toHaveBeenCalledTimes(1);
+    expect(api.getCampaignAssignments).toHaveBeenCalledTimes(1);
     expect(await screen.findByTestId('data-table')).toBeInTheDocument();
     expect(screen.getByText('Lesson Alpha')).toBeInTheDocument();
   });

--- a/src/ops-console/pages/CampaignSetupPage.test.tsx
+++ b/src/ops-console/pages/CampaignSetupPage.test.tsx
@@ -51,6 +51,7 @@ const mockApiHandler = {
   launchCampaign: jest.fn(),
   getCampaignAssignmentOptions: jest.fn(),
   getParentWhatsappClassesBySchoolId: jest.fn(),
+  getCampaignParentsInGroupBySchoolIds: jest.fn(),
   getParentWhatsappParentPhonesByClassId: jest.fn(),
 };
 const mockAuthHandler = {
@@ -153,6 +154,7 @@ const setupApiMocks = () => {
     ],
   });
   mockApiHandler.getParentWhatsappClassesBySchoolId.mockResolvedValue([]);
+  mockApiHandler.getCampaignParentsInGroupBySchoolIds.mockResolvedValue(0);
   mockApiHandler.getParentWhatsappParentPhonesByClassId.mockResolvedValue([]);
 };
 
@@ -649,6 +651,7 @@ describe('CampaignSetupPage', () => {
 
     expect(await screen.findByText('Students:')).toBeInTheDocument();
     expect(await screen.findByText(/Grade 1/)).toBeInTheDocument();
+    expect(mockApiHandler.getCampaignAssignmentOptions).not.toHaveBeenCalled();
 
     await waitFor(() =>
       expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled(),
@@ -658,6 +661,13 @@ describe('CampaignSetupPage', () => {
     expect(
       await screen.findByText('Assignment Configuration'),
     ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mockApiHandler.getCampaignAssignmentOptions).toHaveBeenCalledWith({
+        programId: 'program-1',
+        schoolIds: ['school-1'],
+        gradeIds: ['grade-1'],
+      }),
+    );
     expect(mockApiHandler.createCampaignSetup).not.toHaveBeenCalled();
     expect(screen.queryByText('Campaign setup saved.')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
@@ -710,6 +720,12 @@ describe('CampaignSetupPage', () => {
 
     await screen.findByRole('heading', { name: 'New Campaign' });
     await completeSetupStep();
+    expect(
+      mockApiHandler.getParentWhatsappClassesBySchoolId,
+    ).not.toHaveBeenCalled();
+    expect(
+      mockApiHandler.getCampaignParentsInGroupBySchoolIds,
+    ).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Next' }));
     await openSelectAndChoose('Select Reward Type', 'Digital Rewards');
@@ -783,6 +799,14 @@ describe('CampaignSetupPage', () => {
     expect(
       screen.getByRole('heading', { name: 'Campaign Communication Timeline' }),
     ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        mockApiHandler.getParentWhatsappClassesBySchoolId,
+      ).toHaveBeenCalledTimes(1),
+    );
+    expect(
+      mockApiHandler.getCampaignParentsInGroupBySchoolIds,
+    ).toHaveBeenCalledTimes(1);
   });
 
   it('requires at least one configured communication day before proceeding to summary', async () => {
@@ -855,6 +879,7 @@ describe('CampaignSetupPage', () => {
     });
     await openSelectAndChoose('Select Program', 'Early Learning');
     expect(await screen.findByText('Students:')).toBeInTheDocument();
+    expect(mockApiHandler.getCampaignAssignmentOptions).not.toHaveBeenCalled();
 
     await waitFor(() =>
       expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled(),
@@ -895,6 +920,7 @@ describe('CampaignSetupPage', () => {
     expect(
       screen.getByRole('heading', { name: 'Campaign Communication Timeline' }),
     ).toBeInTheDocument();
+    expect(mockApiHandler.getCampaignAssignmentOptions).not.toHaveBeenCalled();
     expect(
       screen.queryByText(
         'No campaign days are available yet. Complete assignment setup to generate the communication schedule.',

--- a/src/ops-console/pages/CampaignSetupPage.tsx
+++ b/src/ops-console/pages/CampaignSetupPage.tsx
@@ -35,6 +35,7 @@ const CampaignSetupPage: React.FC = () => {
     isAssignmentComplete,
     launchMessage,
     launching,
+    loadingReach,
     reviewData,
     selectedAssignmentSchoolIds,
     setActiveStepSafe,
@@ -167,7 +168,8 @@ const CampaignSetupPage: React.FC = () => {
               form={campaignSetup.form}
               frequency={campaignSetup.assignmentFrequency}
               assignmentDrafts={campaignSetup.assignmentDrafts}
-              selectedSchoolIds={selectedAssignmentSchoolIds}
+              campaignReach={reviewData.campaignReach}
+              loadingReach={loadingReach}
               communicationState={communicationState}
               communicationValidation={communicationValidation}
               showValidation={communicationAttempted}

--- a/src/ops-console/pages/ProgramPage.test.tsx
+++ b/src/ops-console/pages/ProgramPage.test.tsx
@@ -125,6 +125,7 @@ const mockSetSearchTerm = jest.fn();
 const mockSetFilters = jest.fn();
 const mockSetTempFilters = jest.fn();
 const mockSetIsFilterOpen = jest.fn();
+const mockHandleOpenFilters = jest.fn();
 const mockSetSelectedDateRange = jest.fn();
 const mockSetPage = jest.fn();
 const mockHandleClearFilters = jest.fn();
@@ -152,6 +153,7 @@ jest.mock('./ProgramPageLogic', () => ({
     filterOptions: {},
     isFilterOpen: false,
     setIsFilterOpen: mockSetIsFilterOpen,
+    handleOpenFilters: mockHandleOpenFilters,
     handleClearFilters: mockHandleClearFilters,
     selectedDateRange: '7d',
     setSelectedDateRange: mockSetSelectedDateRange,
@@ -210,7 +212,7 @@ it('renders the Program page and wires table actions to page logic', async () =>
   expect(mockSetPage).toHaveBeenCalledWith(1);
 
   await user.click(screen.getByRole('button', { name: 'open filters' }));
-  expect(mockSetIsFilterOpen).toHaveBeenCalledWith(true);
+  expect(mockHandleOpenFilters).toHaveBeenCalled();
 
   await user.click(screen.getByRole('button', { name: 'close filters' }));
   expect(mockSetIsFilterOpen).toHaveBeenCalledWith(false);

--- a/src/ops-console/pages/ProgramPage.tsx
+++ b/src/ops-console/pages/ProgramPage.tsx
@@ -43,7 +43,7 @@ const ProgramPageContent: React.FC<ProgramPageContentProps> = ({
         tempFilters={logic.tempFilters}
         filterOptions={logic.filterOptions}
         isFilterOpen={logic.isFilterOpen}
-        onOpenFilters={() => logic.setIsFilterOpen(true)}
+        onOpenFilters={logic.handleOpenFilters}
         onCloseFilters={() => {
           logic.setIsFilterOpen(false);
           logic.setTempFilters(logic.filters);

--- a/src/ops-console/pages/ProgramPageLogic.test.ts
+++ b/src/ops-console/pages/ProgramPageLogic.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useProgramPageLogic } from './ProgramPageLogic';
+
+const mockReplace = jest.fn();
+
+jest.mock('react-router', () => ({
+  useHistory: () => ({
+    push: jest.fn(),
+    replace: mockReplace,
+  }),
+  useLocation: () => ({
+    search: '',
+  }),
+}));
+
+jest.mock('../../utility/logger', () => ({
+  error: jest.fn(),
+}));
+
+const mockApiHandler = {
+  getPrograms: jest.fn(),
+  getProgramFilterOptions: jest.fn(),
+};
+
+jest.mock('../../services/ServiceConfig', () => ({
+  ServiceConfig: {
+    getI: () => ({
+      apiHandler: mockApiHandler,
+    }),
+  },
+}));
+
+describe('useProgramPageLogic', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApiHandler.getPrograms.mockResolvedValue({
+      data: [],
+      total: 0,
+    });
+    mockApiHandler.getProgramFilterOptions.mockResolvedValue({
+      state: ['Karnataka'],
+    });
+  });
+
+  it('loads program filter options only after opening filters and caches them', async () => {
+    const { result } = renderHook(() => useProgramPageLogic());
+
+    await waitFor(() => expect(mockApiHandler.getPrograms).toHaveBeenCalled());
+    expect(mockApiHandler.getProgramFilterOptions).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.handleOpenFilters();
+    });
+
+    await waitFor(() =>
+      expect(mockApiHandler.getProgramFilterOptions).toHaveBeenCalledTimes(1),
+    );
+
+    await act(async () => {
+      result.current.handleOpenFilters();
+    });
+
+    expect(mockApiHandler.getProgramFilterOptions).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ops-console/pages/ProgramPageLogic.ts
+++ b/src/ops-console/pages/ProgramPageLogic.ts
@@ -209,7 +209,8 @@ export const useProgramPageLogic = () => {
 
   useEffect(() => setTempFilters(filters), [filters]);
 
-  const loadFilterOptions = useCallback(async (): Promise<void> => {
+  const handleOpenFilters = useCallback(async (): Promise<void> => {
+    setIsFilterOpen(true);
     if (hasLoadedFilterOptionsRef.current) return;
 
     setIsFilterLoading(true);
@@ -224,11 +225,6 @@ export const useProgramPageLogic = () => {
       setIsFilterLoading(false);
     }
   }, [api]);
-
-  const handleOpenFilters = useCallback(() => {
-    setIsFilterOpen(true);
-    void loadFilterOptions();
-  }, [loadFilterOptions]);
 
   useEffect(() => {
     const params = new URLSearchParams();

--- a/src/ops-console/pages/ProgramPageLogic.ts
+++ b/src/ops-console/pages/ProgramPageLogic.ts
@@ -10,12 +10,6 @@ import {
   DEFAULT_DATE_RANGE,
   DEFAULT_PROGRAM_PAGE_SIZE,
   createEmptyProgramFilters,
-  getProgramSelectedFilterLabel,
-  getProgramSelectedFilterText,
-  programFilterConfigs,
-  programTabOptions,
-  PROGRAM_HEADER_PERCENT_FILTER_BY_COLUMN,
-  PROGRAM_PERCENT_FILTERS,
   type DateRangeValue,
   type Filters,
 } from './ProgramPageConfig';
@@ -176,6 +170,7 @@ export const useProgramPageLogic = () => {
   const [orderBy, setOrderBy] = useState('programName');
   const [orderDir, setOrderDir] = useState<'asc' | 'desc'>('asc');
   const tableScrollRef = useRef<HTMLDivElement>(null);
+  const hasLoadedFilterOptionsRef = useRef(false);
   const debouncedSearchTerm = useDebouncedValue(searchTerm, 500);
   const isSearchPending = searchTerm !== debouncedSearchTerm;
   const pageSize = DEFAULT_PROGRAM_PAGE_SIZE;
@@ -214,21 +209,26 @@ export const useProgramPageLogic = () => {
 
   useEffect(() => setTempFilters(filters), [filters]);
 
-  useEffect(() => {
-    const fetchFilterOptions = async (): Promise<void> => {
-      setIsFilterLoading(true);
-      try {
-        setFilterOptions(
-          mapProgramFilterOptions(await api.getProgramFilterOptions()),
-        );
-      } catch (error) {
-        logger.error('Failed to fetch program filters', error);
-      } finally {
-        setIsFilterLoading(false);
-      }
-    };
-    fetchFilterOptions();
+  const loadFilterOptions = useCallback(async (): Promise<void> => {
+    if (hasLoadedFilterOptionsRef.current) return;
+
+    setIsFilterLoading(true);
+    try {
+      setFilterOptions(
+        mapProgramFilterOptions(await api.getProgramFilterOptions()),
+      );
+      hasLoadedFilterOptionsRef.current = true;
+    } catch (error) {
+      logger.error('Failed to fetch program filters', error);
+    } finally {
+      setIsFilterLoading(false);
+    }
   }, [api]);
+
+  const handleOpenFilters = useCallback(() => {
+    setIsFilterOpen(true);
+    void loadFilterOptions();
+  }, [loadFilterOptions]);
 
   useEffect(() => {
     const params = new URLSearchParams();
@@ -287,6 +287,7 @@ export const useProgramPageLogic = () => {
     filterOptions,
     handleClearFilters,
     handleExportPrograms,
+    handleOpenFilters,
     handleHeaderFilterChange,
     handleSort,
     history,

--- a/src/ops-console/pages/RequestList.tsx
+++ b/src/ops-console/pages/RequestList.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  Box,
-  IconButton,
-  Tab,
-  Tabs,
-  Typography,
-} from '@mui/material';
+import { Box, IconButton, Tab, Tabs, Typography } from '@mui/material';
 import { REQUEST_TABS } from '../../common/constants';
 import DataTablePagination from '../components/DataTablePagination';
 import DataTableBody from '../components/DataTableBody';
@@ -28,6 +22,7 @@ const RequestList: React.FC = () => {
     filters,
     handleCancelFilters,
     handleDeleteFilter,
+    handleOpenFilters,
     handleRowClick,
     handleSort,
     handleTabChange,
@@ -90,7 +85,7 @@ const RequestList: React.FC = () => {
                   setSearchTerm(e.target.value);
                 }}
                 filters={filters}
-                onFilterClick={() => setIsFilterOpen(true)}
+                onFilterClick={handleOpenFilters}
                 onClearFilters={handleCancelFilters}
               />
             </div>

--- a/src/ops-console/pages/SchoolDetailsPage.tsx
+++ b/src/ops-console/pages/SchoolDetailsPage.tsx
@@ -56,6 +56,7 @@ const SchoolDetailsPage: React.FC<SchoolDetailComponentProps> = ({ id }) => {
     isFirstTimeCheckIn,
     isMobile,
     loading,
+    loadSchoolDetailsTabData,
     openMenu,
     schoolLocation,
     selectedVisitType,
@@ -215,11 +216,14 @@ const SchoolDetailsPage: React.FC<SchoolDetailComponentProps> = ({ id }) => {
           isMobile={isMobile}
           schoolId={id}
           refreshClasses={() => {
-            void fetchAll();
+            void loadSchoolDetailsTabData(SchoolTabs.Classes, {
+              force: true,
+            });
             setGoToClassesTab(true);
           }}
           goToClassesTab={goToClassesTab}
           onTabChange={(tab) => setActiveTab(tab)}
+          onLoadTabData={loadSchoolDetailsTabData}
         />
       </div>
       <div className="school-detail-columns-gap" />

--- a/src/ops-console/pages/SchoolList.test.tsx
+++ b/src/ops-console/pages/SchoolList.test.tsx
@@ -247,6 +247,35 @@ const mockRunBackgroundWorkerTask =
   >;
 
 describe('SchoolList actions menu', () => {
+  it('loads school filter options only after opening filters and caches them', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() =>
+      expect(
+        mockApiHandler.getSchoolMetricsForSchoolListing,
+      ).toHaveBeenCalled(),
+    );
+
+    expect(
+      mockApiHandler.getSchoolFilterOptionsForSchoolListing,
+    ).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Filter' }));
+
+    await waitFor(() =>
+      expect(
+        mockApiHandler.getSchoolFilterOptionsForSchoolListing,
+      ).toHaveBeenCalledTimes(1),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Filter' }));
+
+    expect(
+      mockApiHandler.getSchoolFilterOptionsForSchoolListing,
+    ).toHaveBeenCalledTimes(1);
+  });
+
   it('shows migrate, upload and add school actions for privileged users', async () => {
     renderPage();
 

--- a/src/ops-console/pages/SchoolListHeaderControls.tsx
+++ b/src/ops-console/pages/SchoolListHeaderControls.tsx
@@ -35,6 +35,7 @@ type SchoolListHeaderControlsProps = {
   handleExportSchools: () => void;
   handleOpenActionsMenu: (event: React.MouseEvent<HTMLButtonElement>) => void;
   handleOpenAddSchoolPage: () => void;
+  handleOpenFilters: () => void;
   handleOpenMigratePage: () => void;
   handleOpenUploadPage: () => void;
   handleSelectDateRange: (nextRange: DateRangeValue) => void;
@@ -53,9 +54,7 @@ type SchoolListHeaderControlsProps = {
   setFilters: React.Dispatch<React.SetStateAction<Filters>>;
   setIsFilterOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setPage: React.Dispatch<React.SetStateAction<number>>;
-  setPercentageFilters: React.Dispatch<
-    React.SetStateAction<PercentageFilters>
-  >;
+  setPercentageFilters: React.Dispatch<React.SetStateAction<PercentageFilters>>;
   setSchoolPerformanceFilter: React.Dispatch<
     React.SetStateAction<SchoolPerformanceFilterValue | null>
   >;
@@ -76,6 +75,7 @@ export default function SchoolListHeaderControls({
   handleExportSchools,
   handleOpenActionsMenu,
   handleOpenAddSchoolPage,
+  handleOpenFilters,
   handleOpenMigratePage,
   handleOpenUploadPage,
   handleSelectDateRange,
@@ -265,7 +265,7 @@ export default function SchoolListHeaderControls({
             <Button
               startIcon={<FilterListIcon fontSize="small" />}
               className="filter-button-SearchAndFilter school-list-top-filter-button"
-              onClick={() => setIsFilterOpen(true)}
+              onClick={handleOpenFilters}
             >
               <span style={{ color: 'black' }}>{t('Filter')}</span>
             </Button>

--- a/src/ops-console/pages/useRequestListPage.ts
+++ b/src/ops-console/pages/useRequestListPage.ts
@@ -146,14 +146,16 @@ export function useRequestListPage() {
     }),
   );
   const schoolNameToIdMapRef = React.useRef<Map<string, string>>(new Map());
-  const isFilterOptionsLoadingRef = React.useRef(false);
+  const hasRequestedFilterOptionsRef = React.useRef(false);
   const [isFilterOptionsLoaded, setIsFilterOptionsLoaded] = useState(false);
   const [orderBy, setOrderBy] = useState('requested_date');
   const [orderDir, setOrderDir] = useState<'desc' | 'asc'>('desc');
   const [pageSize] = useState(DEFAULT_PAGE_SIZE);
-  const isSchoolFilterReady =
-    filters.school.length === 0 || isFilterOptionsLoaded;
-  const isLoading = isFilterLoading || isDataLoading;
+  const hasSchoolFilter = filters.school.length > 0;
+  const isSchoolFilterReady = !hasSchoolFilter || isFilterOptionsLoaded;
+  const shouldLoadFilterOptions = isFilterOpen || hasSchoolFilter;
+  const isLoading =
+    isDataLoading || (!isFilterOpen && hasSchoolFilter && isFilterLoading);
   const columns = useMemo(
     () => getRequestListColumns(selectedTab),
     [selectedTab],
@@ -188,46 +190,45 @@ export function useRequestListPage() {
     history.replace({ search: params.toString() });
   }, [selectedTab, debouncedSearchTerm, filters, page, history]);
 
-  const loadFilterOptions = React.useCallback(async () => {
-    if (isFilterOptionsLoaded || isFilterOptionsLoadingRef.current) return;
+  useEffect(() => {
+    if (!shouldLoadFilterOptions || hasRequestedFilterOptionsRef.current) {
+      return;
+    }
 
-    isFilterOptionsLoadingRef.current = true;
+    hasRequestedFilterOptionsRef.current = true;
     setIsFilterLoading(true);
-    try {
-      const data = await api.getRequestFilterOptions();
-      if (data) {
+
+    api
+      .getRequestFilterOptions()
+      .then((data) => {
+        if (!data) return;
+
         setFilterOptions({
           request_type: (data.requestType || []).filter(
             (value): value is string => Boolean(value),
           ),
           school: data.school || [],
         });
+
         const nameToIdMap = new Map<string, string>();
         (data.school || []).forEach((school: { id: string; name: string }) => {
           nameToIdMap.set(school.name, school.id);
         });
         schoolNameToIdMapRef.current = nameToIdMap;
-      }
-    } catch (error) {
-      logger.error('Failed to fetch filter options', error);
-    } finally {
-      setIsFilterOptionsLoaded(true);
-      setIsFilterLoading(false);
-      isFilterOptionsLoadingRef.current = false;
-    }
-  }, [api, isFilterOptionsLoaded]);
-
-  useEffect(() => {
-    if (filters.school.length > 0) {
-      void loadFilterOptions();
-    }
-  }, [filters.school.length, loadFilterOptions]);
+      })
+      .catch((error) => {
+        logger.error('Failed to fetch filter options', error);
+      })
+      .finally(() => {
+        setIsFilterOptionsLoaded(true);
+        setIsFilterLoading(false);
+      });
+  }, [api, shouldLoadFilterOptions]);
 
   const handleOpenFilters = React.useCallback(() => {
     setIsFilterOpen(true);
     setTempFilters(filters);
-    void loadFilterOptions();
-  }, [filters, loadFilterOptions]);
+  }, [filters]);
 
   useEffect(() => {
     if (!isSchoolFilterReady) return;

--- a/src/ops-console/pages/useRequestListPage.ts
+++ b/src/ops-console/pages/useRequestListPage.ts
@@ -21,6 +21,7 @@ import {
 } from './RequestList.constants';
 import type {
   OpsRequestItem,
+  RequestListFilterOptions,
   RequestListFilters,
   RequestRow,
 } from './RequestList.types';
@@ -138,8 +139,14 @@ export function useRequestListPage() {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [tempFilters, setTempFilters] =
     useState<RequestListFilters>(INITIAL_FILTERS);
-  const [filterOptions, setFilterOptions] = useState(INITIAL_FILTER_OPTIONS);
+  const [filterOptions, setFilterOptions] = useState<RequestListFilterOptions>(
+    () => ({
+      ...INITIAL_FILTER_OPTIONS,
+      request_type: [...Constants.public.Enums.ops_request_type],
+    }),
+  );
   const schoolNameToIdMapRef = React.useRef<Map<string, string>>(new Map());
+  const isFilterOptionsLoadingRef = React.useRef(false);
   const [isFilterOptionsLoaded, setIsFilterOptionsLoaded] = useState(false);
   const [orderBy, setOrderBy] = useState('requested_date');
   const [orderDir, setOrderDir] = useState<'desc' | 'asc'>('desc');
@@ -147,7 +154,10 @@ export function useRequestListPage() {
   const isSchoolFilterReady =
     filters.school.length === 0 || isFilterOptionsLoaded;
   const isLoading = isFilterLoading || isDataLoading;
-  const columns = useMemo(() => getRequestListColumns(selectedTab), [selectedTab]);
+  const columns = useMemo(
+    () => getRequestListColumns(selectedTab),
+    [selectedTab],
+  );
   const pageCount = Math.ceil(total / pageSize);
   const filterOptionsForSlider: Record<string, string[]> = {
     request_type: filterOptions.request_type,
@@ -178,36 +188,46 @@ export function useRequestListPage() {
     history.replace({ search: params.toString() });
   }, [selectedTab, debouncedSearchTerm, filters, page, history]);
 
-  useEffect(() => {
-    const fetchFilterOptions = async () => {
-      setIsFilterLoading(true);
-      try {
-        const data = await api.getRequestFilterOptions();
-        if (data) {
-          setFilterOptions({
-            request_type: (data.requestType || []).filter(
-              (value): value is string => Boolean(value),
-            ),
-            school: data.school || [],
-          });
-          const nameToIdMap = new Map<string, string>();
-          (data.school || []).forEach(
-            (school: { id: string; name: string }) => {
-              nameToIdMap.set(school.name, school.id);
-            },
-          );
-          schoolNameToIdMapRef.current = nameToIdMap;
-        }
-      } catch (error) {
-        logger.error('Failed to fetch filter options', error);
-      } finally {
-        setIsFilterOptionsLoaded(true);
-        setIsFilterLoading(false);
-      }
-    };
+  const loadFilterOptions = React.useCallback(async () => {
+    if (isFilterOptionsLoaded || isFilterOptionsLoadingRef.current) return;
 
-    fetchFilterOptions();
-  }, [api]);
+    isFilterOptionsLoadingRef.current = true;
+    setIsFilterLoading(true);
+    try {
+      const data = await api.getRequestFilterOptions();
+      if (data) {
+        setFilterOptions({
+          request_type: (data.requestType || []).filter(
+            (value): value is string => Boolean(value),
+          ),
+          school: data.school || [],
+        });
+        const nameToIdMap = new Map<string, string>();
+        (data.school || []).forEach((school: { id: string; name: string }) => {
+          nameToIdMap.set(school.name, school.id);
+        });
+        schoolNameToIdMapRef.current = nameToIdMap;
+      }
+    } catch (error) {
+      logger.error('Failed to fetch filter options', error);
+    } finally {
+      setIsFilterOptionsLoaded(true);
+      setIsFilterLoading(false);
+      isFilterOptionsLoadingRef.current = false;
+    }
+  }, [api, isFilterOptionsLoaded]);
+
+  useEffect(() => {
+    if (filters.school.length > 0) {
+      void loadFilterOptions();
+    }
+  }, [filters.school.length, loadFilterOptions]);
+
+  const handleOpenFilters = React.useCallback(() => {
+    setIsFilterOpen(true);
+    setTempFilters(filters);
+    void loadFilterOptions();
+  }, [filters, loadFilterOptions]);
 
   useEffect(() => {
     if (!isSchoolFilterReady) return;
@@ -399,6 +419,7 @@ export function useRequestListPage() {
     filters,
     handleCancelFilters,
     handleDeleteFilter,
+    handleOpenFilters,
     handleRowClick,
     handleSort,
     handleTabChange,

--- a/src/ops-console/pages/useSchoolListPage.ts
+++ b/src/ops-console/pages/useSchoolListPage.ts
@@ -219,7 +219,8 @@ export function useSchoolListPage() {
     setPage(1);
   }, [searchTerm]);
 
-  const loadFilterOptions = useCallback(async () => {
+  const handleOpenFilters = useCallback(async () => {
+    setIsFilterOpen(true);
     if (hasLoadedFilterOptionsRef.current) return;
 
     setIsFilterLoading(true);
@@ -235,11 +236,6 @@ export function useSchoolListPage() {
       setIsFilterLoading(false);
     }
   }, [api]);
-
-  const handleOpenFilters = useCallback(() => {
-    setIsFilterOpen(true);
-    void loadFilterOptions();
-  }, [loadFilterOptions]);
 
   const handleSort = (colKey: string) => {
     const column = columns.find((col) => String(col.key) === colKey);

--- a/src/ops-console/pages/useSchoolListPage.ts
+++ b/src/ops-console/pages/useSchoolListPage.ts
@@ -93,6 +93,7 @@ export function useSchoolListPage() {
     useState<HTMLElement | null>(null);
   const actionsButtonCloseShineTimeoutRef = useRef<number | null>(null);
   const actionsButtonCloseShineRafRef = useRef<number | null>(null);
+  const hasLoadedFilterOptionsRef = useRef(false);
   const isFirstSearchRenderRef = useRef(true);
   const { roles } = useAppSelector(
     (state: RootState) => state.auth as AuthState,
@@ -218,22 +219,27 @@ export function useSchoolListPage() {
     setPage(1);
   }, [searchTerm]);
 
-  useEffect(() => {
-    const fetchFilterOptions = async () => {
-      setIsFilterLoading(true);
-      try {
-        const data = await api.getSchoolFilterOptionsForSchoolListing();
-        if (data) {
-          setFilterOptions(mapSchoolListFilterOptions(data));
-        }
-      } catch (error) {
-        logger.error('Failed to fetch filter options', error);
-      } finally {
-        setIsFilterLoading(false);
+  const loadFilterOptions = useCallback(async () => {
+    if (hasLoadedFilterOptionsRef.current) return;
+
+    setIsFilterLoading(true);
+    try {
+      const data = await api.getSchoolFilterOptionsForSchoolListing();
+      if (data) {
+        setFilterOptions(mapSchoolListFilterOptions(data));
+        hasLoadedFilterOptionsRef.current = true;
       }
-    };
-    fetchFilterOptions();
+    } catch (error) {
+      logger.error('Failed to fetch filter options', error);
+    } finally {
+      setIsFilterLoading(false);
+    }
   }, [api]);
+
+  const handleOpenFilters = useCallback(() => {
+    setIsFilterOpen(true);
+    void loadFilterOptions();
+  }, [loadFilterOptions]);
 
   const handleSort = (colKey: string) => {
     const column = columns.find((col) => String(col.key) === colKey);
@@ -357,6 +363,7 @@ export function useSchoolListPage() {
     handleExportSchools,
     handleOpenActionsMenu,
     handleOpenAddSchoolPage,
+    handleOpenFilters,
     handleOpenMigratePage,
     handleOpenPercentageFilter,
     handleOpenSchoolPerformanceFilter,

--- a/src/services/api/apihandler/ApiHandler.fieldActivities.ts
+++ b/src/services/api/apihandler/ApiHandler.fieldActivities.ts
@@ -9,6 +9,10 @@ import {
   UserSchoolClassResult,
 } from '../../../ops-console/pages/NewUserPageOps';
 import { FCSchoolStats } from '../../../ops-console/pages/SchoolDetailsPage';
+import type {
+  TeacherAssignmentCountMap,
+  TeacherAssignmentCountPair,
+} from '../serviceapi/ServiceApi.fieldActivities';
 
 export class ApiHandlerFieldActivities extends ApiHandlerOpsUsers {
   async getActiveStudentsCountByClass(classId: string): Promise<string> {
@@ -116,11 +120,10 @@ export class ApiHandlerFieldActivities extends ApiHandlerOpsUsers {
     return this.s.getActivitiesFilterOptions();
   }
 
-  async getRecentAssignmentCountByTeacher(
-    teacherId: string,
-    classId: string,
-  ): Promise<number | null> {
-    return await this.s.getRecentAssignmentCountByTeacher(teacherId, classId);
+  async getRecentAssignmentCountsByTeachers(
+    pairs: TeacherAssignmentCountPair[],
+  ): Promise<TeacherAssignmentCountMap> {
+    return await this.s.getRecentAssignmentCountsByTeachers(pairs);
   }
 
   async createNoteForSchool(params: {

--- a/src/services/api/serviceapi/ServiceApi.fieldActivities.ts
+++ b/src/services/api/serviceapi/ServiceApi.fieldActivities.ts
@@ -14,6 +14,13 @@ import type {
   ActivitiesFilterOptions,
 } from './ServiceApi.types';
 
+export type TeacherAssignmentCountPair = {
+  teacherId: string;
+  classId: string;
+};
+
+export type TeacherAssignmentCountMap = Record<string, number | null>;
+
 export interface ServiceApiFieldActivities {
   getActiveStudentsCountByClass(classId: string): Promise<string>;
 
@@ -85,10 +92,9 @@ export interface ServiceApiFieldActivities {
 
   getActivitiesFilterOptions(): Promise<ActivitiesFilterOptions | null>;
 
-  getRecentAssignmentCountByTeacher(
-    teacherId: string,
-    classId: string,
-  ): Promise<number | null>;
+  getRecentAssignmentCountsByTeachers(
+    pairs: TeacherAssignmentCountPair[],
+  ): Promise<TeacherAssignmentCountMap>;
 
   createNoteForSchool(params: {
     schoolId: string;

--- a/src/services/api/sqlite/SqliteApi.program.fieldCoordinator.ts
+++ b/src/services/api/sqlite/SqliteApi.program.fieldCoordinator.ts
@@ -6,6 +6,10 @@ import {
 import logger from '../../../utility/logger';
 import { SqliteApiProgramClassManagement } from './SqliteApi.program.classManagement';
 import { FCSchoolStats } from '../../../ops-console/pages/SchoolDetailsPage';
+import type {
+  TeacherAssignmentCountMap,
+  TeacherAssignmentCountPair,
+} from '../serviceapi/ServiceApi.fieldActivities';
 
 export class SqliteApiProgramFieldCoordinator extends SqliteApiProgramClassManagement {
   [key: string]: any;
@@ -85,17 +89,13 @@ export class SqliteApiProgramFieldCoordinator extends SqliteApiProgramClassManag
     return this._serverApi.getNotesBySchoolId(schoolId, limit, offset, sortBy);
   }
 
-  async getRecentAssignmentCountByTeacher(
-    teacherId: string,
-    classId: string,
-  ): Promise<number | null> {
+  async getRecentAssignmentCountsByTeachers(
+    pairs: TeacherAssignmentCountPair[],
+  ): Promise<TeacherAssignmentCountMap> {
     logger.warn(
-      'getRecentAssignmentCountByTeacher is not supported in SQLite mode',
+      'getRecentAssignmentCountsByTeachers is not supported in SQLite mode',
     );
-    return this._serverApi.getRecentAssignmentCountByTeacher(
-      teacherId,
-      classId,
-    );
+    return this._serverApi.getRecentAssignmentCountsByTeachers(pairs);
   }
 
   public async getSchoolStatsForSchool(

--- a/src/services/api/supabase/SupabaseApi.program.fieldCoordinator.ts
+++ b/src/services/api/supabase/SupabaseApi.program.fieldCoordinator.ts
@@ -2,6 +2,10 @@ import { EnumType, TABLES, TableTypes } from '../../../common/constants';
 import logger from '../../../utility/logger';
 import { ServiceConfig } from '../../ServiceConfig';
 import { SupabaseApiProgramClassManagement } from './SupabaseApi.program.classManagement';
+import type {
+  TeacherAssignmentCountMap,
+  TeacherAssignmentCountPair,
+} from '../serviceapi/ServiceApi.fieldActivities';
 
 export interface SupabaseApiProgramFieldCoordinator {
   [key: string]: any;
@@ -184,32 +188,73 @@ export class SupabaseApiProgramFieldCoordinator extends SupabaseApiProgramClassM
     }
   }
 
-  async getRecentAssignmentCountByTeacher(
-    teacherId: string,
-    classId: string,
-  ): Promise<number | null> {
-    if (!this.supabase) return null;
+  async getRecentAssignmentCountsByTeachers(
+    pairs: TeacherAssignmentCountPair[],
+  ): Promise<TeacherAssignmentCountMap> {
+    const normalizedPairs = Array.from(
+      new Map(
+        pairs
+          .map((pair) => ({
+            teacherId: String(pair.teacherId ?? '').trim(),
+            classId: String(pair.classId ?? '').trim(),
+          }))
+          .filter((pair) => pair.teacherId && pair.classId)
+          .map((pair) => [`${pair.teacherId}:${pair.classId}`, pair]),
+      ).values(),
+    );
+    const counts: TeacherAssignmentCountMap = {};
+    normalizedPairs.forEach((pair) => {
+      counts[`${pair.teacherId}:${pair.classId}`] = 0;
+    });
 
+    if (!this.supabase || normalizedPairs.length === 0) return counts;
+
+    const teacherIds = Array.from(
+      new Set(normalizedPairs.map((pair) => pair.teacherId)),
+    );
+    const classIds = Array.from(
+      new Set(normalizedPairs.map((pair) => pair.classId)),
+    );
+    const requestedPairKeys = new Set(Object.keys(counts));
+    const batchIdsByPair = new Map<string, Set<string | null>>();
     const SEVEN_DAYS_AGO = new Date(
       Date.now() - 7 * 24 * 60 * 60 * 1000,
     ).toISOString();
 
     const { data, error } = await this.supabase
       .from(TABLES.Assignment)
-      .select('batch_id')
-      .eq('created_by', teacherId)
-      .eq('class_id', classId)
+      .select('created_by, class_id, batch_id')
+      .in('created_by', teacherIds)
+      .in('class_id', classIds)
       .eq('is_deleted', false)
       .gte('created_at', SEVEN_DAYS_AGO);
 
     if (error) {
-      logger.error('Error fetching assignments:', error);
-      return null;
+      logger.error('Error fetching assignment counts:', error);
+      return Object.fromEntries(
+        normalizedPairs.map((pair) => [
+          `${pair.teacherId}:${pair.classId}`,
+          null,
+        ]),
+      );
     }
 
-    if (!data || data.length === 0) return 0;
+    (data ?? []).forEach((row) => {
+      const teacherId = String(row.created_by ?? '').trim();
+      const classId = String(row.class_id ?? '').trim();
+      const pairKey = `${teacherId}:${classId}`;
+      if (!requestedPairKeys.has(pairKey)) return;
+      if (!batchIdsByPair.has(pairKey)) {
+        batchIdsByPair.set(pairKey, new Set());
+      }
+      batchIdsByPair.get(pairKey)?.add(row.batch_id ?? null);
+    });
 
-    return new Set(data.map((row) => row.batch_id)).size;
+    batchIdsByPair.forEach((batchIds, pairKey) => {
+      counts[pairKey] = batchIds.size;
+    });
+
+    return counts;
   }
 
   async createNoteForSchool(params: {

--- a/src/services/api/supabase/SupabaseApi.program.requests.ts
+++ b/src/services/api/supabase/SupabaseApi.program.requests.ts
@@ -1,3 +1,4 @@
+import { Constants } from '../../database';
 import { EnumType, TABLES } from '../../../common/constants';
 import logger from '../../../utility/logger';
 import { SupabaseApiProgramActivityStats } from './SupabaseApi.program.activityStats';
@@ -66,45 +67,34 @@ export class SupabaseApiProgramRequests extends SupabaseApiProgramActivityStats 
     try {
       if (!this.supabase) return null;
 
-      const [requestTypeResponse, schoolResponse] = await Promise.all([
-        this.supabase
-          .from(TABLES.OpsRequests)
-          .select('request_type')
-          .eq('is_deleted', false),
+      const requestTypes = [...Constants.public.Enums.ops_request_type];
 
-        this.supabase
-          .from(TABLES.OpsRequests)
-          .select('school_id, school:school(id, name)')
-          .eq('is_deleted', false)
-          .not('school_id', 'is', null),
-      ]);
-
-      if (requestTypeResponse.error) {
-        logger.error(
-          'Failed to fetch request types:',
-          requestTypeResponse.error.message,
-        );
-        throw requestTypeResponse.error;
-      }
+      const schoolResponse = await this.supabase
+        .from(TABLES.School)
+        .select(
+          `
+          id,
+          name,
+          ops_requests!inner()
+        `,
+        )
+        .eq('is_deleted', false)
+        .eq('ops_requests.is_deleted', false)
+        .not('ops_requests.school_id', 'is', null)
+        .order('name', { ascending: true });
 
       if (schoolResponse.error) {
         logger.error('Failed to fetch schools:', schoolResponse.error.message);
         throw schoolResponse.error;
       }
-      // 1. Get unique request types
-      const allRequestTypes = (requestTypeResponse.data || []).map(
-        (item) => item.request_type,
-      );
-      const uniqueRequestTypes = [...new Set(allRequestTypes)];
 
-      // 2. Get unique schools with id and name
       const schoolMap = new Map<string, { id: string; name: string }>();
 
       ((schoolResponse.data as any[]) || []).forEach((item) => {
-        if (item.school && item.school.id && item.school.name) {
-          schoolMap.set(item.school.id, {
-            id: item.school.id,
-            name: item.school.name,
+        if (item?.id && item?.name) {
+          schoolMap.set(item.id, {
+            id: item.id,
+            name: item.name,
           });
         }
       });
@@ -112,7 +102,7 @@ export class SupabaseApiProgramRequests extends SupabaseApiProgramActivityStats 
       const uniqueSchools = Array.from(schoolMap.values());
 
       return {
-        requestType: uniqueRequestTypes,
+        requestType: requestTypes,
         school: uniqueSchools,
       };
     } catch (error) {


### PR DESCRIPTION
- Refactor data loading throughout the app to defer initialization until needed, reducing initial load time and unnecessary API calls. 
- Specific improvements: 

    (1) SchoolDetailsPage now loads class/student/teacher data only when respective tabs are accessed; 
    (2) Filter options across pages (SchoolList, RequestList, ProgramPage) are fetched only when filter panel is opened; 
    (3) Campaign communication data is loaded only at step 3 or later; 
    (4) Teacher assignment performance queries consolidated from individual calls to single batch query using new getRecentAssignmentCountsByTeachers API; 
    (5) Campaign setup assignment options load only when on correct step; (6) Added deduplication and caching mechanisms to prevent duplicate API requests. 

- Caches loaded tabs via refs to ensure data is fetched only once per page session.