### PR TITLE
feat/CHIM-1241: add auto approval date to requests

### DIFF
--- a/src/ops-console/pages/RequestList.columns.ts
+++ b/src/ops-console/pages/RequestList.columns.ts
@@ -27,6 +27,13 @@ const pendingColumns: Column<RequestRow>[] = [
     sortable: true,
     orderBy: 'requested_date',
   },
+  {
+    key: 'auto_approves_on',
+    label: t('Auto approves on'),
+    width: 'fit-content',
+    sortable: true,
+    orderBy: 'auto_approves_on',
+  },
 ];
 
 const approvedColumns: Column<RequestRow>[] = [

--- a/src/ops-console/pages/RequestList.columns.ts
+++ b/src/ops-console/pages/RequestList.columns.ts
@@ -60,12 +60,7 @@ const approvedColumns: Column<RequestRow>[] = [
     sortable: true,
     orderBy: 'approved_date',
   },
-  {
-    key: 'approved_by',
-    label: t('Approved By'),
-    width: '10%',
-    sortable: false,
-  },
+  { key: 'approved_by', label: t('Approved By'), width: '10%', sortable: false },
 ];
 
 const rejectedColumns: Column<RequestRow>[] = [
@@ -92,12 +87,7 @@ const rejectedColumns: Column<RequestRow>[] = [
     sortable: true,
     orderBy: 'rejected_date',
   },
-  {
-    key: 'rejected_by',
-    label: t('Rejected By'),
-    width: '20%',
-    sortable: false,
-  },
+  { key: 'rejected_by', label: t('Rejected By'), width: '20%', sortable: false },
 ];
 
 const flaggedColumns: Column<RequestRow>[] = [

--- a/src/ops-console/pages/RequestList.columns.ts
+++ b/src/ops-console/pages/RequestList.columns.ts
@@ -27,6 +27,13 @@ const pendingColumns: Column<RequestRow>[] = [
     sortable: true,
     orderBy: 'requested_date',
   },
+  {
+    key: 'auto_approves_on',
+    label: t('Auto approves on'),
+    width: 'fit-content',
+    sortable: true,
+    orderBy: 'auto_approves_on',
+  },
 ];
 
 const approvedColumns: Column<RequestRow>[] = [
@@ -53,7 +60,12 @@ const approvedColumns: Column<RequestRow>[] = [
     sortable: true,
     orderBy: 'approved_date',
   },
-  { key: 'approved_by', label: t('Approved By'), width: '10%', sortable: false },
+  {
+    key: 'approved_by',
+    label: t('Approved By'),
+    width: '10%',
+    sortable: false,
+  },
 ];
 
 const rejectedColumns: Column<RequestRow>[] = [
@@ -80,7 +92,12 @@ const rejectedColumns: Column<RequestRow>[] = [
     sortable: true,
     orderBy: 'rejected_date',
   },
-  { key: 'rejected_by', label: t('Rejected By'), width: '20%', sortable: false },
+  {
+    key: 'rejected_by',
+    label: t('Rejected By'),
+    width: '20%',
+    sortable: false,
+  },
 ];
 
 const flaggedColumns: Column<RequestRow>[] = [

--- a/src/ops-console/pages/RequestList.types.ts
+++ b/src/ops-console/pages/RequestList.types.ts
@@ -39,6 +39,7 @@ export type RequestRow = {
   class: string;
   from: string;
   requested_date?: string;
+  auto_approves_on?: string;
   approved_date?: string;
   approved_by?: string;
   rejected_date?: string;

--- a/src/ops-console/pages/useRequestListPage.ts
+++ b/src/ops-console/pages/useRequestListPage.ts
@@ -34,12 +34,25 @@ function parseJSONParam<T>(param: string | null, fallback: T): T {
   }
 }
 
-function formatDateOnly(dateStr?: string) {
+function formatDateOnly(dateStr?: string | null) {
   if (!dateStr) return '-';
   return new Date(dateStr).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
     day: '2-digit',
+  });
+}
+
+function formatAutoApprovesOn(
+  requestType?: string | null,
+  requestEndsAt?: string | null,
+) {
+  if (requestType !== 'student' || !requestEndsAt) return 'NA';
+  return new Date(requestEndsAt).toLocaleDateString('en-IN', {
+    timeZone: 'Asia/Kolkata',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
   });
 }
 
@@ -100,6 +113,10 @@ function mapRequests(
           class: req.classInfo?.name || '-',
           from: req.requestedBy?.name || '-',
           requested_date: requestedDate,
+          auto_approves_on: formatAutoApprovesOn(
+            req.request_type,
+            req.request_ends_at,
+          ),
         };
       });
   }
@@ -269,6 +286,7 @@ export function useRequestListPage() {
           approved_date: 'updated_at',
           rejected_date: 'updated_at',
           requested_date: 'created_at',
+          auto_approves_on: 'request_ends_at',
           flagged_date: 'updated_at',
           school_name: 'school(name)',
         };

--- a/src/ops-console/pages/useRequestListPage.ts
+++ b/src/ops-console/pages/useRequestListPage.ts
@@ -43,6 +43,19 @@ function formatDateOnly(dateStr?: string) {
   });
 }
 
+function formatAutoApprovesOn(
+  requestType?: string | null,
+  requestEndsAt?: string | null,
+) {
+  if (requestType !== 'student' || !requestEndsAt) return 'NA';
+  return new Date(requestEndsAt).toLocaleDateString('en-IN', {
+    timeZone: 'Asia/Kolkata',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
 function mapRequests(
   requestItems: OpsRequestItem[],
   selectedTab: REQUEST_TABS,
@@ -100,6 +113,10 @@ function mapRequests(
           class: req.classInfo?.name || '-',
           from: req.requestedBy?.name || '-',
           requested_date: requestedDate,
+          auto_approves_on: formatAutoApprovesOn(
+            req.request_type,
+            req.request_ends_at,
+          ),
         };
       });
   }
@@ -269,6 +286,7 @@ export function useRequestListPage() {
           approved_date: 'updated_at',
           rejected_date: 'updated_at',
           requested_date: 'created_at',
+          auto_approves_on: 'request_ends_at',
           flagged_date: 'updated_at',
           school_name: 'school(name)',
         };

--- a/src/ops-console/pages/useRequestListPage.ts
+++ b/src/ops-console/pages/useRequestListPage.ts
@@ -34,7 +34,7 @@ function parseJSONParam<T>(param: string | null, fallback: T): T {
   }
 }
 
-function formatDateOnly(dateStr?: string | null) {
+function formatDateOnly(dateStr?: string) {
   if (!dateStr) return '-';
   return new Date(dateStr).toLocaleDateString('en-US', {
     year: 'numeric',


### PR DESCRIPTION
[CHIM-1241](https://chimple.atlassian.net/browse/CHIM-1241)

## Description

Added an **Auto approves on** column to the Pending Requests listing.

## Changes

- Displays the auto-approval date for student requests.
- Displays `NA` for other request types.
- Uses the existing `request_ends_at` value.
- Added sorting support for the new column.
- Preserved existing request listing functionality.

## Result

- For student requests

<img width="1366" height="720" alt="image" src="https://github.com/user-attachments/assets/9d8735cb-b1e6-4153-9743-8e617a350ede" />

- For other requests

<img width="1366" height="720" alt="image" src="https://github.com/user-attachments/assets/b89b3e2f-367d-44f8-bfd1-96ec1ee202cd" />



[CHIM-1241]: https://chimple.atlassian.net/browse/CHIM-1241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