### PR TITLE
fix: scope campaign school performance windows

### DIFF
--- a/src/ops-console/components/campaignsOverview/CampaignSchoolPerformanceReport.helpers.ts
+++ b/src/ops-console/components/campaignsOverview/CampaignSchoolPerformanceReport.helpers.ts
@@ -174,7 +174,7 @@ const formatInteger = (value: number) => value.toLocaleString('en-IN');
 
 const formatDurationMinutes = (value: number) =>
   `${Number(value || 0).toLocaleString('en-IN', {
-    maximumFractionDigits: 2,
+    maximumFractionDigits: 0,
   })}m`;
 
 const matchesLevel = (percent: number, level: ActiveStudentsLevel | null) => {
@@ -242,7 +242,7 @@ export const mapCampaignSchoolPerformanceRows = (
   (response?.rows ?? []).map((row) => {
     const activeStudents = row.activeStudents ?? 0;
     const activatedStudents = row.activatedStudents ?? 0;
-    const avgTimeSpentMinutes = row.avgTimeSpent ?? 0;
+    const avgTimeSpentMinutes = Math.round(row.avgTimeSpent ?? 0);
 
     return {
       id: row.schoolId,

--- a/src/services/api/supabase/SupabaseApi.campaign.reports.ts
+++ b/src/services/api/supabase/SupabaseApi.campaign.reports.ts
@@ -33,13 +33,13 @@ import { SupabaseApiCampaignMessaging } from './SupabaseApi.campaign.messaging';
 export interface SupabaseApiCampaignReports {}
 
 /**
- * Campaign school metrics are persisted with the campaign id in metric_window
- * so both 7-day and campaign-day views can resolve from the same row set later.
+ * Campaign-day metrics are persisted with the campaign id in metric_window,
+ * while 7-day metrics use the shared school-level 7d window.
  */
 const buildCampaignSchoolMetricWindow = (
   campaignId: string,
-  _metricWindow: '7d' | 'campaign_days',
-) => campaignId;
+  metricWindow: '7d' | 'campaign_days',
+) => (metricWindow === '7d' ? metricWindow : campaignId);
 
 export class SupabaseApiCampaignReports extends SupabaseApiCampaignMessaging {
   async getCampaignListingMetrics(
@@ -416,15 +416,32 @@ export class SupabaseApiCampaignReports extends SupabaseApiCampaignMessaging {
     const metricWindow = params.metricWindow ?? '7d';
 
     try {
-      const { data, error } = await this.supabase
+      const campaignSchoolIds =
+        metricWindow === '7d'
+          ? (await this.getCampaignWhatsappReportContext(campaignId.trim()))
+              .schoolIds
+          : [];
+
+      if (metricWindow === '7d' && campaignSchoolIds.length === 0) {
+        return emptyResponse;
+      }
+
+      let query = this.supabase
         .from(TABLES.SchoolMetrics)
         .select('*')
         .eq(
           'metric_window',
           buildCampaignSchoolMetricWindow(campaignId.trim(), metricWindow),
         )
-        .eq('is_deleted', false)
-        .order('school_name', { ascending: true });
+        .eq('is_deleted', false);
+
+      if (metricWindow === '7d') {
+        query = query.is('grade_id', null).in('school_id', campaignSchoolIds);
+      }
+
+      const { data, error } = await query.order('school_name', {
+        ascending: true,
+      });
 
       if (error) {
         logger.error('Error fetching campaign school performance report:', {


### PR DESCRIPTION
- Use 7d school metrics only when grade_id is null.
- Filter 7d school performance rows to campaign target schools.
- Keep campaign-days performance using campaign-specific metric rows.
