### PR TITLE
Add build-open-apk script with bundle support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -155,6 +155,7 @@
         "husky": "^9.1.7",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
+        "jszip": "^3.10.1",
         "lint-staged": "^16.3.3",
         "prettier": "^3.8.1",
         "prop-types": "^15.8.1",
@@ -162,6 +163,7 @@
         "storybook": "^10.4.6",
         "storybook-react-i18next": "^10.1.2",
         "ts-jest": "^29.4.6",
+        "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
         "vite": "^7.0.4",
         "webpack": "^5.101.3"
@@ -3337,6 +3339,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -7192,9 +7218,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7212,9 +7235,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7232,9 +7252,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7252,9 +7269,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7272,9 +7286,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7292,9 +7303,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7312,9 +7320,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7332,9 +7337,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7566,9 +7568,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7583,9 +7582,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7600,9 +7596,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7617,9 +7610,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7634,9 +7624,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7651,9 +7638,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7668,9 +7652,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7685,9 +7666,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8156,9 +8134,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8173,9 +8148,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8216,9 +8188,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8233,9 +8202,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8250,9 +8216,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8267,9 +8230,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8284,9 +8244,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8301,9 +8258,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8318,9 +8272,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9127,6 +9078,34 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
@@ -10940,6 +10919,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/adler-32": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
@@ -11146,6 +11138,13 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -12579,6 +12578,13 @@
         "node": ">= 14"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-fetch": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
