### PR TITLE
fix(chim-1251): allow Field Coordinators to view all school interactions

### DIFF
--- a/src/ops-console/pages/SidebarPage.tsx
+++ b/src/ops-console/pages/SidebarPage.tsx
@@ -122,6 +122,8 @@ const SidebarPage: React.FC = () => {
 
     const schoolListPath = `${path}${PAGES.SCHOOL_LIST}`;
     const schoolDetailsPrefix = `${path}${PAGES.SCHOOL_LIST}${PAGES.SCHOOL_DETAILS}/`;
+    const activitiesPath = `${schoolListPath}${PAGES.ACTIVITIES_PAGE}`;
+    const schoolActivitiesPath = `${activitiesPath}${PAGES.SCHOOL_ACTIVITIES}`;
     const campaignsPath = `${path}${PAGES.ADMIN_CAMPAIGNS}`;
     const campaignDetailsPrefix = `${campaignsPath}/`;
     const campaignCreatePath = `${path}${PAGES.ADMIN_CAMPAIGNS_NEW}`;
@@ -142,7 +144,9 @@ const SidebarPage: React.FC = () => {
           location.pathname.startsWith(requestDetailsPrefix) ||
           location.pathname === devicesPath ||
           location.pathname === resourcesPath ||
-          location.pathname === dashboardPath));
+          location.pathname === dashboardPath ||
+          location.pathname === activitiesPath ||
+          location.pathname === schoolActivitiesPath));
 
     if (!isAllowedPath) {
       history.replace(schoolListPath);


### PR DESCRIPTION
[CHIM-1251](https://chimple.atlassian.net/browse/CHIM-1251)

## Summary

Fixed an issue where Field Coordinators were redirected to the Schools listing page when clicking **View All Interactions**.

## Changes

- Added the View All Interactions route to the Field Coordinator allowed paths.
- Added the interaction details route to the Field Coordinator allowed paths.
- Preserved existing role-based navigation behavior.

## Result

<img width="1366" height="720" alt="image" src="https://github.com/user-attachments/assets/3abc1fc3-d6fc-427f-b301-9d097b8f4f4c" />
<img width="1366" height="720" alt="image" src="https://github.com/user-attachments/assets/7150ef25-72e7-402b-a622-affe6a031855" />


[CHIM-1251]: https://chimple.atlassian.net/browse/CHIM-1251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