### PR TITLE
Add fieldCoordinators export column

### DIFF
--- a/src/ops-console/pages/SchoolList.columns.tsx
+++ b/src/ops-console/pages/SchoolList.columns.tsx
@@ -163,6 +163,11 @@ export const getSchoolListColumns = (): Column<SchoolListRow>[] => [
 export const getSchoolListExportColumns = (): SchoolListExportColumn[] => [
   { key: 'name', label: t('School Name'), part: 'value' },
   { key: 'udise', label: t('UDISE'), part: 'value' },
+  {
+    key: 'fieldCoordinators',
+    label: t('Field Coordinator'),
+    part: 'value',
+  },
   { key: 'block', label: t('Block'), part: 'value' },
   {
     key: 'schoolPerformance',

--- a/src/ops-console/pages/SchoolList.export.test.ts
+++ b/src/ops-console/pages/SchoolList.export.test.ts
@@ -13,6 +13,7 @@ describe('buildSchoolListExportSheetRows', () => {
         school_performance: 'green',
         district: 'Pune',
         udise: '1234567890',
+        field_coordinators: ['Field Coordinator 1'],
         onboarded_students: 100,
         activated_students: 80,
         active_students: 60,
@@ -37,6 +38,7 @@ describe('buildSchoolListExportSheetRows', () => {
       [
         'School Name',
         'UDISE',
+        'Field Coordinator',
         'Block',
         'School Performance',
         'Onboarded Students',
@@ -62,6 +64,7 @@ describe('buildSchoolListExportSheetRows', () => {
       [
         'Alpha School',
         '1234567890',
+        'Field Coordinator 1',
         '--',
         'High Performing',
         '100',
@@ -118,6 +121,7 @@ describe('buildSchoolListExportSheetRows', () => {
     expect(exportRows[1]).toHaveLength(exportRows[0].length);
     expect(exportRows[1]).toEqual([
       'Beta School',
+      '--',
       '--',
       '--',
       '--',

--- a/src/ops-console/pages/SchoolList.export.ts
+++ b/src/ops-console/pages/SchoolList.export.ts
@@ -3,6 +3,7 @@ import {
   formatCompactNumber,
   formatPercent,
   getSchoolListExportColumns,
+  getSchoolCoordinatorList,
   pickFirstNumber,
   resolvePerformanceStatus,
 } from './SchoolList.helpers';
@@ -61,6 +62,10 @@ const buildExportCellTextMap = (school: SchoolListSourceRow) => {
     },
     udise: {
       valueText: school.udise ? String(school.udise).trim() : '--',
+      percentText: '--',
+    },
+    fieldCoordinators: {
+      valueText: getSchoolCoordinatorList(school).join(', ') || '--',
       percentText: '--',
     },
     block: {

--- a/src/ops-console/pages/SchoolList.test.tsx
+++ b/src/ops-console/pages/SchoolList.test.tsx
@@ -462,6 +462,7 @@ describe('SchoolList export', () => {
             [
               'School Name',
               'UDISE',
+              'Field Coordinator',
               'Block',
               'School Performance',
               'Onboarded Students',
@@ -487,6 +488,7 @@ describe('SchoolList export', () => {
             [
               'Alpha School',
               '1234567890',
+              'Field Coordinator 1',
               '--',
               'High Performing',
               '100',
@@ -528,16 +530,16 @@ describe('SchoolList export', () => {
         sheetMerges: {
           Schools: [
             {
-              s: { r: 0, c: 5 },
-              e: { r: 0, c: 6 },
+              s: { r: 0, c: 6 },
+              e: { r: 0, c: 7 },
             },
             {
-              s: { r: 0, c: 7 },
-              e: { r: 0, c: 8 },
+              s: { r: 0, c: 8 },
+              e: { r: 0, c: 9 },
             },
             {
-              s: { r: 0, c: 10 },
-              e: { r: 0, c: 11 },
+              s: { r: 0, c: 11 },
+              e: { r: 0, c: 12 },
             },
           ],
         },


### PR DESCRIPTION
- Include Field Coordinator in school export: add a fieldCoordinators column to getSchoolListExportColumns and populate its export cell in buildExportCellTextMap by importing and using getSchoolCoordinatorList(school).join(', ') with a '--' fallback. 
- Changes made in SchoolList.columns.tsx and SchoolList.export.ts to expose coordinators in exported data.