@@ -12949,6 +12955,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {
@@ -22550,6 +22566,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -22986,6 +23046,13 @@
       "bin": {
         "uuid": "dist-node/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -23567,9 +23634,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -23584,9 +23648,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -23601,9 +23662,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -23618,9 +23676,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24549,6 +24604,16 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "build:android": "tsc -p tsconfig.build.json && vite build && npx @capawesome/cli manifests:generate --path dist && npx cap sync android",
     "build:storybook": "storybook build",
     "build:full": "npm run build",
+    "build:open-apk": "ts-node scripts/build-open-apk.ts",
     "create-check-sum": "node scripts/check_sum_generator.js",
     "serve-build": "http-server dist",
     "test": "jest --config jest.config.js",
@@ -199,6 +200,7 @@
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-storybook": "^0.10.0",
     "http-server": "^14.1.1",
+    "jszip": "^3.10.1",
     "husky": "^9.1.7",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
@@ -209,6 +211,7 @@
     "storybook": "^10.4.6",
     "storybook-react-i18next": "^10.1.2",
     "ts-jest": "^29.4.6",
+    "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
     "vite": "^7.0.4",
     "webpack": "^5.101.3"

--- a/scripts/build-open-apk.ts
+++ b/scripts/build-open-apk.ts
@@ -1,5 +1,23 @@
+// - Copy/extract lesson ZIPs from local D:\chimple-zips first, then fall back to prod remote bundle URLs
+// - Add full-path mascot .riv input and copy it into bundled app assets
+// - Continue APK builds while reporting missing bundles unless --fail-on-missing is passed
+
+// Run locally:
+
+// npx ts-node scripts/build-open-apk.ts --language=pt --avatar=G:\mascot_with_accessories_sep_2025.riv --course_ids=0937c891-9bed-4fa2-b422-ad3bee7f4569 --output=G:\open-apk-output
+
+// npx ts-node scripts/build-open-apk.ts --language=pt --avatar=G:\mascot_with_accessories_sep_2025.riv --course_ids=0937c891-9bed-4fa2-b422-ad3bee7f4569 --output=G:\open-apk-output --zip-source=D:\chimple-zips
+
+// Optional flags:
+
+// --skip-build       Prepare bundles only, do not build APK
+// --dry-run          Resolve lessons and write manifest only
+// --zip-source=PATH  Override local ZIP folder, defaults to D:\chimple-zips
+// --fail-on-missing  Stop if any bundle cannot be found
+
 import JSZip from 'jszip';
 import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
@@ -20,6 +38,7 @@ type CourseRow = {
   id: string;
   code: string | null;
   name: string | null;
+  subject_id?: string | null;
 };
 
 type ChapterRow = {
@@ -77,6 +96,17 @@ type BundleManifestEntry = {
   error?: string;
 };
 
+type ImageManifestEntry = {
+  table: string;
+  rowId: string;
+  column: string;
+  originalUrl: string;
+  localPath?: string;
+  filePath?: string;
+  status: 'already-present' | 'downloaded' | 'missing' | 'dry-run';
+  error?: string;
+};
+
 type Manifest = {
   generatedAt: string;
   language: string;
@@ -89,6 +119,9 @@ type Manifest = {
   chapterLessonCount: number;
   lessonCount: number;
   bundleCount: number;
+  imageAssetCount: number;
+  imageAssets: ImageManifestEntry[];
+  importJsonRewrittenForBuild: boolean;
   bundles: BundleManifestEntry[];
 };
 
@@ -101,6 +134,12 @@ const lessonBundlesDir = path.join(
 );
 const tmpRoot = path.join(lessonBundlesDir, '.tmp-open-apk');
 const manifestPath = path.join(repoRoot, 'scripts', 'open-apk-manifest.json');
+const imageAssetsDir = path.join(
+  repoRoot,
+  'public',
+  'assets',
+  'open-apk-images',
+);
 const importJsonPath = path.join(
   repoRoot,
   'public',
@@ -116,14 +155,15 @@ const pathwayMascotPath = path.join(
 );
 
 const remoteBundleBaseUrls = [
-  'https://chimple-bundles.web.app/',
   'https://pub-9d27d46558f64e93a979827424d3e766.r2.dev/',
+  'https://chimple-bundles.web.app/',
   'https://cuba-stage-zip-bundle.web.app/',
   'https://cdn.jsdelivr.net/gh/chimple/chimple-zips@main/',
   'https://raw.githubusercontent.com/chimple/chimple-zips/main/',
 ];
 
 const unique = <T>(items: T[]): T[] => Array.from(new Set(items));
+const imageColumnNames = new Set(['image', 'image_url', 'thumbnail', 'icon']);
 
 const parseArgs = (argv: string[]): CliOptions => {
   const raw: Record<string, string | boolean> = {};
@@ -217,6 +257,53 @@ const fileExists = async (filePath: string): Promise<boolean> => {
   }
 };
 
+const isRemoteUrl = (value: unknown): value is string =>
+  typeof value === 'string' && /^https?:\/\//i.test(value.trim());
+
+const getPublicImagePath = (url: string): string => {
+  const parsedUrl = new URL(url);
+  const extension = path.extname(parsedUrl.pathname).toLowerCase();
+  const safeExtension =
+    extension && extension.length <= 8
+      ? extension.replace(/[^a-z0-9.]/g, '')
+      : '';
+  const hash = crypto
+    .createHash('sha256')
+    .update(url)
+    .digest('hex')
+    .slice(0, 24);
+  return `/assets/open-apk-images/${hash}${safeExtension || '.bin'}`;
+};
+
+const downloadImageAsset = async (
+  url: string,
+): Promise<{
+  localPath: string;
+  filePath: string;
+  status: 'already-present' | 'downloaded';
+}> => {
+  const localPath = getPublicImagePath(url);
+  const filePath = path.join(repoRoot, 'public', localPath.replace(/^\//, ''));
+
+  if (await fileExists(filePath)) {
+    return { localPath, filePath, status: 'already-present' };
+  }
+
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) continue;
+      await fs.writeFile(filePath, Buffer.from(await response.arrayBuffer()));
+      return { localPath, filePath, status: 'downloaded' };
+    } catch {
+      // Try again; transient image CDN failures should not block the whole graph.
+    }
+  }
+
+  throw new Error(`Unable to download image: ${url}`);
+};
+
 const prepareAvatar = async (
   avatar: string,
 ): Promise<{ avatarPath: string; pathwayMascotPath: string }> => {
@@ -255,11 +342,6 @@ const isActiveRow = (row: { is_deleted?: unknown }): boolean =>
   row.is_deleted === 0 ||
   row.is_deleted === '0' ||
   row.is_deleted == null;
-
-const readImportJson = async (): Promise<ImportJson> => {
-  const content = await fs.readFile(importJsonPath, 'utf8');
-  return JSON.parse(content) as ImportJson;
-};
 
 const readRows = <T extends Record<string, unknown>>(
   importJson: ImportJson,
@@ -360,6 +442,99 @@ const resolveLessons = (
   ).filter((lesson) => lessonIds.includes(lesson.id) && isActiveRow(lesson));
 
   return { courses, chapters, chapterLessons, lessons };
+};
+
+const getSubjectRowsForCourses = (
+  importJson: ImportJson,
+  courses: CourseRow[],
+) => {
+  const subjectIds = new Set(
+    courses
+      .map((course) => course.subject_id)
+      .filter((subjectId): subjectId is string => !!subjectId),
+  );
+
+  if (subjectIds.size === 0) return [];
+
+  return readRows<{ id: string; is_deleted?: unknown }>(
+    importJson,
+    'subject',
+  ).filter((subject) => subjectIds.has(subject.id) && isActiveRow(subject));
+};
+
+const rewriteSelectedImageUrls = async (
+  importJson: ImportJson,
+  selectedRowsByTable: Map<string, Set<string>>,
+  dryRun: boolean,
+): Promise<ImageManifestEntry[]> => {
+  const imageAssets: ImageManifestEntry[] = [];
+  const downloadCache = new Map<
+    string,
+    Pick<ImageManifestEntry, 'localPath' | 'filePath' | 'status' | 'error'>
+  >();
+
+  for (const table of importJson.tables) {
+    const selectedIds = selectedRowsByTable.get(table.name);
+    if (!selectedIds || selectedIds.size === 0) continue;
+
+    const idIndex = table.schema.findIndex((column) => column.column === 'id');
+    if (idIndex < 0) continue;
+
+    const imageColumnIndexes = table.schema
+      .map((column, index) => ({ column: column.column, index }))
+      .filter(({ column }) => imageColumnNames.has(column));
+
+    if (imageColumnIndexes.length === 0) continue;
+
+    for (const row of table.values ?? []) {
+      const rowId = String(row[idIndex] ?? '');
+      if (!selectedIds.has(rowId)) continue;
+
+      for (const { column, index } of imageColumnIndexes) {
+        const originalUrl = row[index];
+        if (!isRemoteUrl(originalUrl)) continue;
+
+        if (dryRun) {
+          imageAssets.push({
+            table: table.name,
+            rowId,
+            column,
+            originalUrl,
+            localPath: getPublicImagePath(originalUrl),
+            status: 'dry-run',
+          });
+          continue;
+        }
+
+        let cached = downloadCache.get(originalUrl);
+        if (!cached) {
+          try {
+            cached = await downloadImageAsset(originalUrl);
+          } catch (error: any) {
+            cached = {
+              status: 'missing',
+              error: error?.message ?? String(error),
+            };
+          }
+          downloadCache.set(originalUrl, cached);
+        }
+
+        imageAssets.push({
+          table: table.name,
+          rowId,
+          column,
+          originalUrl,
+          ...cached,
+        });
+
+        if (cached.localPath) {
+          row[index] = cached.localPath;
+        }
+      }
+    }
+  }
+
+  return imageAssets;
 };
 
 const getBundleId = (lesson: LessonRow): string | null =>
@@ -594,7 +769,9 @@ const main = async (): Promise<void> => {
   const options = parseArgs(process.argv.slice(2));
 
   await fs.mkdir(lessonBundlesDir, { recursive: true });
-  const importJson = await readImportJson();
+  await fs.mkdir(imageAssetsDir, { recursive: true });
+  const originalImportJsonContent = await fs.readFile(importJsonPath, 'utf8');
+  const importJson = JSON.parse(originalImportJsonContent) as ImportJson;
   const avatar = await prepareAvatar(options.avatar);
 
   const language = resolveLanguage(importJson, options.language);
@@ -606,6 +783,24 @@ const main = async (): Promise<void> => {
     courseIds,
     language?.id ?? null,
   );
+  const subjects = getSubjectRowsForCourses(importJson, courses);
+
+  const selectedRowsByTable = new Map<string, Set<string>>([
+    ['subject', new Set(subjects.map((subject) => subject.id))],
+    ['course', new Set(courses.map((course) => course.id))],
+    ['chapter', new Set(chapters.map((chapter) => chapter.id))],
+    ['lesson', new Set(lessons.map((lesson) => lesson.id))],
+  ]);
+
+  const imageAssets = await rewriteSelectedImageUrls(
+    importJson,
+    selectedRowsByTable,
+    options.dryRun,
+  );
+  const importJsonNeedsRewrite =
+    !options.dryRun &&
+    !options.skipBuild &&
+    imageAssets.some((asset) => asset.localPath);
 
   const lessonsByBundle = new Map<string, string[]>();
   const bundleVersions = new Map<string, number>();
@@ -653,6 +848,9 @@ const main = async (): Promise<void> => {
     chapterLessonCount: chapterLessons.length,
     lessonCount: lessons.length,
     bundleCount: lessonsByBundle.size,
+    imageAssetCount: imageAssets.length,
+    imageAssets,
+    importJsonRewrittenForBuild: importJsonNeedsRewrite,
     bundles,
   };
 
@@ -681,8 +879,22 @@ const main = async (): Promise<void> => {
     );
   }
 
+  const missingImages = imageAssets.filter(
+    (asset) => asset.status === 'missing',
+  );
+  if (missingImages.length > 0) {
+    console.warn(
+      `Missing image assets: ${missingImages
+        .map((asset) => `${asset.table}.${asset.column}:${asset.rowId}`)
+        .join(', ')}`,
+    );
+  }
+
   console.log(
     `Prepared ${bundles.length} bundles: ${bundles.filter((bundle) => bundle.status === 'extracted').length} extracted, ${bundles.filter((bundle) => bundle.status === 'already-extracted').length} already present.`,
+  );
+  console.log(
+    `Prepared ${imageAssets.length} image assets: ${imageAssets.filter((asset) => asset.status === 'downloaded').length} downloaded, ${imageAssets.filter((asset) => asset.status === 'already-present').length} already present.`,
   );
 
   if (options.skipBuild || options.dryRun) {
@@ -690,7 +902,24 @@ const main = async (): Promise<void> => {
     return;
   }
 
-  await buildAndCopyApk(path.resolve(options.output));
+  try {
+    if (importJsonNeedsRewrite) {
+      await fs.writeFile(
+        importJsonPath,
+        `${JSON.stringify(importJson, null, 2)}\n`,
+      );
+      console.log(
+        'Temporarily rewrote public/databases/import.json with bundled image paths for this APK build.',
+      );
+    }
+
+    await buildAndCopyApk(path.resolve(options.output));
+  } finally {
+    if (importJsonNeedsRewrite) {
+      await fs.writeFile(importJsonPath, originalImportJsonContent);
+      console.log('Restored original public/databases/import.json.');
+    }
+  }
 };
 
 main().catch((error) => {

--- a/scripts/build-open-apk.ts
+++ b/scripts/build-open-apk.ts
@@ -1,0 +1,699 @@
+import JSZip from 'jszip';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+type CliOptions = {
+  language: string;
+  avatar: string;
+  courseIds: string[];
+  output: string;
+  zipSource: string;
+  skipBuild: boolean;
+  dryRun: boolean;
+  force: boolean;
+  failOnMissing: boolean;
+};
+
+type CourseRow = {
+  id: string;
+  code: string | null;
+  name: string | null;
+};
+
+type ChapterRow = {
+  id: string;
+  course_id: string | null;
+  name: string | null;
+  sort_index: number | null;
+};
+
+type ChapterLessonRow = {
+  chapter_id: string | null;
+  language_id: string | null;
+  lesson_id: string | null;
+  locale_id: string | null;
+  sort_index: number | null;
+};
+
+type LanguageRow = {
+  id: string;
+  code: string | null;
+  name?: string | null;
+};
+
+type ImportJsonColumn = {
+  column: string;
+  value: string;
+};
+
+type ImportJsonTable = {
+  name: string;
+  schema: ImportJsonColumn[];
+  values?: unknown[][];
+};
+
+type ImportJson = {
+  tables: ImportJsonTable[];
+};
+
+type LessonRow = {
+  id: string;
+  name: string | null;
+  cocos_lesson_id: string | null;
+  lido_lesson_id: string | null;
+  version: number | null;
+};
+
+type BundleManifestEntry = {
+  bundleId: string;
+  lessonIds: string[];
+  status: 'already-extracted' | 'extracted' | 'missing' | 'dry-run';
+  source?: string;
+  sourceUrl?: string;
+  zipPath?: string;
+  dbVersion?: number;
+  error?: string;
+};
+
+type Manifest = {
+  generatedAt: string;
+  language: string;
+  languageId: string | null;
+  avatar: string;
+  pathwayMascot: string;
+  courseIds: string[];
+  courses: CourseRow[];
+  chapterCount: number;
+  chapterLessonCount: number;
+  lessonCount: number;
+  bundleCount: number;
+  bundles: BundleManifestEntry[];
+};
+
+const repoRoot = process.cwd();
+const lessonBundlesDir = path.join(
+  repoRoot,
+  'public',
+  'assets',
+  'lessonBundles',
+);
+const tmpRoot = path.join(lessonBundlesDir, '.tmp-open-apk');
+const manifestPath = path.join(repoRoot, 'scripts', 'open-apk-manifest.json');
+const importJsonPath = path.join(
+  repoRoot,
+  'public',
+  'databases',
+  'import.json',
+);
+const animationAssetsDir = path.join(repoRoot, 'public', 'assets', 'animation');
+const pathwayMascotPath = path.join(
+  repoRoot,
+  'public',
+  'pathwayAssets',
+  'chimpleRive.riv',
+);
+
+const remoteBundleBaseUrls = [
+  'https://chimple-bundles.web.app/',
+  'https://pub-9d27d46558f64e93a979827424d3e766.r2.dev/',
+  'https://cuba-stage-zip-bundle.web.app/',
+  'https://cdn.jsdelivr.net/gh/chimple/chimple-zips@main/',
+  'https://raw.githubusercontent.com/chimple/chimple-zips/main/',
+];
+
+const unique = <T>(items: T[]): T[] => Array.from(new Set(items));
+
+const parseArgs = (argv: string[]): CliOptions => {
+  const raw: Record<string, string | boolean> = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+
+    const trimmed = arg.slice(2);
+    const equalsIndex = trimmed.indexOf('=');
+    if (equalsIndex >= 0) {
+      raw[trimmed.slice(0, equalsIndex)] = trimmed.slice(equalsIndex + 1);
+      continue;
+    }
+
+    const next = argv[index + 1];
+    if (!next || next.startsWith('--')) {
+      raw[trimmed] = true;
+      continue;
+    }
+
+    raw[trimmed] = next;
+    index += 1;
+  }
+
+  const getString = (key: string): string | undefined => {
+    const value = raw[key];
+    return typeof value === 'string' ? value.trim() : undefined;
+  };
+
+  const courseIds = (
+    getString('course_ids') ??
+    getString('course-ids') ??
+    getString('course_id') ??
+    getString('course-id') ??
+    ''
+  )
+    .split(',')
+    .map((courseId) => courseId.trim())
+    .filter(Boolean);
+
+  const options: CliOptions = {
+    language: getString('language') ?? '',
+    avatar: getString('avatar') ?? '',
+    courseIds,
+    output: getString('output') ?? '',
+    zipSource: getString('zip-source') ?? 'D:\\chimple-zips',
+    skipBuild: raw['skip-build'] === true,
+    dryRun: raw['dry-run'] === true,
+    force: raw.force === true,
+    failOnMissing: raw['fail-on-missing'] === true,
+  };
+
+  const missing = [
+    ['language', options.language],
+    ['avatar', options.avatar],
+    ['course_ids', options.courseIds.length ? 'ok' : ''],
+    ['output', options.output],
+  ]
+    .filter(([, value]) => !value)
+    .map(([key]) => `--${key}`);
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required argument(s): ${missing.join(', ')}`);
+  }
+
+  return options;
+};
+
+const safeWithin = (parent: string, child: string): boolean => {
+  const relative = path.relative(parent, child);
+  return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+};
+
+const ensureCleanTmpDir = async (dir: string): Promise<void> => {
+  if (!safeWithin(tmpRoot, dir)) {
+    throw new Error(`Refusing to clean unsafe temp directory: ${dir}`);
+  }
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(dir, { recursive: true });
+};
+
+const fileExists = async (filePath: string): Promise<boolean> => {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const prepareAvatar = async (
+  avatar: string,
+): Promise<{ avatarPath: string; pathwayMascotPath: string }> => {
+  const sourcePath = path.isAbsolute(avatar)
+    ? avatar
+    : path.join(animationAssetsDir, avatar);
+
+  if (!(await fileExists(sourcePath))) {
+    throw new Error(`Avatar asset not found: ${sourcePath}`);
+  }
+
+  if (path.extname(sourcePath).toLowerCase() !== '.riv') {
+    throw new Error(`Avatar must be a .riv file: ${sourcePath}`);
+  }
+
+  await fs.mkdir(animationAssetsDir, { recursive: true });
+  const animationAssetPath = path.join(
+    animationAssetsDir,
+    path.basename(sourcePath),
+  );
+
+  if (path.resolve(sourcePath) !== path.resolve(animationAssetPath)) {
+    await fs.copyFile(sourcePath, animationAssetPath);
+  }
+
+  await fs.copyFile(sourcePath, pathwayMascotPath);
+
+  return {
+    avatarPath: animationAssetPath,
+    pathwayMascotPath,
+  };
+};
+
+const isActiveRow = (row: { is_deleted?: unknown }): boolean =>
+  row.is_deleted === false ||
+  row.is_deleted === 0 ||
+  row.is_deleted === '0' ||
+  row.is_deleted == null;
+
+const readImportJson = async (): Promise<ImportJson> => {
+  const content = await fs.readFile(importJsonPath, 'utf8');
+  return JSON.parse(content) as ImportJson;
+};
+
+const readRows = <T extends Record<string, unknown>>(
+  importJson: ImportJson,
+  tableName: string,
+): T[] => {
+  const table = importJson.tables.find(
+    (candidate) => candidate.name === tableName,
+  );
+  if (!table) throw new Error(`Table not found in import.json: ${tableName}`);
+
+  const columns = table.schema.map((column) => column.column);
+  return (table.values ?? []).map((values) => {
+    const row: Record<string, unknown> = {};
+    columns.forEach((column, index) => {
+      row[column] = values[index];
+    });
+    return row as T;
+  });
+};
+
+const resolveLanguage = (
+  importJson: ImportJson,
+  languageCode: string,
+): LanguageRow | null => {
+  const language = readRows<LanguageRow & { is_deleted?: unknown }>(
+    importJson,
+    'language',
+  ).find(
+    (row) =>
+      isActiveRow(row) &&
+      row.code?.trim().toLowerCase() === languageCode.trim().toLowerCase(),
+  );
+
+  if (!language?.id) {
+    console.warn(
+      `Language code not found in import.json: ${languageCode}. Continuing without chapter_lesson language filtering.`,
+    );
+    return null;
+  }
+
+  return language;
+};
+
+const resolveLessons = (
+  importJson: ImportJson,
+  courseIds: string[],
+  languageId: string | null,
+) => {
+  const courses = readRows<CourseRow & { is_deleted?: unknown }>(
+    importJson,
+    'course',
+  ).filter((course) => courseIds.includes(course.id) && isActiveRow(course));
+  const foundCourseIds = new Set(courses.map((course) => course.id));
+  const missingCourseIds = courseIds.filter(
+    (courseId) => !foundCourseIds.has(courseId),
+  );
+
+  if (missingCourseIds.length > 0) {
+    throw new Error(`Course ID(s) not found: ${missingCourseIds.join(', ')}`);
+  }
+
+  const chapters = readRows<ChapterRow & { is_deleted?: unknown }>(
+    importJson,
+    'chapter',
+  )
+    .filter(
+      (chapter) =>
+        !!chapter.course_id &&
+        courseIds.includes(chapter.course_id) &&
+        isActiveRow(chapter),
+    )
+    .sort((a, b) => (a.sort_index ?? 0) - (b.sort_index ?? 0));
+
+  const chapterIds = unique(chapters.map((chapter) => chapter.id));
+  const chapterLessons = readRows<ChapterLessonRow & { is_deleted?: unknown }>(
+    importJson,
+    'chapter_lesson',
+  )
+    .filter(
+      (chapterLesson) =>
+        !!chapterLesson.chapter_id &&
+        chapterIds.includes(chapterLesson.chapter_id) &&
+        isActiveRow(chapterLesson) &&
+        (!languageId ||
+          chapterLesson.language_id == null ||
+          chapterLesson.language_id === languageId),
+    )
+    .sort((a, b) => (a.sort_index ?? 0) - (b.sort_index ?? 0));
+
+  const lessonIds = unique(
+    chapterLessons
+      .map((chapterLesson) => chapterLesson.lesson_id)
+      .filter((lessonId): lessonId is string => !!lessonId),
+  );
+  const lessons = readRows<LessonRow & { is_deleted?: unknown }>(
+    importJson,
+    'lesson',
+  ).filter((lesson) => lessonIds.includes(lesson.id) && isActiveRow(lesson));
+
+  return { courses, chapters, chapterLessons, lessons };
+};
+
+const getBundleId = (lesson: LessonRow): string | null =>
+  lesson.lido_lesson_id ?? lesson.cocos_lesson_id ?? null;
+
+const downloadZip = async (
+  bundleId: string,
+): Promise<{ data: Buffer; sourceUrl: string } | null> => {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    for (const baseUrl of remoteBundleBaseUrls) {
+      const zipUrl = new URL(
+        `${bundleId}.zip`,
+        baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`,
+      ).toString();
+
+      try {
+        console.log(`Trying remote bundle: ${zipUrl}`);
+        const response = await fetch(zipUrl);
+        if (!response.ok) continue;
+        return {
+          data: Buffer.from(await response.arrayBuffer()),
+          sourceUrl: zipUrl,
+        };
+      } catch (error) {
+        console.warn(`Remote bundle failed: ${zipUrl}`);
+      }
+    }
+  }
+  return null;
+};
+
+const detectCommonRoot = (fileNames: string[], bundleId: string): string => {
+  if (fileNames.includes('index.xml')) return '';
+
+  const roots = unique(
+    fileNames
+      .map((fileName) => fileName.replace(/\\/g, '/').split('/')[0])
+      .filter(Boolean),
+  );
+
+  if (roots.length !== 1) return '';
+
+  const root = roots[0];
+  const rootPrefix = `${root}/`;
+  if (fileNames.includes(`${rootPrefix}index.xml`)) return rootPrefix;
+  if (root === bundleId) return rootPrefix;
+  return '';
+};
+
+const extractZipToBundleDir = async (
+  zipData: Buffer,
+  bundleId: string,
+  force: boolean,
+  dbVersion: number,
+): Promise<void> => {
+  const finalDir = path.join(lessonBundlesDir, bundleId);
+  const indexPath = path.join(finalDir, 'index.xml');
+
+  if (await fileExists(indexPath)) return;
+
+  if ((await fileExists(finalDir)) && !force) {
+    throw new Error(
+      `Bundle folder exists without index.xml: ${finalDir}. Re-run with --force to replace it.`,
+    );
+  }
+
+  await fs.mkdir(tmpRoot, { recursive: true });
+  const tmpDir = path.join(tmpRoot, `${bundleId}-${process.pid}`);
+  await ensureCleanTmpDir(tmpDir);
+
+  try {
+    const zip = await JSZip.loadAsync(zipData);
+    const files = Object.values(zip.files).filter((file) => !file.dir);
+    const normalizedNames = files.map((file) => file.name.replace(/\\/g, '/'));
+    const commonRoot = detectCommonRoot(normalizedNames, bundleId);
+
+    for (const file of files) {
+      const normalizedName = file.name.replace(/\\/g, '/');
+      const relativeName = commonRoot
+        ? normalizedName.slice(commonRoot.length)
+        : normalizedName;
+
+      if (!relativeName || relativeName.startsWith('../')) continue;
+
+      const outputPath = path.resolve(tmpDir, relativeName);
+      if (!safeWithin(tmpDir, outputPath)) {
+        throw new Error(`Unsafe ZIP entry path: ${file.name}`);
+      }
+
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+      await fs.writeFile(outputPath, await file.async('nodebuffer'));
+    }
+
+    if (!(await fileExists(path.join(tmpDir, 'index.xml')))) {
+      throw new Error(
+        `Extracted bundle ${bundleId} does not contain index.xml`,
+      );
+    }
+
+    await fs.writeFile(path.join(tmpDir, '.version'), String(dbVersion));
+
+    if (force) {
+      await fs.rm(finalDir, { recursive: true, force: true });
+    }
+    await fs.rename(tmpDir, finalDir);
+  } catch (error) {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+    throw error;
+  }
+};
+
+const prepareBundle = async (
+  bundleId: string,
+  lessonIds: string[],
+  dbVersion: number,
+  options: CliOptions,
+): Promise<BundleManifestEntry> => {
+  const finalIndexPath = path.join(lessonBundlesDir, bundleId, 'index.xml');
+  if (await fileExists(finalIndexPath)) {
+    return {
+      bundleId,
+      lessonIds,
+      status: 'already-extracted',
+      source: 'bundled',
+      dbVersion,
+    };
+  }
+
+  if (options.dryRun) {
+    return { bundleId, lessonIds, status: 'dry-run', dbVersion };
+  }
+
+  const localZipPath = path.join(options.zipSource, `${bundleId}.zip`);
+  if (await fileExists(localZipPath)) {
+    const zipData = await fs.readFile(localZipPath);
+    await extractZipToBundleDir(zipData, bundleId, options.force, dbVersion);
+    return {
+      bundleId,
+      lessonIds,
+      status: 'extracted',
+      source: 'local',
+      zipPath: localZipPath,
+      dbVersion,
+    };
+  }
+
+  const remoteZip = await downloadZip(bundleId);
+  if (remoteZip) {
+    await extractZipToBundleDir(
+      remoteZip.data,
+      bundleId,
+      options.force,
+      dbVersion,
+    );
+    return {
+      bundleId,
+      lessonIds,
+      status: 'extracted',
+      source: 'remote',
+      sourceUrl: remoteZip.sourceUrl,
+      dbVersion,
+    };
+  }
+
+  return {
+    bundleId,
+    lessonIds,
+    status: 'missing',
+    dbVersion,
+    error: `No ZIP found locally or remotely for ${bundleId}`,
+  };
+};
+
+const run = (command: string, args: string[], cwd: string): void => {
+  console.log(`Running: ${command} ${args.join(' ')}`);
+  const result = spawnSync(command, args, {
+    cwd,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`Command failed: ${command} ${args.join(' ')}`);
+  }
+};
+
+const findReleaseApk = async (): Promise<string> => {
+  const releaseDir = path.join(
+    repoRoot,
+    'android',
+    'app',
+    'build',
+    'outputs',
+    'apk',
+    'release',
+  );
+  const entries = await fs.readdir(releaseDir, { withFileTypes: true });
+  const apks = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.apk'))
+    .map((entry) => path.join(releaseDir, entry.name));
+
+  if (apks.length < 1) {
+    throw new Error(`No release APK found in ${releaseDir}`);
+  }
+
+  const apkStats = await Promise.all(
+    apks.map(async (apkPath) => ({
+      apkPath,
+      stat: await fs.stat(apkPath),
+    })),
+  );
+  apkStats.sort((a, b) => b.stat.mtimeMs - a.stat.mtimeMs);
+  return apkStats[0].apkPath;
+};
+
+const buildAndCopyApk = async (outputDir: string): Promise<void> => {
+  run('npm', ['run', 'build:android'], repoRoot);
+  run(
+    process.platform === 'win32' ? 'gradlew.bat' : './gradlew',
+    ['assembleRelease'],
+    path.join(repoRoot, 'android'),
+  );
+
+  await fs.mkdir(outputDir, { recursive: true });
+  const apkPath = await findReleaseApk();
+  const targetPath = path.join(outputDir, path.basename(apkPath));
+  await fs.copyFile(apkPath, targetPath);
+  console.log(`APK copied to ${targetPath}`);
+};
+
+const main = async (): Promise<void> => {
+  const options = parseArgs(process.argv.slice(2));
+
+  await fs.mkdir(lessonBundlesDir, { recursive: true });
+  const importJson = await readImportJson();
+  const avatar = await prepareAvatar(options.avatar);
+
+  const language = resolveLanguage(importJson, options.language);
+  const courseIds = options.courseIds;
+
+  console.log(`Resolving lessons for course IDs: ${courseIds.join(', ')}`);
+  const { courses, chapters, chapterLessons, lessons } = await resolveLessons(
+    importJson,
+    courseIds,
+    language?.id ?? null,
+  );
+
+  const lessonsByBundle = new Map<string, string[]>();
+  const bundleVersions = new Map<string, number>();
+  const lessonsWithoutBundle = lessons.filter((lesson) => !getBundleId(lesson));
+  for (const lesson of lessons) {
+    const bundleId = getBundleId(lesson);
+    if (!bundleId) continue;
+    lessonsByBundle.set(bundleId, [
+      ...(lessonsByBundle.get(bundleId) ?? []),
+      lesson.id,
+    ]);
+    bundleVersions.set(
+      bundleId,
+      Math.max(bundleVersions.get(bundleId) ?? 1, Number(lesson.version ?? 1)),
+    );
+  }
+
+  const bundles: BundleManifestEntry[] = [];
+  for (const [bundleId, lessonIds] of lessonsByBundle) {
+    const dbVersion = bundleVersions.get(bundleId) ?? 1;
+    try {
+      bundles.push(
+        await prepareBundle(bundleId, lessonIds, dbVersion, options),
+      );
+    } catch (error: any) {
+      bundles.push({
+        bundleId,
+        lessonIds,
+        status: 'missing',
+        dbVersion,
+        error: error?.message ?? String(error),
+      });
+    }
+  }
+
+  const manifest: Manifest = {
+    generatedAt: new Date().toISOString(),
+    language: options.language,
+    languageId: language?.id ?? null,
+    avatar: avatar.avatarPath,
+    pathwayMascot: avatar.pathwayMascotPath,
+    courseIds,
+    courses,
+    chapterCount: chapters.length,
+    chapterLessonCount: chapterLessons.length,
+    lessonCount: lessons.length,
+    bundleCount: lessonsByBundle.size,
+    bundles,
+  };
+
+  await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(`Manifest written to ${manifestPath}`);
+
+  if (lessonsWithoutBundle.length > 0) {
+    console.warn(
+      `Lessons without lido_lesson_id/cocos_lesson_id: ${lessonsWithoutBundle.length}`,
+    );
+  }
+
+  const missingBundles = bundles.filter(
+    (bundle) => bundle.status === 'missing',
+  );
+  if (missingBundles.length > 0) {
+    const missingMessage = `Missing or invalid bundles: ${missingBundles
+      .map((bundle) => bundle.bundleId)
+      .join(', ')}`;
+    if (options.failOnMissing) {
+      throw new Error(missingMessage);
+    }
+    console.warn(missingMessage);
+    console.warn(
+      'Continuing APK build because --fail-on-missing was not provided.',
+    );
+  }
+
+  console.log(
+    `Prepared ${bundles.length} bundles: ${bundles.filter((bundle) => bundle.status === 'extracted').length} extracted, ${bundles.filter((bundle) => bundle.status === 'already-extracted').length} already present.`,
+  );
+
+  if (options.skipBuild || options.dryRun) {
+    console.log('Skipping APK build.');
+    return;
+  }
+
+  await buildAndCopyApk(path.resolve(options.output));
+};
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Add open APK bundle preparation script

- Add build-open-apk CLI for preparing offline lesson bundles before Android builds
- Resolve course lessons from public/databases/import.json using --course_ids
- Copy/extract lesson ZIPs from local D:\chimple-zips first, then fall back to prod remote bundle URLs
- Support full-path mascot .riv input and copy it into bundled app assets
- Continue APK builds while reporting missing bundles unless --fail-on-missing is passed

Run locally:

`npx ts-node scripts/build-open-apk.ts --language=pt --avatar=G:\mascot_with_accessories_sep_2025.riv --course_ids=0937c891-9bed-4fa2-b422-ad3bee7f4569 --output=G:\open-apk-output`

`npx ts-node scripts/build-open-apk.ts --language=pt --avatar=G:\mascot_with_accessories_sep_2025.riv --course_ids=0937c891-9bed-4fa2-b422-ad3bee7f4569 --output=G:\open-apk-output --zip-source=D:\chimple-zips`

Optional flags:

--skip-build       Prepare bundles only, do not build APK
--dry-run          Resolve lessons and write manifest only
--zip-source=PATH  Override local ZIP folder, defaults to D:\chimple-zips
--fail-on-missing  Stop if any bundle cannot be found