### PR TITLE
Stabilize Home header and shell after lesson return

### DIFF
--- a/src/components/HomeHeader.tsx
+++ b/src/components/HomeHeader.tsx
@@ -44,15 +44,15 @@ const HomeHeader: React.FC<{
   onHeaderIconClick: Function;
   pendingAssignmentCount: number;
   pendingLiveQuizCount: number;
-  isReturnFromLesson?: boolean;
-  isReturnFromSchoolModeSwitchProfile?: boolean;
+  isReturnFromLidoOrSwitchProfile?: boolean;
+  isReturnFromSwitchProfileReturn?: boolean;
 }> = ({
   currentHeader,
   onHeaderIconClick,
   pendingAssignmentCount,
   pendingLiveQuizCount,
-  isReturnFromLesson,
-  isReturnFromSchoolModeSwitchProfile,
+  isReturnFromLidoOrSwitchProfile,
+  isReturnFromSwitchProfileReturn,
 }) => {
   const { t } = useTranslation();
   const currentStudent = Util.getCurrentStudent();
@@ -158,7 +158,7 @@ const HomeHeader: React.FC<{
     }
   };
   useEffect(() => {
-    if (!isReturnFromLesson && !isReturnFromSchoolModeSwitchProfile) {
+    if (!isReturnFromLidoOrSwitchProfile && !isReturnFromSwitchProfileReturn) {
       init();
     }
     window.addEventListener('JoinClassListner', handleJoinClassListner);
@@ -181,8 +181,8 @@ const HomeHeader: React.FC<{
     };
   }, [
     isHomeHeaderSpecialsEnabled,
-    isReturnFromLesson,
-    isReturnFromSchoolModeSwitchProfile,
+    isReturnFromLidoOrSwitchProfile,
+    isReturnFromSwitchProfileReturn,
   ]);
 
   const handleJoinClassListner = () => {

--- a/src/components/HomeHeader.tsx
+++ b/src/components/HomeHeader.tsx
@@ -22,12 +22,10 @@ import { useHistory } from 'react-router';
 import { schoolUtil } from '../utility/schoolUtil';
 import ProfileMenu from './ProfileMenu/ProfileMenu';
 import logger from '../utility/logger';
-
 // Define the Props for StarsCounter
 interface StarsCounterProps {
   starsCount: number;
 }
-
 // StarsCounter Component
 const StarsCounter: React.FC<StarsCounterProps> = ({ starsCount }) => {
   return (
@@ -41,7 +39,6 @@ const StarsCounter: React.FC<StarsCounterProps> = ({ starsCount }) => {
     </div>
   );
 };
-
 const HomeHeader: React.FC<{
   currentHeader: string;
   onHeaderIconClick: Function;
@@ -57,14 +54,20 @@ const HomeHeader: React.FC<{
 }) => {
   const { t } = useTranslation();
   const currentStudent = Util.getCurrentStudent();
+  const currentMode = localStorage.getItem(CURRENT_MODE);
   const [currentHeaderIconList, setCurrentHeaderIconList] = useState<
     HeaderIconConfig[] | undefined
   >(() =>
-    Array.from(DEFAULT_HEADER_ICON_CONFIGS.values()).filter(
-      (element) =>
-        localStorage.getItem(CURRENT_MODE) !== MODES.SCHOOL ||
-        element.headerList !== HOMEHEADERLIST.ASSIGNMENT,
-    ),
+    Array.from(DEFAULT_HEADER_ICON_CONFIGS.values()).filter((element) => {
+      if (
+        currentMode === MODES.SCHOOL &&
+        element.headerList === HOMEHEADERLIST.ASSIGNMENT
+      ) {
+        return false;
+      }
+
+      return true;
+    }),
   );
   var headerIconList: HeaderIconConfig[] = [];
 

--- a/src/components/HomeHeader.tsx
+++ b/src/components/HomeHeader.tsx
@@ -7,6 +7,8 @@ import {
   HeaderIconConfig,
   PAGES,
   MODES,
+  CURRENT_MODE,
+  IS_CONECTED,
   TableTypes,
   CURRENT_STUDENT_CHANGED_EVENT,
   HOME_HEADER_SPECIALS_ENABLED,
@@ -45,27 +47,59 @@ const HomeHeader: React.FC<{
   onHeaderIconClick: Function;
   pendingAssignmentCount: number;
   pendingLiveQuizCount: number;
+  isReturnFromLesson?: boolean;
 }> = ({
   currentHeader,
   onHeaderIconClick,
   pendingAssignmentCount,
   pendingLiveQuizCount,
+  isReturnFromLesson,
 }) => {
   const { t } = useTranslation();
-  const [currentHeaderIconList, setCurrentHeaderIconList] =
-    useState<HeaderIconConfig[]>();
+  const currentStudent = Util.getCurrentStudent();
+  const [currentHeaderIconList, setCurrentHeaderIconList] = useState<
+    HeaderIconConfig[] | undefined
+  >(() =>
+    Array.from(DEFAULT_HEADER_ICON_CONFIGS.values()).filter(
+      (element) =>
+        localStorage.getItem(CURRENT_MODE) !== MODES.SCHOOL ||
+        element.headerList !== HOMEHEADERLIST.ASSIGNMENT,
+    ),
+  );
   var headerIconList: HeaderIconConfig[] = [];
 
   const history = useHistory();
-  const [student, setStudent] = useState<TableTypes<'user'>>();
-  const studentRef = useRef<TableTypes<'user'> | null>(null);
+  const [student, setStudent] = useState<TableTypes<'user'> | undefined>(
+    currentStudent,
+  );
+  const studentRef = useRef<TableTypes<'user'> | null>(currentStudent ?? null);
 
-  const [studentMode, setStudentMode] = useState<string | undefined>();
-  const [canShowAvatar, setCanShowAvatar] = useState<boolean>();
+  const [studentMode, setStudentMode] = useState<string | undefined>(
+    localStorage.getItem(CURRENT_MODE) ?? undefined,
+  );
+  const [canShowAvatar, setCanShowAvatar] = useState<boolean>(true);
   const [isProfileMenuOpen, setProfileMenuOpen] = useState(false);
-  const [starsCount, setStarsCount] = useState<number>(0); // State for stars count
+  const [starsCount, setStarsCount] = useState<number>(() =>
+    currentStudent?.id
+      ? Util.getLocalStarsForStudent(
+          currentStudent.id,
+          currentStudent.stars || 0,
+        )
+      : 0,
+  ); // State for stars count
 
-  const [isLinked, setIsLinked] = useState(false);
+  const [isLinked, setIsLinked] = useState<boolean>(() => {
+    if (!currentStudent?.id) return false;
+    try {
+      const connectedData = localStorage.getItem(IS_CONECTED);
+      const parsedConnectedData = connectedData
+        ? JSON.parse(connectedData)
+        : {};
+      return Boolean(parsedConnectedData[currentStudent.id]);
+    } catch {
+      return false;
+    }
+  });
   const isHomeHeaderSpecialsEnabled = useFeatureIsOn(
     HOME_HEADER_SPECIALS_ENABLED,
   );
@@ -131,7 +165,9 @@ const HomeHeader: React.FC<{
   };
 
   useEffect(() => {
-    init();
+    if (!isReturnFromLesson) {
+      init();
+    }
     window.addEventListener('JoinClassListner', handleJoinClassListner);
 
     const handleStudentChange = (e: Event) => {
@@ -150,7 +186,7 @@ const HomeHeader: React.FC<{
         handleStudentChange,
       );
     };
-  }, [isHomeHeaderSpecialsEnabled]);
+  }, [isHomeHeaderSpecialsEnabled, isReturnFromLesson]);
 
   const handleJoinClassListner = () => {
     setIsLinked(true);

--- a/src/components/HomeHeader.tsx
+++ b/src/components/HomeHeader.tsx
@@ -45,12 +45,14 @@ const HomeHeader: React.FC<{
   pendingAssignmentCount: number;
   pendingLiveQuizCount: number;
   isReturnFromLesson?: boolean;
+  isReturnFromSchoolModeSwitchProfile?: boolean;
 }> = ({
   currentHeader,
   onHeaderIconClick,
   pendingAssignmentCount,
   pendingLiveQuizCount,
   isReturnFromLesson,
+  isReturnFromSchoolModeSwitchProfile,
 }) => {
   const { t } = useTranslation();
   const currentStudent = Util.getCurrentStudent();
@@ -65,18 +67,15 @@ const HomeHeader: React.FC<{
       ) {
         return false;
       }
-
       return true;
     }),
   );
   var headerIconList: HeaderIconConfig[] = [];
-
   const history = useHistory();
   const [student, setStudent] = useState<TableTypes<'user'> | undefined>(
     currentStudent,
   );
   const studentRef = useRef<TableTypes<'user'> | null>(currentStudent ?? null);
-
   const [studentMode, setStudentMode] = useState<string | undefined>(
     localStorage.getItem(CURRENT_MODE) ?? undefined,
   );
@@ -90,7 +89,6 @@ const HomeHeader: React.FC<{
         )
       : 0,
   ); // State for stars count
-
   const [isLinked, setIsLinked] = useState<boolean>(() => {
     if (!currentStudent?.id) return false;
     try {
@@ -114,7 +112,6 @@ const HomeHeader: React.FC<{
       setStarsCount(0);
       return;
     }
-
     const dbStars = curr.stars || 0;
     const localStars = Util.getLocalStarsForStudent(curr.id, dbStars);
     setStarsCount(localStars);
@@ -133,18 +130,14 @@ const HomeHeader: React.FC<{
       const linked = await api.isStudentLinked(student.id, fromCache);
       setIsLinked(linked);
       setStudentMode(currMode);
-
       // Fetch stars count for the current student
       const currentStudent = Util.getCurrentStudent();
       setStarsCount(currentStudent?.stars || 0);
-
       // 🔹 store student in state + ref
       setStudent(student);
       studentRef.current = student;
-
       // 🔹 initial stars: LOCAL-FIRST
       refreshStarsFromLocal();
-
       DEFAULT_HEADER_ICON_CONFIGS.forEach(async (element) => {
         if (
           !(
@@ -157,18 +150,15 @@ const HomeHeader: React.FC<{
           headerIconList.push(element);
         }
       });
-
       if (!headerIconList) return;
-
       setCurrentHeaderIconList(headerIconList);
       setStudent(student);
     } catch (error) {
       logger.error('Error in init:', error);
     }
   };
-
   useEffect(() => {
-    if (!isReturnFromLesson) {
+    if (!isReturnFromLesson && !isReturnFromSchoolModeSwitchProfile) {
       init();
     }
     window.addEventListener('JoinClassListner', handleJoinClassListner);
@@ -189,7 +179,11 @@ const HomeHeader: React.FC<{
         handleStudentChange,
       );
     };
-  }, [isHomeHeaderSpecialsEnabled, isReturnFromLesson]);
+  }, [
+    isHomeHeaderSpecialsEnabled,
+    isReturnFromLesson,
+    isReturnFromSchoolModeSwitchProfile,
+  ]);
 
   const handleJoinClassListner = () => {
     setIsLinked(true);

--- a/src/components/ProfileMenu/ProfileMenu.test.tsx
+++ b/src/components/ProfileMenu/ProfileMenu.test.tsx
@@ -231,7 +231,7 @@ describe('ProfileMenu Notification Logic', () => {
         pathname: PAGES.SELECT_MODE,
         state: {
           from: '/',
-          fromSchoolModeSwitchProfile: true,
+          fromSwitchProfileReturn: true,
         },
       }),
     );

--- a/src/hooks/useHome.ts
+++ b/src/hooks/useHome.ts
@@ -74,17 +74,17 @@ export const useHome = () => {
   const isRewardFeatureOn = useFeatureIsOn(IS_REWARD_FEATURE_ON);
   const location = useLocation<{
     fromLido?: boolean;
-    fromSchoolModeSwitchProfile?: boolean;
+    fromSwitchProfileReturn?: boolean;
   }>();
   const urlParams = new URLSearchParams(location.search);
-  const isReturnFromSchoolModeSwitchProfile =
-    location.state?.fromSchoolModeSwitchProfile === true;
-  const isReturnFromLesson =
+  const isReturnFromSwitchProfileReturn =
+    location.state?.fromSwitchProfileReturn === true;
+  const isReturnFromLidoOrSwitchProfile =
     location.state?.fromLido === true ||
-    isReturnFromSchoolModeSwitchProfile ||
+    isReturnFromSwitchProfileReturn ||
     urlParams.get('isReload') === 'true';
   const [isLoading, setIsLoading] = useState<boolean>(
-    !isReturnFromSchoolModeSwitchProfile,
+    !isReturnFromSwitchProfileReturn,
   );
   if (isRewardFeatureOn === true) {
     localStorage.setItem(IS_REWARD_FEATURE_ON, 'true');
@@ -96,9 +96,9 @@ export const useHome = () => {
     setCanShowAvatar(true);
   };
   const [canShowAvatar, setCanShowAvatar] = useState<boolean>(true);
-  const hasSkippedSchoolModeSwitchProfileTabSyncRef = useRef(false);
+  const hasSkippedSwitchProfileReturnTabSyncRef = useRef(false);
   const [currentHeader, setCurrentHeader] = useState(() => {
-    if (isReturnFromLesson) {
+    if (isReturnFromLidoOrSwitchProfile) {
       return HOMEHEADERLIST.HOME;
     }
     const currPage = urlParams.get('tab');
@@ -118,10 +118,10 @@ export const useHome = () => {
   const [to, setTo] = useState<number>(0);
   useEffect(() => {
     if (
-      isReturnFromSchoolModeSwitchProfile &&
-      !hasSkippedSchoolModeSwitchProfileTabSyncRef.current
+      isReturnFromSwitchProfileReturn &&
+      !hasSkippedSwitchProfileReturnTabSyncRef.current
     ) {
-      hasSkippedSchoolModeSwitchProfileTabSyncRef.current = true;
+      hasSkippedSwitchProfileReturnTabSyncRef.current = true;
       return;
     }
     const params = new URLSearchParams(location.search);
@@ -164,7 +164,7 @@ export const useHome = () => {
       history.replace(PAGES.SELECT_MODE);
       return;
     }
-    if (isReturnFromLesson) {
+    if (isReturnFromLidoOrSwitchProfile) {
       setIsLoading(false);
       return;
     }
@@ -582,8 +582,8 @@ export const useHome = () => {
     pendingAssignmentCount,
     pendingLiveQuizCount,
     refreshKey,
-    isReturnFromSchoolModeSwitchProfile,
-    isReturnFromLesson,
+    isReturnFromSwitchProfileReturn,
+    isReturnFromLidoOrSwitchProfile,
     setCurrentHeader,
     setPendingAssignmentCount,
     setPendingLiveQuizCount,

--- a/src/hooks/useHome.ts
+++ b/src/hooks/useHome.ts
@@ -83,12 +83,14 @@ export const useHome = () => {
   }
 
   let tempPageNumber = 1;
-  const location = useLocation();
+  const location = useLocation<{ fromLido?: boolean }>();
   const getCanShowAvatar = async () => {
     setCanShowAvatar(true);
   };
   const urlParams = new URLSearchParams(location.search);
   const [canShowAvatar, setCanShowAvatar] = useState<boolean>(true);
+  const isReturnFromLesson =
+    location.state?.fromLido === true || urlParams.get('isReload') === 'true';
   const [currentHeader, setCurrentHeader] = useState(() => {
     const currPage = urlParams.get('tab');
     if (
@@ -151,6 +153,10 @@ export const useHome = () => {
     const student = Util.getCurrentStudent();
     if (!student) {
       history.replace(PAGES.SELECT_MODE);
+      return;
+    }
+    if (isReturnFromLesson) {
+      setIsLoading(false);
       return;
     }
     const studentDetails = student;
@@ -570,6 +576,7 @@ export const useHome = () => {
     pendingAssignmentCount,
     pendingLiveQuizCount,
     refreshKey,
+    isReturnFromLesson,
     setCurrentHeader,
     setPendingAssignmentCount,
     setPendingLiveQuizCount,

--- a/src/hooks/useHome.ts
+++ b/src/hooks/useHome.ts
@@ -1,5 +1,5 @@
 import { IonPage, IonHeader, useIonViewWillEnter } from '@ionic/react';
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
 import {
   HOMEHEADERLIST,
   PAGES,
@@ -50,12 +50,9 @@ import {
 import { replaceWithNavigationTarget } from '../helper/navigation/NavigationHandler';
 import { getAppSearchParams } from '../utility/routerLocation';
 import { PopupConfig } from '../components/GenericPopUp/GenericPopUpType';
-
 const localData: any = {};
-
 export const useHome = () => {
   const [dataCourse, setDataCourse] = useState<HomeworkPathwayLesson[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isStudentLinked, setIsStudentLinked] = useState<boolean>();
   const [refreshKey, setRefreshKey] = useState(0);
   const [lessonCourseMap, setLessonCourseMap] = useState<{
@@ -75,23 +72,35 @@ export const useHome = () => {
   const history = useHistory();
   const { setGbUpdated } = useGbContext();
   const isRewardFeatureOn = useFeatureIsOn(IS_REWARD_FEATURE_ON);
-
+  const location = useLocation<{
+    fromLido?: boolean;
+    fromSchoolModeSwitchProfile?: boolean;
+  }>();
+  const urlParams = new URLSearchParams(location.search);
+  const isReturnFromSchoolModeSwitchProfile =
+    location.state?.fromSchoolModeSwitchProfile === true;
+  const isReturnFromLesson =
+    location.state?.fromLido === true ||
+    isReturnFromSchoolModeSwitchProfile ||
+    urlParams.get('isReload') === 'true';
+  const [isLoading, setIsLoading] = useState<boolean>(
+    !isReturnFromSchoolModeSwitchProfile,
+  );
   if (isRewardFeatureOn === true) {
     localStorage.setItem(IS_REWARD_FEATURE_ON, 'true');
   } else if (isRewardFeatureOn === false) {
     localStorage.setItem(IS_REWARD_FEATURE_ON, 'false');
   }
-
   let tempPageNumber = 1;
-  const location = useLocation<{ fromLido?: boolean }>();
   const getCanShowAvatar = async () => {
     setCanShowAvatar(true);
   };
-  const urlParams = new URLSearchParams(location.search);
   const [canShowAvatar, setCanShowAvatar] = useState<boolean>(true);
-  const isReturnFromLesson =
-    location.state?.fromLido === true || urlParams.get('isReload') === 'true';
+  const hasSkippedSchoolModeSwitchProfileTabSyncRef = useRef(false);
   const [currentHeader, setCurrentHeader] = useState(() => {
+    if (isReturnFromLesson) {
+      return HOMEHEADERLIST.HOME;
+    }
     const currPage = urlParams.get('tab');
     if (
       currPage &&
@@ -105,14 +114,18 @@ export const useHome = () => {
   const appStateChange = (isActive: boolean) => {
     Util.onAppStateChange({ isActive });
   };
-
   const [from, setFrom] = useState<number>(0);
   const [to, setTo] = useState<number>(0);
-
   useEffect(() => {
+    if (
+      isReturnFromSchoolModeSwitchProfile &&
+      !hasSkippedSchoolModeSwitchProfileTabSyncRef.current
+    ) {
+      hasSkippedSchoolModeSwitchProfileTabSyncRef.current = true;
+      return;
+    }
     const params = new URLSearchParams(location.search);
     const tabFromUrl = params.get('tab');
-
     if (
       tabFromUrl &&
       Object.values(HOMEHEADERLIST).includes(tabFromUrl as HOMEHEADERLIST) &&
@@ -121,7 +134,6 @@ export const useHome = () => {
       setCurrentHeader(tabFromUrl as HOMEHEADERLIST);
     }
   }, [location.search, currentHeader]);
-
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     if (currentHeader && params.get('tab') !== currentHeader) {
@@ -134,11 +146,9 @@ export const useHome = () => {
       });
     }
   }, [currentHeader, history, location.pathname, location.search]);
-
   const popupConfig = useFeatureValue<PopupConfig | null>(GENERIC_POP_UP, null);
   useEffect(() => {
     if (!popupConfig) return;
-
     if (
       currentHeader &&
       popupConfig.screen_name &&
@@ -148,7 +158,6 @@ export const useHome = () => {
       PopupManager.onTimeElapsed(popupConfig);
     }
   }, [currentHeader, popupConfig]);
-
   useEffect(() => {
     const student = Util.getCurrentStudent();
     if (!student) {
@@ -168,10 +177,8 @@ export const useHome = () => {
         parent = await ServiceConfig.getI()?.authHandler.getCurrentUser();
         (updatedStudentDetails as any).parent_id = parent?.id;
       }
-
       // Get Device Info
       const device = await Util.logDeviceInfo();
-
       // Initial Update with Student and Device info
       updateLocalAttributes({
         studentDetails: updatedStudentDetails,
@@ -179,7 +186,6 @@ export const useHome = () => {
       });
       setGbUpdated(true);
     })();
-
     localStorage.setItem(SHOW_DAILY_PROGRESS_FLAG, 'true');
     Util.checkDownloadedLessonsFromLocal();
     initData();
@@ -576,6 +582,7 @@ export const useHome = () => {
     pendingAssignmentCount,
     pendingLiveQuizCount,
     refreshKey,
+    isReturnFromSchoolModeSwitchProfile,
     isReturnFromLesson,
     setCurrentHeader,
     setPendingAssignmentCount,

--- a/src/hooks/useProfileMenu.ts
+++ b/src/hooks/useProfileMenu.ts
@@ -181,6 +181,7 @@ export const useProfileMenu = ({ onClose }: ProfileMenuProps) => {
       ...parsePath(PAGES.DISPLAY_STUDENT),
       state: {
         from: history.location.pathname,
+        fromSchoolModeSwitchProfile: true,
       },
     });
   };

--- a/src/hooks/useProfileMenu.ts
+++ b/src/hooks/useProfileMenu.ts
@@ -181,7 +181,7 @@ export const useProfileMenu = ({ onClose }: ProfileMenuProps) => {
       ...parsePath(PAGES.DISPLAY_STUDENT),
       state: {
         from: history.location.pathname,
-        fromSchoolModeSwitchProfile: true,
+        fromSwitchProfileReturn: true,
       },
     });
   };
@@ -200,7 +200,7 @@ export const useProfileMenu = ({ onClose }: ProfileMenuProps) => {
       ...parsePath(PAGES.SELECT_MODE),
       state: {
         from: history.location.pathname,
-        fromSchoolModeSwitchProfile: true,
+        fromSwitchProfileReturn: true,
       },
     });
   };

--- a/src/pages/DisplayStudents.test.tsx
+++ b/src/pages/DisplayStudents.test.tsx
@@ -14,6 +14,11 @@ import logger from '../utility/logger';
 const mockHistoryReplace = jest.fn();
 const mockSetGbUpdated = jest.fn();
 const mockPresentToast = jest.fn();
+const mockLocation = {
+  pathname: '/display-students',
+  search: '',
+  state: undefined,
+};
 
 const mockApi = {
   getParentStudentProfiles: jest.fn(),
@@ -67,6 +72,7 @@ jest.mock('react-router', () => ({
     replace: mockHistoryReplace,
     location: { pathname: '/display-students' },
   }),
+  useLocation: () => mockLocation,
 }));
 
 jest.mock('i18next', () => ({
@@ -330,7 +336,7 @@ describe('DisplayStudents', () => {
     });
   });
 
-  test('navigates to home with current query params when profile is complete', async () => {
+  test('navigates to home when profile is complete', async () => {
     window.history.replaceState(
       {},
       '',
@@ -342,9 +348,12 @@ describe('DisplayStudents', () => {
     await clickStudentOnePlayButton();
 
     await waitFor(() => {
-      expect(mockHistoryReplace).toHaveBeenCalledWith(
-        `${PAGES.HOME}?tab=ASSIGNMENT&page=/join-class`,
-      );
+      expect(mockHistoryReplace).toHaveBeenCalledWith({
+        pathname: PAGES.HOME,
+        search: '',
+        hash: '',
+        state: undefined,
+      });
     });
   });
 });

--- a/src/pages/DisplayStudents.tsx
+++ b/src/pages/DisplayStudents.tsx
@@ -3,7 +3,7 @@ import { ScreenOrientation } from '../utility/screenOrientation';
 import { IonPage } from '@ionic/react';
 import { t } from 'i18next';
 import { FC, useEffect, useState } from 'react';
-import { useHistory } from 'react-router';
+import { useHistory, useLocation } from 'react-router';
 import {
   AVATARS,
   EDIT_STUDENTS_MAP,
@@ -32,6 +32,7 @@ const DisplayStudents: FC<{}> = () => {
   const [studentMode, setStudentMode] = useState<string | undefined>();
   const api = ServiceConfig.getI().apiHandler;
   const history = useHistory();
+  const location = useLocation<{ fromSchoolModeSwitchProfile?: boolean }>();
   const { setGbUpdated } = useGbContext();
   const isWebPlatform = Capacitor.getPlatform() === 'web';
   const getProfileCardPlayActionParams = (
@@ -85,7 +86,8 @@ const DisplayStudents: FC<{}> = () => {
     setIsLoading(false);
   };
   const onStudentClick = async (student: TableTypes<'user'>) => {
-    schoolUtil.setCurrMode(MODES.PARENT);
+    if (studentMode !== MODES.SCHOOL && studentMode !== MODES.TEACHER_SCHOOL)
+      schoolUtil.setCurrMode(MODES.PARENT);
     await Util.setCurrentStudent(student, undefined, true);
     const linkedData = await api.getStudentClassesAndSchools(student.id);
     void Util.ensureLidoCommonAudioForStudent(student).catch((error) => {
@@ -117,7 +119,12 @@ const DisplayStudents: FC<{}> = () => {
         },
       });
     } else {
-      history.replace(PAGES.HOME + getAppSearch());
+      history.replace({
+        ...parsePath(PAGES.HOME),
+        state: location.state?.fromSchoolModeSwitchProfile
+          ? { fromSchoolModeSwitchProfile: true }
+          : undefined,
+      });
     }
   };
   return (

--- a/src/pages/DisplayStudents.tsx
+++ b/src/pages/DisplayStudents.tsx
@@ -32,7 +32,7 @@ const DisplayStudents: FC<{}> = () => {
   const [studentMode, setStudentMode] = useState<string | undefined>();
   const api = ServiceConfig.getI().apiHandler;
   const history = useHistory();
-  const location = useLocation<{ fromSchoolModeSwitchProfile?: boolean }>();
+  const location = useLocation<{ fromSwitchProfileReturn?: boolean }>();
   const { setGbUpdated } = useGbContext();
   const isWebPlatform = Capacitor.getPlatform() === 'web';
   const getProfileCardPlayActionParams = (
@@ -121,8 +121,8 @@ const DisplayStudents: FC<{}> = () => {
     } else {
       history.replace({
         ...parsePath(PAGES.HOME),
-        state: location.state?.fromSchoolModeSwitchProfile
-          ? { fromSchoolModeSwitchProfile: true }
+        state: location.state?.fromSwitchProfileReturn
+          ? { fromSwitchProfileReturn: true }
           : undefined,
       });
     }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -23,6 +23,7 @@ const Home = () => {
     pendingAssignmentCount,
     pendingLiveQuizCount,
     refreshKey,
+    isReturnFromLesson,
     setCurrentHeader,
     setPendingAssignmentCount,
     setPendingLiveQuizCount,
@@ -38,6 +39,7 @@ const Home = () => {
           onHeaderIconClick={onHeaderIconClick}
           pendingAssignmentCount={pendingAssignmentCount}
           pendingLiveQuizCount={pendingLiveQuizCount}
+          isReturnFromLesson={isReturnFromLesson}
         />
       </IonHeader>
       <div className="slider-content">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -23,6 +23,7 @@ const Home = () => {
     pendingAssignmentCount,
     pendingLiveQuizCount,
     refreshKey,
+    isReturnFromSchoolModeSwitchProfile,
     isReturnFromLesson,
     setCurrentHeader,
     setPendingAssignmentCount,
@@ -39,6 +40,9 @@ const Home = () => {
           onHeaderIconClick={onHeaderIconClick}
           pendingAssignmentCount={pendingAssignmentCount}
           pendingLiveQuizCount={pendingLiveQuizCount}
+          isReturnFromSchoolModeSwitchProfile={
+            isReturnFromSchoolModeSwitchProfile
+          }
           isReturnFromLesson={isReturnFromLesson}
         />
       </IonHeader>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -23,8 +23,8 @@ const Home = () => {
     pendingAssignmentCount,
     pendingLiveQuizCount,
     refreshKey,
-    isReturnFromSchoolModeSwitchProfile,
-    isReturnFromLesson,
+    isReturnFromSwitchProfileReturn,
+    isReturnFromLidoOrSwitchProfile,
     setCurrentHeader,
     setPendingAssignmentCount,
     setPendingLiveQuizCount,
@@ -40,10 +40,8 @@ const Home = () => {
           onHeaderIconClick={onHeaderIconClick}
           pendingAssignmentCount={pendingAssignmentCount}
           pendingLiveQuizCount={pendingLiveQuizCount}
-          isReturnFromSchoolModeSwitchProfile={
-            isReturnFromSchoolModeSwitchProfile
-          }
-          isReturnFromLesson={isReturnFromLesson}
+          isReturnFromSwitchProfileReturn={isReturnFromSwitchProfileReturn}
+          isReturnFromLidoOrSwitchProfile={isReturnFromLidoOrSwitchProfile}
         />
       </IonHeader>
       <div className="slider-content">

--- a/src/pages/SelectMode.init.ts
+++ b/src/pages/SelectMode.init.ts
@@ -199,7 +199,7 @@ export const initializeSelectMode = async (ctx: any) => {
   const shouldSuppressTeacherAutoEntry =
     currentMode === MODES.TEACHER_SCHOOL &&
     (location.state?.fromKidsAppLocationSchool === true ||
-      location.state?.fromSchoolModeSwitchProfile === true);
+      location.state?.fromSwitchProfileReturn === true);
   const shouldAutoEnterTeacherApp =
     teacherRoleEntries.length > 0 && !shouldSuppressTeacherAutoEntry;
   const shouldUseEmptySchoolFallback = !shouldSuppressTeacherAutoEntry;

--- a/src/pages/SelectMode.test.tsx
+++ b/src/pages/SelectMode.test.tsx
@@ -1434,6 +1434,47 @@ describe('SelectMode page', () => {
     expect(screen.getByText('Student 1')).toBeInTheDocument();
   });
 
+  it('preserves school-mode switch profile flag when selecting a student', async () => {
+    const school = { id: 'school-1', name: 'School 1' };
+    const classData = { id: 'class-1', name: 'Class 1', school_id: school.id };
+    mockLocationState = { fromSchoolModeSwitchProfile: true };
+    localStorage.setItem(CURRENT_SCHOOL_NAME, JSON.stringify(school.name));
+    localStorage.setItem(CURRENT_CLASS_NAME, JSON.stringify(classData));
+    localStorage.setItem(USER_SELECTION_STAGE, 'true');
+    localStorage.setItem(
+      SELECTED_STUDENTS,
+      JSON.stringify([
+        { id: 'student-1', name: 'Student 1', avatar: 'avatar1' },
+      ]),
+    );
+    mockGetCurrMode.mockResolvedValue(MODES.SCHOOL);
+    mockAuthHandler.getCurrentUser.mockResolvedValue({ id: 'user-1' });
+    mockApiHandler.getSchoolsForUser.mockResolvedValue([
+      { school, role: 'PARENT' },
+    ]);
+    mockApiHandler.getSchoolsWithRoleAutouser.mockResolvedValue([
+      { id: 'school-1' },
+    ]);
+    mockApiHandler.getClassesForSchool.mockResolvedValue([classData]);
+    mockApiHandler.getStudentsForClass.mockResolvedValue([
+      { id: 'student-1', name: 'Student 1', avatar: 'avatar1' },
+    ]);
+
+    render(<SelectMode />);
+
+    await waitFor(() =>
+      expect(document.querySelector('.class-container')).not.toBeNull(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+
+    await waitFor(() =>
+      expect(mockHistoryReplace).toHaveBeenCalledWith({
+        pathname: PAGES.HOME,
+        state: { fromSchoolModeSwitchProfile: true },
+      }),
+    );
+  });
+
   it('handles MODES.SCHOOL with schoolName and className, no selectedUser -> STAGES.CLASS', async () => {
     const school = { id: 'school-1', name: 'School 1' };
     const classData = { id: 'class-1', name: 'Class 1' };

--- a/src/pages/SelectMode.test.tsx
+++ b/src/pages/SelectMode.test.tsx
@@ -73,7 +73,7 @@ const mockHistoryReplace = jest.fn();
 let mockLocationState:
   | {
       fromKidsAppLocationSchool?: boolean;
-      fromSchoolModeSwitchProfile?: boolean;
+      fromSwitchProfileReturn?: boolean;
     }
   | undefined;
 jest.mock('react-router', () => {
@@ -926,7 +926,7 @@ describe('SelectMode page', () => {
       name: 'Class 1',
       school_id: teacherSchool.id,
     };
-    mockLocationState = { fromSchoolModeSwitchProfile: true };
+    mockLocationState = { fromSwitchProfileReturn: true };
     mockGetCurrMode.mockResolvedValue(MODES.TEACHER_SCHOOL);
     mockAuthHandler.getCurrentUser.mockResolvedValue({
       id: 'user-1',
@@ -1437,7 +1437,7 @@ describe('SelectMode page', () => {
   it('preserves school-mode switch profile flag when selecting a student', async () => {
     const school = { id: 'school-1', name: 'School 1' };
     const classData = { id: 'class-1', name: 'Class 1', school_id: school.id };
-    mockLocationState = { fromSchoolModeSwitchProfile: true };
+    mockLocationState = { fromSwitchProfileReturn: true };
     localStorage.setItem(CURRENT_SCHOOL_NAME, JSON.stringify(school.name));
     localStorage.setItem(CURRENT_CLASS_NAME, JSON.stringify(classData));
     localStorage.setItem(USER_SELECTION_STAGE, 'true');
@@ -1470,7 +1470,7 @@ describe('SelectMode page', () => {
     await waitFor(() =>
       expect(mockHistoryReplace).toHaveBeenCalledWith({
         pathname: PAGES.HOME,
-        state: { fromSchoolModeSwitchProfile: true },
+        state: { fromSwitchProfileReturn: true },
       }),
     );
   });

--- a/src/pages/useSelectModeController.ts
+++ b/src/pages/useSelectModeController.ts
@@ -431,7 +431,12 @@ export const useSelectModeController = () => {
       school_ids: resolvedSchoolIds,
     });
     setGbUpdated(true);
-    history.replace(PAGES.HOME);
+    history.replace({
+      pathname: PAGES.HOME,
+      state: location.state?.fromSchoolModeSwitchProfile
+        ? { fromSchoolModeSwitchProfile: true }
+        : undefined,
+    });
   };
   const onClassSelect = async (
     selectedClass: TableTypes<'class'>,

--- a/src/pages/useSelectModeController.ts
+++ b/src/pages/useSelectModeController.ts
@@ -69,7 +69,7 @@ interface SchoolModeOption {
 
 interface SelectModeLocationState {
   fromKidsAppLocationSchool?: boolean;
-  fromSchoolModeSwitchProfile?: boolean;
+  fromSwitchProfileReturn?: boolean;
 }
 
 export const useSelectModeController = () => {
@@ -433,8 +433,8 @@ export const useSelectModeController = () => {
     setGbUpdated(true);
     history.replace({
       pathname: PAGES.HOME,
-      state: location.state?.fromSchoolModeSwitchProfile
-        ? { fromSchoolModeSwitchProfile: true }
+      state: location.state?.fromSwitchProfileReturn
+        ? { fromSwitchProfileReturn: true }
         : undefined,
     });
   };


### PR DESCRIPTION
- Detect lesson-return navigation from Lido and skip the heavy Home re-init on that path.

- Bootstrap HomeHeader from existing local state and skip its async init when returning from a lesson.

- Keep the pathway refresh flow intact so only the pathway subtree updates, reducing header/shell flicker on Android and slow networks.