### PR TITLE
Add work from home visit type support

### DIFF
--- a/src/common/constants/opsCampaigns.ts
+++ b/src/common/constants/opsCampaigns.ts
@@ -96,6 +96,7 @@ export enum SchoolVisitType {
   ParentsTeacherMeeting = 'parents_teacher_meeting',
   TeacherTraining = 'teacher_training_meeting',
   Community = 'community_visit',
+  WorkFromHome = 'work_from_home',
 }
 
 export const SchoolVisitTypeLabels: Record<SchoolVisitType, string> = {
@@ -103,6 +104,7 @@ export const SchoolVisitTypeLabels: Record<SchoolVisitType, string> = {
   [SchoolVisitType.ParentsTeacherMeeting]: 'Parents Teacher Meeting',
   [SchoolVisitType.TeacherTraining]: 'Teacher Training Meeting',
   [SchoolVisitType.Community]: 'Community Visit',
+  [SchoolVisitType.WorkFromHome]: 'Work from Home',
 };
 
 export enum SchoolVisitStatus {

--- a/src/ops-console/hooks/useSchoolActivities.tsx
+++ b/src/ops-console/hooks/useSchoolActivities.tsx
@@ -2,7 +2,12 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Chip } from '@mui/material';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { t } from 'i18next';
-import { PERFORMANCE_UI, PerformanceLevel } from '../../common/constants';
+import {
+  PERFORMANCE_UI,
+  PerformanceLevel,
+  SchoolVisitType,
+  SchoolVisitTypeLabels,
+} from '../../common/constants';
 import { Column } from '../components/DataTableBody';
 import { FcActivity } from '../../interface/modelInterfaces';
 import { ServiceConfig } from '../../services/ServiceConfig';
@@ -10,6 +15,7 @@ import logger from '../../utility/logger';
 import { OpsUtil } from '../OpsUtility/OpsUtil';
 
 const DEFAULT_PAGE_SIZE = 20;
+type VisitDetail = { type?: string | null };
 
 export const useSchoolActivities = (activityData: any) => {
   const api = ServiceConfig.getI().apiHandler;
@@ -63,14 +69,12 @@ export const useSchoolActivities = (activityData: any) => {
               : null,
           })),
         );
-
-        if (searchTerm) {
+        if (searchTerm)
           data = data.filter((item) =>
             (item.user?.name ?? '')
               .toLowerCase()
               .includes(searchTerm.toLowerCase()),
           );
-        }
         Object.entries(filters).forEach(([key, values]) => {
           if (!values.length) return;
           data = data.filter((item) => {
@@ -84,6 +88,25 @@ export const useSchoolActivities = (activityData: any) => {
                   PERFORMANCE_UI[item.raw.support_level as PerformanceLevel]
                     ?.label,
                 );
+              case 'visitType': {
+                const normalizedValues = values.map((value) =>
+                  value.toLowerCase(),
+                );
+                const visitDetails = activityData.visitDetails ?? [];
+                return Array.isArray(visitDetails)
+                  ? visitDetails.some((visit: VisitDetail) => {
+                      const visitType = String(visit?.type || '').toLowerCase();
+                      const visitLabel =
+                        SchoolVisitTypeLabels[
+                          visitType as SchoolVisitType
+                        ]?.toLowerCase() ?? '';
+                      return (
+                        normalizedValues.includes(visitType) ||
+                        normalizedValues.includes(visitLabel)
+                      );
+                    })
+                  : false;
+              }
               default:
                 return true;
             }
@@ -98,7 +121,6 @@ export const useSchoolActivities = (activityData: any) => {
               : right.localeCompare(left);
           });
         }
-
         setTotal(data.length);
         const start = (page - 1) * DEFAULT_PAGE_SIZE;
         setActivities(
@@ -154,7 +176,6 @@ export const useSchoolActivities = (activityData: any) => {
         setLoadingData(false);
       }
     };
-
     fetchActivitiesWithMeta();
   }, [filters, searchTerm, orderBy, orderDir, page, activityData.activities]);
 
@@ -165,6 +186,7 @@ export const useSchoolActivities = (activityData: any) => {
         const res = await api.getActivitiesFilterOptions();
         const performanceValues = res?.performance ?? [];
         const contactTypeValues = res?.contactType ?? [];
+        const visitTypeValues = res?.visitType ?? [];
         setFilterOptions({
           ...(res ?? {}),
           performance: performanceValues.map((value) =>
@@ -177,6 +199,12 @@ export const useSchoolActivities = (activityData: any) => {
               (value ?? '').charAt(0).toUpperCase() +
               (value ?? '').slice(1).toLowerCase(),
           ),
+          visitType: visitTypeValues.map(
+            (value) =>
+              SchoolVisitTypeLabels[(value ?? '') as SchoolVisitType] ??
+              value ??
+              '',
+          ),
         });
       } catch {
         setFilterOptions({});
@@ -184,7 +212,6 @@ export const useSchoolActivities = (activityData: any) => {
         setLoadingFilters(false);
       }
     };
-
     fetchFilterOptions();
   }, [api]);
 
@@ -197,7 +224,6 @@ export const useSchoolActivities = (activityData: any) => {
     { key: 'techIssues', label: t('Tech Issues'), sortable: false },
     { key: 'details', label: t('Details'), sortable: false },
   ];
