### PR TITLE
Reorder SchoolCheckInMap and remove top margin

### DIFF
--- a/src/ops-console/components/SchoolDetailsComponents/SchoolCheckInModal.css
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolCheckInModal.css
@@ -313,7 +313,6 @@
 
 /* Confirmation Section explicit styling */
 .schoolcheckinmodal .check-in-confirmation-section {
-  margin-top: 16px;
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/src/ops-console/components/SchoolDetailsComponents/SchoolCheckInModal.tsx
+++ b/src/ops-console/components/SchoolDetailsComponents/SchoolCheckInModal.tsx
@@ -90,18 +90,18 @@ const SchoolCheckInModal: React.FC<SchoolCheckInModalProps> = ({
             userLocation={state.userLocation}
           />
 
-          <SchoolCheckInMap
-            isSchoolLocationMissing={state.isSchoolLocationMissing}
-            targetLocation={state.targetLocation}
-            userLocation={state.userLocation}
-          />
-
           {state.isSchoolLocationMissing && state.isCheckIn && (
             <SchoolCheckInConfirmation
               isConfirmedInSchool={state.isConfirmedInSchool}
               setIsConfirmedInSchool={state.setIsConfirmedInSchool}
             />
           )}
+
+          <SchoolCheckInMap
+            isSchoolLocationMissing={state.isSchoolLocationMissing}
+            targetLocation={state.targetLocation}
+            userLocation={state.userLocation}
+          />
         </div>
 
         <SchoolCheckInActions


### PR DESCRIPTION
- Move SchoolCheckInMap below the check-in confirmation so the confirmation UI appears above the map when the school location is missing. 
- Remove margin-top:16px from .check-in-confirmation-section to tighten spacing. 
- Changes touch SchoolCheckInModal.tsx and SchoolCheckInModal.css and only affect layout/spacing (no functional logic changes).