### PR TITLE
Align request school filter with tab-specific pending rules

### DIFF
--- a/src/ops-console/components/FilterSlider.tsx
+++ b/src/ops-console/components/FilterSlider.tsx
@@ -45,6 +45,7 @@ const FilterSlider: React.FC<FilterSliderProps> = ({
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const [schoolSearchValue, setSchoolSearchValue] = React.useState('');
 
   const getOptionLabel = (option: SchoolFilterOption) =>
     typeof option === 'string' ? option : option.name;
@@ -82,7 +83,39 @@ const FilterSlider: React.FC<FilterSliderProps> = ({
             key={key}
             multiple
             options={filterOptions[key] || []}
+            filterOptions={
+              key === 'school'
+                ? (options, state) => {
+                    const query = state.inputValue.trim().toLowerCase();
+                    if (!query) return options;
+
+                    const rank = (name: string) => {
+                      const lower = name.toLowerCase();
+                      if (lower.startsWith(query)) return 0;
+                      if (lower.includes(` ${query}`)) return 1;
+                      if (lower.includes(query)) return 2;
+                      return 3;
+                    };
+
+                    return [...options]
+                      .filter((option) =>
+                        getOptionLabel(option).toLowerCase().includes(query),
+                      )
+                      .sort((a, b) => {
+                        const left = getOptionLabel(a);
+                        const right = getOptionLabel(b);
+                        return (
+                          rank(left) - rank(right) ||
+                          left.localeCompare(right, undefined, {
+                            sensitivity: 'base',
+                          })
+                        );
+                      });
+                  }
+                : undefined
+            }
             disableCloseOnSelect
+            filterSelectedOptions={false}
             getOptionLabel={getOptionLabel}
             isOptionEqualToValue={(option, value) =>
               getOptionValue(option) === getOptionValue(value)
@@ -94,6 +127,23 @@ const FilterSlider: React.FC<FilterSliderProps> = ({
                   )
                 : (filters[key] ?? [])
             }
+            inputValue={key === 'school' ? schoolSearchValue : undefined}
+            onInputChange={(_, newInputValue, reason) => {
+              if (key !== 'school') return;
+
+              if (reason === 'clear') {
+                setSchoolSearchValue('');
+                return;
+              }
+
+              if (reason === 'input') {
+                setSchoolSearchValue(newInputValue);
+                return;
+              }
+
+              // Keep the current search text after a selection so the filtered
+              // result set stays visible for additional picks.
+            }}
             onChange={(e, value) => {
               const nextValues = Array.isArray(value)
                 ? value.map(getOptionValue)

--- a/src/ops-console/components/FilterSlider.tsx
+++ b/src/ops-console/components/FilterSlider.tsx
@@ -47,6 +47,10 @@ const FilterSlider: React.FC<FilterSliderProps> = ({
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [schoolSearchValue, setSchoolSearchValue] = React.useState('');
 
+  React.useEffect(() => {
+    if (!isOpen) setSchoolSearchValue('');
+  }, [isOpen]);
+
   const getOptionLabel = (option: SchoolFilterOption) =>
     typeof option === 'string' ? option : option.name;
   const getOptionValue = (option: SchoolFilterOption) =>

--- a/src/ops-console/pages/useRequestListPage.ts
+++ b/src/ops-console/pages/useRequestListPage.ts
@@ -146,13 +146,28 @@ export function useRequestListPage() {
     }),
   );
   const schoolNameToIdMapRef = React.useRef<Map<string, string>>(new Map());
-  const hasRequestedFilterOptionsRef = React.useRef(false);
-  const [isFilterOptionsLoaded, setIsFilterOptionsLoaded] = useState(false);
+  const hasRequestedFilterOptionsRef =
+    React.useRef<EnumType<'ops_request_status'> | null>(null);
   const [orderBy, setOrderBy] = useState('requested_date');
   const [orderDir, setOrderDir] = useState<'desc' | 'asc'>('desc');
   const [pageSize] = useState(DEFAULT_PAGE_SIZE);
+  const requestStatus = useMemo<EnumType<'ops_request_status'>>(() => {
+    switch (selectedTab) {
+      case REQUEST_TABS.PENDING:
+        return Constants.public.Enums.ops_request_status[0];
+      case REQUEST_TABS.APPROVED:
+        return Constants.public.Enums.ops_request_status[2];
+      case REQUEST_TABS.REJECTED:
+        return Constants.public.Enums.ops_request_status[1];
+      case REQUEST_TABS.FLAGGED:
+        return Constants.public.Enums.ops_request_status[3];
+      default:
+        return Constants.public.Enums.ops_request_status[0];
+    }
+  }, [selectedTab]);
   const hasSchoolFilter = filters.school.length > 0;
-  const isSchoolFilterReady = !hasSchoolFilter || isFilterOptionsLoaded;
+  const isSchoolFilterReady =
+    !hasSchoolFilter || hasRequestedFilterOptionsRef.current === requestStatus;
   const shouldLoadFilterOptions = isFilterOpen || hasSchoolFilter;
   const isLoading =
     isDataLoading || (!isFilterOpen && hasSchoolFilter && isFilterLoading);
@@ -191,15 +206,18 @@ export function useRequestListPage() {
   }, [selectedTab, debouncedSearchTerm, filters, page, history]);
 
   useEffect(() => {
-    if (!shouldLoadFilterOptions || hasRequestedFilterOptionsRef.current) {
+    if (
+      !shouldLoadFilterOptions ||
+      hasRequestedFilterOptionsRef.current === requestStatus
+    ) {
       return;
     }
 
-    hasRequestedFilterOptionsRef.current = true;
+    hasRequestedFilterOptionsRef.current = requestStatus;
     setIsFilterLoading(true);
 
     api
-      .getRequestFilterOptions()
+      .getRequestFilterOptions(requestStatus)
       .then((data) => {
         if (!data) return;
 
@@ -220,10 +238,9 @@ export function useRequestListPage() {
         logger.error('Failed to fetch filter options', error);
       })
       .finally(() => {
-        setIsFilterOptionsLoaded(true);
         setIsFilterLoading(false);
       });
-  }, [api, shouldLoadFilterOptions]);
+  }, [api, requestStatus, shouldLoadFilterOptions]);
 
   const handleOpenFilters = React.useCallback(() => {
     setIsFilterOpen(true);
@@ -236,24 +253,6 @@ export function useRequestListPage() {
     const fetchData = async () => {
       setIsDataLoading(true);
       try {
-        let tempTab: EnumType<'ops_request_status'>;
-        switch (selectedTab) {
-          case REQUEST_TABS.PENDING:
-            tempTab = Constants.public.Enums.ops_request_status[0];
-            break;
-          case REQUEST_TABS.APPROVED:
-            tempTab = Constants.public.Enums.ops_request_status[2];
-            break;
-          case REQUEST_TABS.REJECTED:
-            tempTab = Constants.public.Enums.ops_request_status[1];
-            break;
-          case REQUEST_TABS.FLAGGED:
-            tempTab = Constants.public.Enums.ops_request_status[3];
-            break;
-          default:
-            tempTab = Constants.public.Enums.ops_request_status[0];
-        }
-
         const filtersWithSchoolIds = {
           ...filters,
           school: filters.school
@@ -274,7 +273,7 @@ export function useRequestListPage() {
         };
         const backendOrderBy = orderByMapping[orderBy] || orderBy;
         const { data, total } = await api.getOpsRequests(
-          tempTab,
+          requestStatus,
           page,
           pageSize,
           backendOrderBy,
@@ -298,6 +297,7 @@ export function useRequestListPage() {
     tableScrollRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
   }, [
     api,
+    requestStatus,
     selectedTab,
     page,
     pageSize,

--- a/src/ops-console/pages/useRequestListPage.ts
+++ b/src/ops-console/pages/useRequestListPage.ts
@@ -116,17 +116,37 @@ export function useRequestListPage() {
   );
   const userRoles = roles || [];
   const tabOptions = useMemo(() => getRequestTabOptions(userRoles), []);
-  const [selectedTab, setSelectedTab] = useState<REQUEST_TABS>(() => {
+  const initialSelectedTab = (() => {
     const v = qs.get('tab') as REQUEST_TABS | null;
     return v && Object.values(REQUEST_TABS).includes(v)
       ? v
       : REQUEST_TABS.PENDING;
-  });
+  })();
+  const [selectedTab, setSelectedTab] =
+    useState<REQUEST_TABS>(initialSelectedTab);
   const [searchTerm, setSearchTerm] = useState(() => qs.get('search') || '');
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(searchTerm);
-  const [filters, setFilters] = useState<RequestListFilters>(() =>
-    parseJSONParam(qs.get('filters'), INITIAL_FILTERS),
-  );
+  const [filtersByTab, setFiltersByTab] = useState<
+    Record<REQUEST_TABS, RequestListFilters>
+  >(() => ({
+    [REQUEST_TABS.PENDING]:
+      initialSelectedTab === REQUEST_TABS.PENDING
+        ? parseJSONParam(qs.get('filters'), INITIAL_FILTERS)
+        : INITIAL_FILTERS,
+    [REQUEST_TABS.APPROVED]:
+      initialSelectedTab === REQUEST_TABS.APPROVED
+        ? parseJSONParam(qs.get('filters'), INITIAL_FILTERS)
+        : INITIAL_FILTERS,
+    [REQUEST_TABS.REJECTED]:
+      initialSelectedTab === REQUEST_TABS.REJECTED
+        ? parseJSONParam(qs.get('filters'), INITIAL_FILTERS)
+        : INITIAL_FILTERS,
+    [REQUEST_TABS.FLAGGED]:
+      initialSelectedTab === REQUEST_TABS.FLAGGED
+        ? parseJSONParam(qs.get('filters'), INITIAL_FILTERS)
+        : INITIAL_FILTERS,
+  }));
+  const filters = filtersByTab[selectedTab] ?? INITIAL_FILTERS;
   const [page, setPage] = useState(() => {
     const p = parseInt(qs.get('page') || '', 10);
     return isNaN(p) || p < 1 ? 1 : p;
@@ -137,8 +157,45 @@ export function useRequestListPage() {
   const [isDataLoading, setIsDataLoading] = useState(false);
   const [total, setTotal] = useState(0);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
-  const [tempFilters, setTempFilters] =
-    useState<RequestListFilters>(INITIAL_FILTERS);
+  const [tempFiltersByTab, setTempFiltersByTab] = useState<
+    Record<REQUEST_TABS, RequestListFilters>
+  >(() => ({
+    [REQUEST_TABS.PENDING]: INITIAL_FILTERS,
+    [REQUEST_TABS.APPROVED]: INITIAL_FILTERS,
+    [REQUEST_TABS.REJECTED]: INITIAL_FILTERS,
+    [REQUEST_TABS.FLAGGED]: INITIAL_FILTERS,
+  }));
+  const tempFilters = tempFiltersByTab[selectedTab] ?? INITIAL_FILTERS;
+  const setFilters = React.useCallback(
+    (value: React.SetStateAction<RequestListFilters>) => {
+      setFiltersByTab((prev) => {
+        const current = prev[selectedTab] ?? INITIAL_FILTERS;
+        const next =
+          typeof value === 'function'
+            ? (value as (prevState: RequestListFilters) => RequestListFilters)(
+                current,
+              )
+            : value;
+        return { ...prev, [selectedTab]: next };
+      });
+    },
+    [selectedTab],
+  );
+  const setTempFilters = React.useCallback(
+    (value: React.SetStateAction<RequestListFilters>) => {
+      setTempFiltersByTab((prev) => {
+        const current = prev[selectedTab] ?? INITIAL_FILTERS;
+        const next =
+          typeof value === 'function'
+            ? (value as (prevState: RequestListFilters) => RequestListFilters)(
+                current,
+              )
+            : value;
+        return { ...prev, [selectedTab]: next };
+      });
+    },
+    [selectedTab],
+  );
   const [filterOptions, setFilterOptions] = useState<RequestListFilterOptions>(
     () => ({
       ...INITIAL_FILTER_OPTIONS,
@@ -245,7 +302,7 @@ export function useRequestListPage() {
   const handleOpenFilters = React.useCallback(() => {
     setIsFilterOpen(true);
     setTempFilters(filters);
-  }, [filters]);
+  }, [filters, selectedTab]);
 
   useEffect(() => {
     if (!isSchoolFilterReady) return;
@@ -339,10 +396,10 @@ export function useRequestListPage() {
   };
 
   const handleDeleteFilter = (key: string, value: string) => {
-    setFilters((prev) => {
+    setFilters((current) => {
       const updated = {
-        ...prev,
-        [key]: prev[key].filter((v) => v !== value),
+        ...current,
+        [key]: current[key].filter((v) => v !== value),
       };
       setTempFilters(updated);
       return updated;

--- a/src/ops-console/pages/useRequestListPage.ts
+++ b/src/ops-console/pages/useRequestListPage.ts
@@ -126,27 +126,9 @@ export function useRequestListPage() {
     useState<REQUEST_TABS>(initialSelectedTab);
   const [searchTerm, setSearchTerm] = useState(() => qs.get('search') || '');
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(searchTerm);
-  const [filtersByTab, setFiltersByTab] = useState<
-    Record<REQUEST_TABS, RequestListFilters>
-  >(() => ({
-    [REQUEST_TABS.PENDING]:
-      initialSelectedTab === REQUEST_TABS.PENDING
-        ? parseJSONParam(qs.get('filters'), INITIAL_FILTERS)
-        : INITIAL_FILTERS,
-    [REQUEST_TABS.APPROVED]:
-      initialSelectedTab === REQUEST_TABS.APPROVED
-        ? parseJSONParam(qs.get('filters'), INITIAL_FILTERS)
-        : INITIAL_FILTERS,
-    [REQUEST_TABS.REJECTED]:
-      initialSelectedTab === REQUEST_TABS.REJECTED
-        ? parseJSONParam(qs.get('filters'), INITIAL_FILTERS)
-        : INITIAL_FILTERS,
-    [REQUEST_TABS.FLAGGED]:
-      initialSelectedTab === REQUEST_TABS.FLAGGED
-        ? parseJSONParam(qs.get('filters'), INITIAL_FILTERS)
-        : INITIAL_FILTERS,
-  }));
-  const filters = filtersByTab[selectedTab] ?? INITIAL_FILTERS;
+  const [filters, setFilters] = useState<RequestListFilters>(() =>
+    parseJSONParam(qs.get('filters'), INITIAL_FILTERS),
+  );
   const [page, setPage] = useState(() => {
     const p = parseInt(qs.get('page') || '', 10);
     return isNaN(p) || p < 1 ? 1 : p;
@@ -157,44 +139,8 @@ export function useRequestListPage() {
   const [isDataLoading, setIsDataLoading] = useState(false);
   const [total, setTotal] = useState(0);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
-  const [tempFiltersByTab, setTempFiltersByTab] = useState<
-    Record<REQUEST_TABS, RequestListFilters>
-  >(() => ({
-    [REQUEST_TABS.PENDING]: INITIAL_FILTERS,
-    [REQUEST_TABS.APPROVED]: INITIAL_FILTERS,
-    [REQUEST_TABS.REJECTED]: INITIAL_FILTERS,
-    [REQUEST_TABS.FLAGGED]: INITIAL_FILTERS,
-  }));
-  const tempFilters = tempFiltersByTab[selectedTab] ?? INITIAL_FILTERS;
-  const setFilters = React.useCallback(
-    (value: React.SetStateAction<RequestListFilters>) => {
-      setFiltersByTab((prev) => {
-        const current = prev[selectedTab] ?? INITIAL_FILTERS;
-        const next =
-          typeof value === 'function'
-            ? (value as (prevState: RequestListFilters) => RequestListFilters)(
-                current,
-              )
-            : value;
-        return { ...prev, [selectedTab]: next };
-      });
-    },
-    [selectedTab],
-  );
-  const setTempFilters = React.useCallback(
-    (value: React.SetStateAction<RequestListFilters>) => {
-      setTempFiltersByTab((prev) => {
-        const current = prev[selectedTab] ?? INITIAL_FILTERS;
-        const next =
-          typeof value === 'function'
-            ? (value as (prevState: RequestListFilters) => RequestListFilters)(
-                current,
-              )
-            : value;
-        return { ...prev, [selectedTab]: next };
-      });
-    },
-    [selectedTab],
+  const [tempFilters, setTempFilters] = useState<RequestListFilters>(() =>
+    parseJSONParam(qs.get('filters'), INITIAL_FILTERS),
   );
   const [filterOptions, setFilterOptions] = useState<RequestListFilterOptions>(
     () => ({
@@ -252,6 +198,10 @@ export function useRequestListPage() {
   }, [debouncedSearchTerm, filters]);
 
   useEffect(() => {
+    setTempFilters(filters);
+  }, [filters]);
+
+  useEffect(() => {
     const params = new URLSearchParams();
     if (selectedTab !== REQUEST_TABS.PENDING)
       params.set('tab', String(selectedTab));
@@ -270,7 +220,6 @@ export function useRequestListPage() {
       return;
     }
 
-    hasRequestedFilterOptionsRef.current = requestStatus;
     setIsFilterLoading(true);
 
     api
@@ -290,6 +239,7 @@ export function useRequestListPage() {
           nameToIdMap.set(school.name, school.id);
         });
         schoolNameToIdMapRef.current = nameToIdMap;
+        hasRequestedFilterOptionsRef.current = requestStatus;
       })
       .catch((error) => {
         logger.error('Failed to fetch filter options', error);
@@ -302,7 +252,7 @@ export function useRequestListPage() {
   const handleOpenFilters = React.useCallback(() => {
     setIsFilterOpen(true);
     setTempFilters(filters);
-  }, [filters, selectedTab]);
+  }, [filters]);
 
   useEffect(() => {
     if (!isSchoolFilterReady) return;

--- a/src/services/api/apihandler/ApiHandler.opsUsers.ts
+++ b/src/services/api/apihandler/ApiHandler.opsUsers.ts
@@ -253,8 +253,8 @@ export class ApiHandlerOpsUsers extends ApiHandlerCampaigns {
     );
   }
 
-  async getRequestFilterOptions() {
-    return this.s.getRequestFilterOptions();
+  async getRequestFilterOptions(requestStatus: EnumType<'ops_request_status'>) {
+    return this.s.getRequestFilterOptions(requestStatus);
   }
 
   async searchTeachersInSchool(

--- a/src/services/api/serviceapi/ServiceApi.opsUsers.ts
+++ b/src/services/api/serviceapi/ServiceApi.opsUsers.ts
@@ -156,7 +156,9 @@ export interface ServiceApiOpsUsers {
     searchTerm?: string,
   ): Promise<OpsRequestsResponse>;
 
-  getRequestFilterOptions(): Promise<RequestFilterOptions | null>;
+  getRequestFilterOptions(
+    requestStatus: EnumType<'ops_request_status'>,
+  ): Promise<RequestFilterOptions | null>;
 
   searchTeachersInSchool(
     schoolId: string,

--- a/src/services/api/sqlite/SqliteApi.program.requests.ts
+++ b/src/services/api/sqlite/SqliteApi.program.requests.ts
@@ -22,7 +22,9 @@ export class SqliteApiProgramRequests extends SqliteApiProgramActivityStats {
     throw new Error('Method not implemented.');
   }
 
-  async getRequestFilterOptions(): Promise<{
+  async getRequestFilterOptions(
+    requestStatus: EnumType<'ops_request_status'>,
+  ): Promise<{
     requestType: Array<string | null>;
     school: { id: string; name: string }[];
   } | null> {

--- a/src/services/api/supabase/SupabaseApi.program.requests.test.ts
+++ b/src/services/api/supabase/SupabaseApi.program.requests.test.ts
@@ -64,4 +64,62 @@ describe('SupabaseApiProgramRequests.getRequestFilterOptions', () => {
     expect(chain.eq).toHaveBeenCalledWith('request_status', 'requested');
     expect(chain.not).toHaveBeenCalledWith('school_id', 'is', null);
   });
+
+  it('excludes schools that only have expired student requested rows', async () => {
+    const rows = [
+      {
+        request_type: 'student',
+        request_ends_at: '2020-01-01T00:00:00.000Z',
+        school: { id: 'school-1', name: 'Expired School' },
+      },
+      {
+        request_type: 'student',
+        request_ends_at: '2030-01-01T00:00:00.000Z',
+        school: { id: 'school-2', name: 'Active School' },
+      },
+      {
+        request_type: 'teacher',
+        request_ends_at: null,
+        school: { id: 'school-3', name: 'Teacher School' },
+      },
+    ];
+
+    type SchoolRow = {
+      request_type: string;
+      request_ends_at: string | null;
+      school: { id: string; name: string } | null;
+    };
+    type Chain = {
+      data: SchoolRow[];
+      error: null;
+      select: jest.Mock<Chain, []>;
+      eq: jest.Mock<Chain, [string, unknown]>;
+      not: jest.Mock<Chain, [string, string, unknown]>;
+    };
+
+    const chain = {} as Chain;
+    chain.data = rows;
+    chain.error = null;
+    chain.select = jest.fn(() => chain);
+    chain.eq = jest.fn(() => chain);
+    chain.not = jest.fn(() => chain);
+
+    const supabase = {
+      from: jest.fn(() => chain),
+    };
+
+    const api =
+      new SupabaseApiProgramRequests() as SupabaseApiProgramRequests & {
+        supabase: typeof supabase;
+      };
+    api.supabase = supabase;
+
+    await expect(api.getRequestFilterOptions('requested')).resolves.toEqual({
+      requestType: ['student', 'teacher', 'principal', 'school'],
+      school: [
+        { id: 'school-2', name: 'Active School' },
+        { id: 'school-3', name: 'Teacher School' },
+      ],
+    });
+  });
 });

--- a/src/services/api/supabase/SupabaseApi.program.requests.test.ts
+++ b/src/services/api/supabase/SupabaseApi.program.requests.test.ts
@@ -1,0 +1,67 @@
+import { SupabaseApiProgramRequests } from './SupabaseApi.program.requests';
+
+jest.mock('../../../utility/logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('./SupabaseApi.program.activityStats', () => ({
+  __esModule: true,
+  SupabaseApiProgramActivityStats: class {},
+}));
+
+describe('SupabaseApiProgramRequests.getRequestFilterOptions', () => {
+  it('returns unique schools with pending requests in alphabetical order', async () => {
+    type SchoolRow = {
+      school: { id: string; name: string } | null;
+    };
+    type Chain = {
+      data: SchoolRow[];
+      error: null;
+      select: jest.Mock<Chain, []>;
+      eq: jest.Mock<Chain, [string, unknown]>;
+      not: jest.Mock<Chain, [string, string, unknown]>;
+    };
+
+    const rows = [
+      { school: { id: 'school-2', name: 'Beta School' } },
+      { school: { id: 'school-1', name: 'Alpha School' } },
+      { school: { id: 'school-2', name: 'Beta School' } },
+      { school: null },
+    ];
+
+    const chain = {} as Chain;
+    chain.data = rows;
+    chain.error = null;
+    chain.select = jest.fn(() => chain);
+    chain.eq = jest.fn(() => chain);
+    chain.not = jest.fn(() => chain);
+
+    const supabase = {
+      from: jest.fn(() => chain),
+    };
+
+    const api =
+      new SupabaseApiProgramRequests() as SupabaseApiProgramRequests & {
+        supabase: typeof supabase;
+      };
+    api.supabase = supabase;
+
+    await expect(api.getRequestFilterOptions('requested')).resolves.toEqual({
+      requestType: ['student', 'teacher', 'principal', 'school'],
+      school: [
+        { id: 'school-1', name: 'Alpha School' },
+        { id: 'school-2', name: 'Beta School' },
+      ],
+    });
+
+    expect(supabase.from).toHaveBeenCalledWith('ops_requests');
+    expect(chain.eq).toHaveBeenCalledWith('request_status', 'requested');
+    expect(chain.not).toHaveBeenCalledWith('school_id', 'is', null);
+  });
+});

--- a/src/services/api/supabase/SupabaseApi.program.requests.ts
+++ b/src/services/api/supabase/SupabaseApi.program.requests.ts
@@ -68,12 +68,16 @@ export class SupabaseApiProgramRequests extends SupabaseApiProgramActivityStats 
       if (!this.supabase) return null;
 
       const requestTypes = [...Constants.public.Enums.ops_request_type];
+      const isRequestedStatus =
+        requestStatus === Constants.public.Enums.ops_request_status[0];
 
       const schoolResponse = await this.supabase
         .from('ops_requests')
         .select(
           `
           school_id,
+          request_type,
+          request_ends_at,
           school:school_id (
             id,
             name
@@ -90,8 +94,22 @@ export class SupabaseApiProgramRequests extends SupabaseApiProgramActivityStats 
       }
 
       const schoolMap = new Map<string, { id: string; name: string }>();
+      const now = Date.now();
 
       ((schoolResponse.data as any[]) || []).forEach((item) => {
+        if (
+          isRequestedStatus &&
+          item?.request_type === Constants.public.Enums.ops_request_type[0]
+        ) {
+          const requestEndsAt = item?.request_ends_at
+            ? Date.parse(item.request_ends_at)
+            : NaN;
+
+          if (!Number.isFinite(requestEndsAt) || requestEndsAt <= now) {
+            return;
+          }
+        }
+
         const school = item?.school;
         if (!school?.id || !school?.name) return;
 

--- a/src/services/api/supabase/SupabaseApi.program.requests.ts
+++ b/src/services/api/supabase/SupabaseApi.program.requests.ts
@@ -63,25 +63,26 @@ export class SupabaseApiProgramRequests extends SupabaseApiProgramActivityStats 
     }
   }
 
-  async getRequestFilterOptions() {
+  async getRequestFilterOptions(requestStatus: EnumType<'ops_request_status'>) {
     try {
       if (!this.supabase) return null;
 
       const requestTypes = [...Constants.public.Enums.ops_request_type];
 
       const schoolResponse = await this.supabase
-        .from(TABLES.School)
+        .from('ops_requests')
         .select(
           `
-          id,
-          name,
-          ops_requests!inner()
+          school_id,
+          school:school_id (
+            id,
+            name
+          )
         `,
         )
         .eq('is_deleted', false)
-        .eq('ops_requests.is_deleted', false)
-        .not('ops_requests.school_id', 'is', null)
-        .order('name', { ascending: true });
+        .eq('request_status', requestStatus)
+        .not('school_id', 'is', null);
 
       if (schoolResponse.error) {
         logger.error('Failed to fetch schools:', schoolResponse.error.message);
@@ -91,15 +92,18 @@ export class SupabaseApiProgramRequests extends SupabaseApiProgramActivityStats 
       const schoolMap = new Map<string, { id: string; name: string }>();
 
       ((schoolResponse.data as any[]) || []).forEach((item) => {
-        if (item?.id && item?.name) {
-          schoolMap.set(item.id, {
-            id: item.id,
-            name: item.name,
-          });
-        }
+        const school = item?.school;
+        if (!school?.id || !school?.name) return;
+
+        schoolMap.set(school.id, {
+          id: school.id,
+          name: school.name,
+        });
       });
 
-      const uniqueSchools = Array.from(schoolMap.values());
+      const uniqueSchools = Array.from(schoolMap.values()).sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+      );
 
       return {
         requestType: requestTypes,


### PR DESCRIPTION
- Make the School filter tab-aware and keep each tab’s filter state separate.  

- Show only schools with relevant pending requests, sorted alphabetically, and keep search results stable after selection.  

- Align the requested-tab dropdown source with the RPC’s requested rules so expired student-only requests are excluded.  

- Add/adjust test coverage for school filter option behavior and requested-tab filtering consistency.