-
   const filterConfigs = useMemo(
     () =>
       [
@@ -211,10 +237,14 @@ export const useSchoolActivities = (activityData: any) => {
           label: t('Contact Type'),
           placeholder: t('Contact Type'),
         },
+        {
+          key: 'visitType',
+          label: t('Type of Visit'),
+          placeholder: t('Type of Visit'),
+        },
       ].filter((filter) => (filterOptions[filter.key] || []).length > 1),
     [filterOptions],
   );
-
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(event.target.value);
     setPage(1);
@@ -237,7 +267,7 @@ export const useSchoolActivities = (activityData: any) => {
     setPage(1);
   };
   const handleCancelFilters = () => {
-    const reset = { performance: [], contactType: [] };
+    const reset = { performance: [], contactType: [], visitType: [] };
     setFilters(reset);
     setTempFilters(reset);
     setIsFilterOpen(false);
@@ -246,15 +276,14 @@ export const useSchoolActivities = (activityData: any) => {
   const handleSort = (colKey: string) => {
     const sortable = ['name', 'contactType', 'performance', 'class', 'time'];
     if (!sortable.includes(colKey)) return;
-    if (orderBy === colKey) {
+    if (orderBy === colKey)
       setOrderDir((prev) => (prev === 'asc' ? 'desc' : 'asc'));
-    } else {
+    else {
       setOrderBy(colKey);
       setOrderDir('asc');
     }
     setPage(1);
   };
-
   return {
     activities,
     columns,

--- a/src/ops-console/hooks/useSchoolDetailsPage.ts
+++ b/src/ops-console/hooks/useSchoolDetailsPage.ts
@@ -54,6 +54,8 @@ const mapSchoolVisitType = (
       return SchoolVisitType.TeacherTraining;
     case SchoolVisitType.Community:
       return SchoolVisitType.Community;
+    case SchoolVisitType.WorkFromHome:
+      return SchoolVisitType.WorkFromHome;
     default:
       return undefined;
   }

--- a/src/services/api/serviceapi/ServiceApi.types.ts
+++ b/src/services/api/serviceapi/ServiceApi.types.ts
@@ -183,6 +183,7 @@ export type FcUserFormSaveResult = {
 export type ActivitiesFilterOptions = {
   contactType: Array<string | null>;
   performance: Array<string | null>;
+  visitType?: Array<string | null>;
 };
 
 export type CampaignObjective =

--- a/src/services/api/sqlite/SqliteApi.program.fieldCoordinator.ts
+++ b/src/services/api/sqlite/SqliteApi.program.fieldCoordinator.ts
@@ -60,6 +60,7 @@ export class SqliteApiProgramFieldCoordinator extends SqliteApiProgramClassManag
   async getActivitiesFilterOptions(): Promise<{
     contactType: Array<string | null>;
     performance: Array<string | null>;
+    visitType?: Array<string | null>;
   } | null> {
     throw new Error('Method not implemented.');
   }

--- a/src/services/api/supabase/SupabaseApi.program.fieldCoordinator.ts
+++ b/src/services/api/supabase/SupabaseApi.program.fieldCoordinator.ts
@@ -158,14 +158,22 @@ export class SupabaseApiProgramFieldCoordinator extends SupabaseApiProgramClassM
     try {
       if (!this.supabase) return null;
 
-      const { data, error } = await this.supabase
-        .from('fc_user_forms')
-        .select('contact_target, support_level')
-        .eq('is_deleted', false);
+      const [
+        { data: forms, error: formsError },
+        { data: visits, error: visitsError },
+      ] = await Promise.all([
+        this.supabase
+          .from('fc_user_forms')
+          .select('contact_target, support_level')
+          .eq('is_deleted', false),
+        this.supabase
+          .from('fc_school_visit')
+          .select('type')
+          .eq('is_deleted', false),
+      ]);
 
-      if (error) throw error;
-
-      const forms = data || [];
+      if (formsError) throw formsError;
+      if (visitsError) throw visitsError;
 
       const contactTypes = [
         ...new Set(forms.map((f) => f.contact_target).filter(Boolean)),
@@ -173,10 +181,14 @@ export class SupabaseApiProgramFieldCoordinator extends SupabaseApiProgramClassM
       const performance = [
         ...new Set(forms.map((f) => f.support_level).filter(Boolean)),
       ];
+      const visitType = [
+        ...new Set(visits.map((visit) => visit.type).filter(Boolean)),
+      ];
 
       return {
         contactType: contactTypes,
         performance: performance,
+        visitType,
       };
     } catch (error) {
       logger.error('Error in getActivitiesFilterOptions:', error);

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -8162,7 +8162,8 @@ export type Database = {
         | 'teacher_training_meeting'
         | 'parents_teacher_meeting'
         | 'regular_visit'
-        | 'community_visit';
+        | 'community_visit'
+        | 'work_from_home';
       special_roles:
         | 'super_admin'
         | 'operational_director'
@@ -8377,6 +8378,7 @@ export const Constants = {
         'parents_teacher_meeting',
         'regular_visit',
         'community_visit',
+        'work_from_home',
       ],
       special_roles: [
         'super_admin',


### PR DESCRIPTION
Implemented Work from Home support in the Ops Console check-in and Interactions flow.

Changes:
- Added Work from Home as a supported visit type in the check-in flow.
- Updated visit type handling so check-in records are created with Work from Home as the visit type.
- Added Work from Home display support in the Interactions listing Type of Visit column.
- Added Work from Home as an option in the Types of Visit filter.
- Ensured Work from Home records can be filtered and identified separately from school and community visits.
- Kept existing visit types and check-in flows unchanged.

Testing:
- Verified existing lint and formatting checks pass.
- Verified new visit type handling works without impacting existing interaction types.