### PR TITLE
fix: improve campaign rewards mobile layout and labels

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -500,6 +500,7 @@
   "Device is online.": "Device is online.",
   "Devices": "Devices",
   "Difficult": "Difficult",
+  "Digital Reward": "Digital Reward",
   "Digital Rewards": "Digital Rewards",
   "Digital Skills": "Digital Skills",
   "Discovering the joy of learning with": "Discovering the joy of learning with",

--- a/src/ops-console/components/campaignsOverview/CampaignRewardsSummaryCards.tsx
+++ b/src/ops-console/components/campaignsOverview/CampaignRewardsSummaryCards.tsx
@@ -62,9 +62,9 @@ const CampaignRewardsSummaryCards: React.FC<
             <Typography
               sx={{
                 color: '#121619',
-                fontSize: 28,
+                fontSize: { xs: 22, sm: 28 },
                 fontWeight: 700,
-                lineHeight: '30px',
+                lineHeight: { xs: '26px', sm: '30px' },
               }}
             >
               {card.count}
@@ -73,9 +73,9 @@ const CampaignRewardsSummaryCards: React.FC<
               <Typography
                 sx={{
                   color: '#1A71F6',
-                  fontSize: 22,
+                  fontSize: { xs: 22, sm: 28 },
                   fontWeight: 700,
-                  lineHeight: '26px',
+                  lineHeight: { xs: '26px', sm: '30px' },
                 }}
               >
                 {card.percent}%

--- a/src/ops-console/components/campaignsOverview/CampaignRewardsTable.tsx
+++ b/src/ops-console/components/campaignsOverview/CampaignRewardsTable.tsx
@@ -39,7 +39,13 @@ const renderFilterSelect = (
   const selectValues = values.includes(value) ? values : [value, ...values];
 
   return (
-    <FormControl size="small" sx={{ minWidth: 150 }}>
+    <FormControl
+      size="small"
+      sx={{
+        flex: { xs: '1 1 0', sm: '0 0 auto' },
+        minWidth: { xs: 0, sm: 150 },
+      }}
+    >
       <Select
         value={value}
         onChange={(event) => onChange(String(event.target.value))}
@@ -47,7 +53,7 @@ const renderFilterSelect = (
         sx={{
           borderRadius: '999px',
           background: '#fff',
-          fontSize: 13,
+          fontSize: { xs: 11, sm: 13 },
           '& .MuiOutlinedInput-notchedOutline': { borderColor: '#E0E4E8' },
         }}
       >
@@ -102,7 +108,12 @@ export const CampaignRewardsReportHeader: React.FC<
         )
       </Typography>
     </Box>
-    <Box display="flex" gap={1.25} flexWrap="wrap">
+    <Box
+      display="flex"
+      gap={{ xs: 0.75, sm: 1.25 }}
+      flexWrap="nowrap"
+      sx={{ width: { xs: '100%', sm: 'auto' } }}
+    >
       {renderFilterSelect(schoolFilter, schoolOptions, onSchoolFilterChange)}
       {renderFilterSelect(classFilter, classOptions, onClassFilterChange)}
       <Button
@@ -113,8 +124,15 @@ export const CampaignRewardsReportHeader: React.FC<
           borderRadius: '999px',
           border: '1px solid #E0E4E8',
           color: '#1A71F6',
-          px: 2,
+          flex: { xs: '0 0 auto', sm: '0 0 auto' },
+          fontSize: { xs: 11, sm: 13 },
+          minWidth: { xs: 74, sm: 96 },
+          px: { xs: 1, sm: 2 },
           textTransform: 'none',
+          whiteSpace: 'nowrap',
+          '& .MuiButton-startIcon': {
+            mr: { xs: 0.25, sm: 1 },
+          },
         }}
       >
         {isExporting ? t('Exporting...') : t('Export')}
