### PR TITLE
fix: show earliest reward report update date

### DIFF
--- a/src/ops-console/components/campaignsOverview/CampaignsOverviewLogic.test.ts
+++ b/src/ops-console/components/campaignsOverview/CampaignsOverviewLogic.test.ts
@@ -18,7 +18,7 @@ import {
   getNextClassFilter,
   getNextSchoolAndClassFilters,
   getCampaignRewardTypeLabel,
-  getLatestCalculatedAt,
+  getEarliestCalculatedAt,
   mapCampaignPerformanceRowsToRewardRows,
   paginateCampaignRewardRows,
   parseCampaignRewards,
@@ -572,8 +572,10 @@ describe('CampaignRewardsReport helpers', () => {
     ]);
   });
 
-  it('should find and format the latest calculated timestamp', () => {
-    expect(getLatestCalculatedAt(mappedRows)).toBe('2026-07-11T10:00:00.000Z');
+  it('should find and format the earliest calculated timestamp', () => {
+    expect(getEarliestCalculatedAt(mappedRows)).toBe(
+      '2026-07-10T10:00:00.000Z',
+    );
     expect(formatCampaignRewardLastUpdated('2026-07-10T10:00:00.000Z')).toBe(
       '10 July 2026',
     );

--- a/src/ops-console/components/campaignsOverview/campaignRewardsReport/campaignRewardRows.ts
+++ b/src/ops-console/components/campaignsOverview/campaignRewardsReport/campaignRewardRows.ts
@@ -301,13 +301,13 @@ export const buildCampaignRewardSummaryCards = (
   ];
 };
 
-export const getLatestCalculatedAt = (rows: CampaignRewardRow[]) =>
-  rows.reduce<string | null>((latest, row) => {
-    if (!row.calculatedAt) return latest;
-    if (!latest) return row.calculatedAt;
-    return new Date(row.calculatedAt).getTime() > new Date(latest).getTime()
+export const getEarliestCalculatedAt = (rows: CampaignRewardRow[]) =>
+  rows.reduce<string | null>((earliest, row) => {
+    if (!row.calculatedAt) return earliest;
+    if (!earliest) return row.calculatedAt;
+    return new Date(row.calculatedAt).getTime() < new Date(earliest).getTime()
       ? row.calculatedAt
-      : latest;
+      : earliest;
   }, null);
 
 export const formatCampaignRewardLastUpdated = (value: string | null) => {

--- a/src/ops-console/components/campaignsOverview/campaignRewardsReport/useCampaignRewardsReportState.ts
+++ b/src/ops-console/components/campaignsOverview/campaignRewardsReport/useCampaignRewardsReportState.ts
@@ -16,7 +16,7 @@ import {
   getCampaignRewardClassOptions,
   getCampaignRewardFilterOptions,
   getCampaignRewardTypeLabel,
-  getLatestCalculatedAt,
+  getEarliestCalculatedAt,
   getNextClassFilter,
   getNextSchoolAndClassFilters,
   getSafeCampaignRewardPage,
@@ -67,7 +67,7 @@ export const useCampaignRewardsReportState = (
   );
   const lastUpdated = useMemo(
     () =>
-      formatCampaignRewardLastUpdated(getLatestCalculatedAt(performanceRows)),
+      formatCampaignRewardLastUpdated(getEarliestCalculatedAt(performanceRows)),
     [performanceRows],
   );
   const sortedRows = useMemo(


### PR DESCRIPTION
- Update reward report Last Updated logic to use the earliest calculatedAt date from report rows.
- Rename the date helper from latest-date behavior to earliest-date behavior for clarity.
- Update campaign rewards logic test to verify the earliest calculated timestamp is selected.