@@ -183,12 +201,14 @@ const CampaignRewardsTable: React.FC<CampaignRewardsTableProps> = ({
       component="article"
       sx={{
         '.data-tablebody-container': {
-          height: { xs: 420, md: 520 },
-          maxHeight: { xs: 420, md: 520 },
+          height: 'auto',
+          maxHeight: 'none',
           marginBottom: 0,
-          overflow: 'auto',
+          overflowX: 'auto',
+          overflowY: 'visible',
+          overscrollBehavior: 'auto',
           WebkitOverflowScrolling: 'touch',
-          touchAction: 'pan-x pan-y',
+          touchAction: 'pan-x',
         },
         '.MuiTableCell-stickyHeader, .data-tablebody-head-cell': {
           overflow: 'visible',

--- a/src/ops-console/components/campaignsOverview/CampaignSchoolPerformanceReport.css
+++ b/src/ops-console/components/campaignsOverview/CampaignSchoolPerformanceReport.css
@@ -78,17 +78,19 @@
 }
 
 .campaign-school-performance-report__table {
-  height: 520px;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: visible;
 }
 
 .campaign-school-performance-report__table .data-tablebody-container {
   -webkit-overflow-scrolling: touch;
-  height: 100%;
+  height: auto;
   margin-bottom: 0;
-  max-height: 100%;
-  overflow: auto;
-  touch-action: pan-x pan-y;
+  max-height: none;
+  overscroll-behavior: auto;
+  overflow-x: auto;
+  overflow-y: visible;
+  touch-action: pan-x;
 }
 
 .campaign-school-performance-report__table .MuiTableCell-stickyHeader,
@@ -235,7 +237,7 @@
   }
 
   .campaign-school-performance-report__table {
-    height: 420px;
+    height: auto;
   }
 
   .campaign-school-performance-report__date {

--- a/src/ops-console/components/campaignsOverview/CampaignsOverviewLogic.test.ts
+++ b/src/ops-console/components/campaignsOverview/CampaignsOverviewLogic.test.ts
@@ -356,15 +356,15 @@ describe('CampaignRewardsReport helpers', () => {
     ).toBeNull();
   });
 
-  it('should default reward labels to physical unless the payload is digital', () => {
+  it('should label reward columns by physical or digital reward type', () => {
     expect(getCampaignRewardTypeLabel(rewards)).toBe('Physical Reward');
     expect(
       getCampaignRewardTypeLabel({
         type: 'digital_rewards',
         rules: [{ rank: 1, min: 90, reward: 'Badge' }],
       }),
-    ).toBe('Reward');
-    expect(getCampaignRewardTypeLabel(null)).toBe('Physical Reward');
+    ).toBe('Digital Reward');
+    expect(getCampaignRewardTypeLabel(null)).toBe('Digital Reward');
   });
 
   it('should map student performance rows into display rows with reward labels', () => {

--- a/src/ops-console/components/campaignsOverview/campaignRewardsReport/campaignRewardRows.ts
+++ b/src/ops-console/components/campaignsOverview/campaignRewardsReport/campaignRewardRows.ts
@@ -27,7 +27,10 @@ export const parseCampaignRewards = (
 
 export const getCampaignRewardTypeLabel = (
   rewards?: CampaignRewardsPayload | null,
-) => (rewards?.type === 'digital_rewards' ? t('Reward') : t('Physical Reward'));
+) =>
+  rewards?.type === 'physical_rewards'
+    ? t('Physical Reward')
+    : t('Digital Reward');
 
 const getRewardLabelForRank = (
   rewards: CampaignRewardsPayload | null,
@@ -96,14 +99,14 @@ export const buildCampaignRewardColumns = (
   {
     key: 'completionPercent',
     label: t('COMPLETION %'),
-    width: 140,
+    width: 170,
     sortable: true,
     align: 'center',
   },
   {
     key: 'rewardRank',
     label: t('REWARD RANK'),
-    width: 120,
+    width: 160,
     sortable: true,
     align: 'center',
   },


### PR DESCRIPTION
- Increase Completion % and Reward Rank column widths in campaign rewards report.
- Show reward type as Physical Reward for physical rewards, otherwise Digital Reward.
- Add missing Digital Reward translation.
- Keep mobile reward filters and export button in one row.
- Prevent rewards and school performance tables from trapping vertical page scroll.
- Match rewards widget value and percentage font sizes responsively.
<img width="1365" height="599" alt="image" src="https://github.com/user-attachments/assets/66039d4e-d95c-4745-b074-fddf78b352e2" />
<img width="235" height="512" alt="image" src="https://github.com/user-attachments/assets/ae38ccdd-7d37-4d34-a664-95b4f2709c2e" />
